### PR TITLE
Show the passage legs while reviewing a route (#32)

### DIFF
--- a/apps/mobile/lib/features/map/passage_leg_table.dart
+++ b/apps/mobile/lib/features/map/passage_leg_table.dart
@@ -34,6 +34,7 @@ class PassageLegTable extends StatelessWidget {
     this.warnings = const [],
     this.onSelectLeg,
     this.selectedLegNumber,
+    this.scrollable = true,
   });
 
   final PassagePlan plan;
@@ -48,6 +49,14 @@ class PassageLegTable extends StatelessWidget {
   final ValueChanged<PassageLeg>? onSelectLeg;
   final int? selectedLegNumber;
 
+  /// Whether this owns the scrolling.
+  ///
+  /// True in a bottom sheet, which gives it a bounded height to scroll within.
+  /// False when embedded in a screen that already scrolls — there the height is
+  /// unbounded, and taking a flex share of infinity is a layout error rather
+  /// than a long list.
+  final bool scrollable;
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -56,6 +65,7 @@ class PassageLegTable extends StatelessWidget {
 
     return Column(
       key: const Key('passage-leg-table'),
+      mainAxisSize: scrollable ? MainAxisSize.max : MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Padding(
@@ -120,10 +130,26 @@ class PassageLegTable extends StatelessWidget {
               style: theme.textTheme.bodyMedium,
             ),
           )
+        else if (!scrollable)
+          // A Column, not a ListView, when the parent scrolls. A nested
+          // scrollable would be invisible to the sailor but very visible to
+          // anything walking the widget tree - it silently became the target of
+          // `find.byType(Scrollable).last` in the review screen's own tests, and
+          // it would take the same scroll gestures the parent wants.
+          for (var index = 0; index < plan.legs.length; index += 1)
+            _LegRow(
+              leg: plan.legs[index],
+              formatter: formatter,
+              minimumHeight: layout.minimumTapTarget,
+              selected: plan.legs[index].number == selectedLegNumber,
+              onTap: onSelectLeg == null
+                  ? null
+                  : () => onSelectLeg!(plan.legs[index]),
+            )
         else
-          // Flexible with shrinkWrap rather than Expanded: a two-leg passage
-          // should not leave two thirds of the sheet empty, and a twenty-leg one
-          // still needs to scroll.
+          // Flexible with shrinkWrap: a two-leg passage should not leave two
+          // thirds of the sheet empty, and a twenty-leg one still needs to
+          // scroll within the height the sheet gives it.
           Flexible(
             child: ListView.builder(
               shrinkWrap: true,
@@ -143,6 +169,10 @@ class PassageLegTable extends StatelessWidget {
                     ),
             ),
           ),
+        // The totals row belongs to the embedded form too; the scrolling form
+        // renders it as the list's last item so it scrolls with the legs.
+        if (!scrollable && plan.hasLegs)
+          _TotalsRow(plan: plan, formatter: formatter),
       ],
     );
   }

--- a/apps/mobile/lib/features/map/route_review_screen.dart
+++ b/apps/mobile/lib/features/map/route_review_screen.dart
@@ -14,6 +14,8 @@ import '../../services/route_reshape_planner.dart';
 import '../../services/route_waypoint_editor.dart';
 import 'maneuver_list_screen.dart';
 import 'resolved_route_map_preview.dart';
+import '../../services/passage_legs.dart';
+import 'passage_leg_table.dart';
 
 enum RouteReviewAction { cancel, edit, confirm }
 
@@ -473,6 +475,9 @@ class _RouteReviewScreenState extends State<RouteReviewScreen> {
         .where((points) => points.isNotEmpty)
         .toList(growable: false);
     final reviewWaypoints = _reviewWaypoints(route);
+    // Derived from the route under review, so it follows a reshape or a removed
+    // waypoint without any extra plumbing.
+    final passagePlan = PassagePlan.of(route);
     final visiblePointsOfInterest = canEditStops && _showPointsOfInterest
         ? _nearbyPointsOfInterest
         : const <BikerPlace>[];
@@ -883,6 +888,18 @@ class _RouteReviewScreenState extends State<RouteReviewScreen> {
                     ],
                   ],
                   const SizedBox(height: 8),
+                  // The legs, before the ordered list of marks. Reviewing a
+                  // passage is deciding whether to sail it, and that decision is
+                  // made on the courses and distances rather than on the names
+                  // (#32). Shown only when there are marks to make legs from - an
+                  // imported track has geometry but nothing to tabulate.
+                  if (passagePlan.hasLegs) ...[
+                    _PassageLegsSection(
+                      plan: passagePlan,
+                      distanceUnit: distanceUnit,
+                    ),
+                    const SizedBox(height: 8),
+                  ],
                   ExpansionTile(
                     key: const Key('route-review-points-section'),
                     tilePadding: EdgeInsets.zero,
@@ -1120,5 +1137,45 @@ class _WarningCard extends StatelessWidget {
         ),
       ],
     ),
+  );
+}
+
+/// The leg table, collapsed into the review screen.
+///
+/// The full [PassageLegTable] is a standalone surface with its own heading and
+/// the planner's caveats; here those caveats already appear in the review
+/// screen's own warning cards, so this shows the figures and lets the
+/// surrounding screen carry the qualifications.
+class _PassageLegsSection extends StatelessWidget {
+  const _PassageLegsSection({required this.plan, required this.distanceUnit});
+
+  final PassagePlan plan;
+  final DistanceUnit distanceUnit;
+
+  @override
+  Widget build(BuildContext context) => ExpansionTile(
+    key: const Key('route-review-legs-section'),
+    tilePadding: EdgeInsets.zero,
+    childrenPadding: EdgeInsets.zero,
+    // Expanded for a passage a sailor actually planned, collapsed for a long
+    // imported track: the same threshold the ordered-marks section uses. A
+    // hundred expanded legs also push everything below them out of the built
+    // area of the scroll view, which is how this was found.
+    initiallyExpanded: plan.legs.length <= 8,
+    title: Text(
+      'Legs (${plan.legs.length})',
+      style: Theme.of(context).textTheme.titleMedium,
+    ),
+    subtitle: const Text('Course to steer, distance and time for each leg.'),
+    children: [
+      PassageLegTable(
+        plan: plan,
+        distanceUnit: distanceUnit,
+        // The screen's own warning cards already carry the planner's caveats.
+        warnings: const [],
+        // The review screen owns the scrolling.
+        scrollable: false,
+      ),
+    ],
   );
 }

--- a/apps/mobile/test/features/map/passage_leg_table_test.dart
+++ b/apps/mobile/test/features/map/passage_leg_table_test.dart
@@ -195,6 +195,66 @@ void main() {
     });
   });
 
+  // The embedded form exists because the review screen already scrolls. It broke
+  // twice: once by taking a flex share of an unbounded height, and once by
+  // introducing a nested Scrollable that silently became the target of
+  // `find.byType(Scrollable).last` in another screen's tests.
+  group('embedded in a scrolling screen', () {
+    testWidgets('adds no scrollable of its own', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData.dark(useMaterial3: true),
+          home: Scaffold(
+            body: SingleChildScrollView(
+              child: PassageLegTable(plan: twoLegs, scrollable: false),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(Scrollable), findsOneWidget);
+      expect(find.byKey(const Key('passage-leg-list')), findsNothing);
+    });
+
+    testWidgets('still shows every leg and the totals', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData.dark(useMaterial3: true),
+          home: Scaffold(
+            body: SingleChildScrollView(
+              child: PassageLegTable(plan: twoLegs, scrollable: false),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('passage-leg-1')), findsOneWidget);
+      expect(find.byKey(const Key('passage-leg-2')), findsOneWidget);
+      expect(find.byKey(const Key('passage-plan-totals')), findsOneWidget);
+    });
+
+    testWidgets('survives an unbounded height', (tester) async {
+      // A Column inside a scroll view offers infinite height. Taking a flex
+      // share of that is a layout error, not a long list.
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData.dark(useMaterial3: true),
+          home: Scaffold(
+            body: SingleChildScrollView(
+              child: Column(
+                children: [PassageLegTable(plan: twoLegs, scrollable: false)],
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(tester.takeException(), isNull);
+    });
+  });
+
   group('formatting helpers', () {
     test('a course is always three figures', () {
       expect(formatCourse(7), '007°T');


### PR DESCRIPTION
Part of #32.

## Why

The review screen is where a sailor decides whether to sail a passage, and that decision is made on the **courses and distances**, not on the names of the marks. It listed the marks in order and gave a total; it did not say what to steer.

## What changed

`PassageLegTable` now sits above the ordered marks in `RouteReviewScreen` — expanded for a passage a sailor planned, collapsed for a long imported track, using the same eight-mark threshold the marks section already uses. It derives from the route under review, so it follows a reshape or a removed waypoint with no extra plumbing.

## The embedded form, and two failures worth recording

The table was written for a bottom sheet, which gives it a bounded height. The review screen already scrolls, so it needed an embedded form. Both attempts failed in instructive ways:

1. **`Flexible` inside a scrolling screen** takes a flex share of an *unbounded* height — a layout error, not a long list.
2. Replacing it with a shrink-wrapped `ListView` fixed the layout and **broke two unrelated tests**: a nested `ListView` is still a `Scrollable`, and it silently became the target of `find.byType(Scrollable).last` in the review screen's own tests. Embedded, it now renders a `Column` and adds no scrollable at all — which is also better behaviour, since a nested scrollable would compete for the parent's gestures.

A third failure was a real UX bug rather than a test problem: expanding **101 legs** by default pushed everything below them out of the built area of the lazy scroll view, so the marks section did not exist at all. Hence the threshold.

## Verification

- 1,616 tests pass, analyzer clean
- Three new tests pin the embedded form: no scrollable of its own, all legs and totals present, survives unbounded height
- Checked on the iPad simulator against the Solent demo: **4 legs, TOTAL 8.6 NM, AT 5 KN 1h 43m** above the ordered marks

## Still open on #32

Waypoint editing on the chart. `ResolvedRouteMapPreview` already has the primitives — `toLatLng`, `toScreenLocationBatch` for pin hit-testing within 32px, and drag plumbing with race guards — and the review screen already has waypoint removal, reshape drawing and an undo stack. What is missing is tap-to-add and drag-to-move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)