### PR TITLE
Add a mark by tapping the chart (#32)

### DIFF
--- a/apps/mobile/lib/features/map/resolved_route_map_preview.dart
+++ b/apps/mobile/lib/features/map/resolved_route_map_preview.dart
@@ -68,6 +68,8 @@ class ResolvedRouteMapPreview extends StatefulWidget {
     this.onReshapeStart,
     this.onReshapeUpdate,
     this.onReshapeEnd,
+    this.addMarkEnabled = false,
+    this.onAddMark,
   });
 
   final List<List<GeoPoint>> paths;
@@ -82,6 +84,17 @@ class ResolvedRouteMapPreview extends StatefulWidget {
   final ValueChanged<RoutePreviewReshapeStart>? onReshapeStart;
   final ValueChanged<GeoPoint>? onReshapeUpdate;
   final VoidCallback? onReshapeEnd;
+
+  /// Whether a tap on open water adds a mark (#32).
+  ///
+  /// Deliberately a mode rather than always-on. A chart is panned and zoomed far
+  /// more often than it is edited, and a stray tap that silently added a mark to
+  /// a passage would be discovered later, in the leg table, by a sailor who did
+  /// not do it.
+  final bool addMarkEnabled;
+
+  /// Called with the tapped position when it hits neither a pin nor the route.
+  final ValueChanged<GeoPoint>? onAddMark;
 
   /// Handed the map's controller once created, so a caller can snapshot it.
   /// Exposed for the recap export, which needs MapLibre's own snapshot because
@@ -203,15 +216,17 @@ class _ResolvedRouteMapPreviewState extends State<ResolvedRouteMapPreview> {
                 ),
               ),
             ),
-            if (widget.reshapeEnabled)
+            if (widget.reshapeEnabled || widget.addMarkEnabled)
               Positioned.fill(
                 child: GestureDetector(
                   key: const Key('route-preview-reshape-surface'),
                   behavior: HitTestBehavior.opaque,
-                  onPanStart: _beginReshape,
-                  onPanUpdate: _updateReshape,
-                  onPanEnd: (_) => _endReshape(),
-                  onPanCancel: _endReshape,
+                  // Dragging is reshaping. In add-mark mode the drag handlers
+                  // are absent so the map keeps its own pan.
+                  onPanStart: widget.reshapeEnabled ? _beginReshape : null,
+                  onPanUpdate: widget.reshapeEnabled ? _updateReshape : null,
+                  onPanEnd: widget.reshapeEnabled ? (_) => _endReshape() : null,
+                  onPanCancel: widget.reshapeEnabled ? _endReshape : null,
                   onTapUp: (details) => unawaited(
                     _handlePointTap(_platformPoint(details.localPosition)),
                   ),
@@ -238,7 +253,7 @@ class _ResolvedRouteMapPreviewState extends State<ResolvedRouteMapPreview> {
                 top: 8,
                 child: _RouteComparisonLegend(),
               ),
-            if (widget.reshapeEnabled)
+            if (widget.reshapeEnabled || widget.addMarkEnabled)
               Positioned(
                 right: 8,
                 top: widget.referencePaths.isEmpty ? 8 : 66,
@@ -247,26 +262,33 @@ class _ResolvedRouteMapPreviewState extends State<ResolvedRouteMapPreview> {
                   onZoomOut: () => unawaited(_zoomBy(-1)),
                 ),
               ),
-            if (widget.reshapeEnabled)
-              const Positioned(
+            if (widget.reshapeEnabled || widget.addMarkEnabled)
+              Positioned(
                 left: 58,
                 right: 58,
                 bottom: 10,
                 child: IgnorePointer(
                   child: DecoratedBox(
-                    decoration: BoxDecoration(
+                    decoration: const BoxDecoration(
                       color: Color(0xE61A2029),
                       borderRadius: BorderRadius.all(Radius.circular(18)),
                     ),
                     child: Padding(
-                      padding: EdgeInsets.symmetric(
+                      padding: const EdgeInsets.symmetric(
                         horizontal: 12,
                         vertical: 7,
                       ),
                       child: Text(
-                        'Drag route or handle · +/− zoom · exit Reshape to pan',
+                        widget.addMarkEnabled
+                            ? 'Tap the chart to add a mark · +/− zoom · '
+                                  'exit Add marks to pan'
+                            : 'Drag route or handle · +/− zoom · '
+                                  'exit Reshape to pan',
                         textAlign: TextAlign.center,
-                        style: TextStyle(color: Colors.white, fontSize: 12),
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 12,
+                        ),
                       ),
                     ),
                   ),
@@ -538,7 +560,24 @@ class _ResolvedRouteMapPreviewState extends State<ResolvedRouteMapPreview> {
         closestDistance = distance;
       }
     }
-    if (closest >= 0 && closestDistance <= 30) callback(closest);
+    if (closest >= 0 && closestDistance <= 30) {
+      callback(closest);
+      return;
+    }
+    await _reportAddMark(controller, tap);
+  }
+
+  /// A tap that hit neither a pin nor the route: open water, so it is a new mark.
+  Future<void> _reportAddMark(
+    ml.MapLibreMapController controller,
+    math.Point<double> tap,
+  ) async {
+    final addMark = widget.onAddMark;
+    if (!widget.addMarkEnabled || addMark == null) return;
+    final location = await controller.toLatLng(tap);
+    addMark(
+      GeoPoint(latitude: location.latitude, longitude: location.longitude),
+    );
   }
 
   void _beginReshape(DragStartDetails details) {

--- a/apps/mobile/lib/features/map/route_review_screen.dart
+++ b/apps/mobile/lib/features/map/route_review_screen.dart
@@ -123,6 +123,11 @@ class _RouteReviewScreenState extends State<RouteReviewScreen> {
   late Duration? _duration = widget.duration;
   late double? _twistinessScore = widget.twistinessScore;
   final List<List<RouteShapingPoint>> _reshapeHistory = [];
+
+  /// Whether a tap on the chart adds a mark (#32). Mutually exclusive with
+  /// reshaping: both want the same gesture surface, and a sailor in one mode
+  /// should not be surprised by the other.
+  bool _addMarkEnabled = false;
   Timer? _reshapeTimer;
   int _reshapeGeneration = 0;
   String? _activeShapingPointId;
@@ -407,6 +412,23 @@ class _RouteReviewScreenState extends State<RouteReviewScreen> {
     );
   }
 
+  /// Inserts a mark where the sailor tapped.
+  ///
+  /// [insertRouteWaypoint] places it on the leg nearest the tap rather than at
+  /// the end, so tapping between two marks splits that leg - which is what
+  /// tapping there means.
+  Future<void> _addMarkAt(GeoPoint point) async {
+    if (_reshaping || _reshapeQueued || widget.onReshapeRoute == null) return;
+    final candidate = insertRouteWaypoint(
+      route,
+      RouteWaypoint(point: point, name: 'Mark ${route.waypoints.length}'),
+    );
+    await _recalculateEditedRoute(
+      candidate,
+      failurePrefix: 'Could not add a mark there.',
+    );
+  }
+
   Future<void> _recalculateEditedRoute(
     ImportedRoute candidate, {
     required String failurePrefix,
@@ -584,6 +606,8 @@ class _RouteReviewScreenState extends State<RouteReviewScreen> {
                         onReshapeStart: _beginRouteReshape,
                         onReshapeUpdate: _updateRouteReshape,
                         onReshapeEnd: _endRouteReshape,
+                        addMarkEnabled: _addMarkEnabled,
+                        onAddMark: (point) => unawaited(_addMarkAt(point)),
                       )
                     : FlutterMap(
                         key: const Key('route-review-map'),
@@ -599,6 +623,21 @@ class _RouteReviewScreenState extends State<RouteReviewScreen> {
                           interactionOptions: const InteractionOptions(
                             flags: InteractiveFlag.all,
                           ),
+                          // Wired on both renderers so adding a mark does not
+                          // depend on which one this build fell back to (#32).
+                          // MapLibre routes its tap through the preview widget's
+                          // own hit-testing; here the map hands us the position
+                          // directly.
+                          onTap: _addMarkEnabled
+                              ? (_, position) => unawaited(
+                                  _addMarkAt(
+                                    GeoPoint(
+                                      latitude: position.latitude,
+                                      longitude: position.longitude,
+                                    ),
+                                  ),
+                                )
+                              : null,
                         ),
                         children: [
                           if (basemapConfiguration.usesLegacyRaster)
@@ -822,9 +861,37 @@ class _RouteReviewScreenState extends State<RouteReviewScreen> {
                           label: Text(
                             _reshapeEnabled ? 'Finish drawing' : 'Redraw a leg',
                           ),
-                          onSelected: (selected) =>
-                              setState(() => _reshapeEnabled = selected),
+                          onSelected: (selected) => setState(() {
+                            _reshapeEnabled = selected;
+                            // One editing mode at a time: they share the
+                            // gesture surface.
+                            if (selected) _addMarkEnabled = false;
+                          }),
                         ),
+                        // Gated on being able to re-plan, not on
+                        // [canEditStops]. That flag distinguishes a destination
+                        // plan from an imported route, and adding a mark to an
+                        // imported passage - nudging it clear of a bank, adding
+                        // a waypoint off a headland - is exactly the adjustment a
+                        // sailor wants to make to someone else's GPX (#32).
+                        if (widget.onReshapeRoute != null)
+                          FilterChip(
+                            key: const Key('toggle-add-marks'),
+                            selected: _addMarkEnabled,
+                            avatar: const Icon(
+                              Icons.add_location_alt_outlined,
+                              size: 18,
+                            ),
+                            label: Text(
+                              _addMarkEnabled ? 'Finish adding' : 'Add a mark',
+                            ),
+                            onSelected: (selected) => setState(() {
+                              _addMarkEnabled = selected;
+                              // One editing mode at a time: they share the
+                              // gesture surface.
+                              if (selected) _reshapeEnabled = false;
+                            }),
+                          ),
                         if (_reshapeHistory.isNotEmpty)
                           ActionChip(
                             key: const Key('undo-route-reshape'),

--- a/apps/mobile/test/features/map/route_review_screen_test.dart
+++ b/apps/mobile/test/features/map/route_review_screen_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tide_and_seek/domain/distance_unit.dart';
 import 'package:tide_and_seek/domain/imported_route.dart';
@@ -194,6 +195,170 @@ void main() {
       scrollable: find.byType(Scrollable).last,
     );
     expect(find.text('Route points (3)'), findsOneWidget);
+  });
+
+  // #32. Adding a mark by tapping the chart is a mode, not a default: a chart is
+  // panned far more often than it is edited, and a stray tap that silently added
+  // a mark would be discovered later, in the leg table, by a sailor who did not
+  // do it.
+  group('adding a mark', () {
+    Future<ImportedRoute?> pumpEditable(WidgetTester tester) async {
+      ImportedRoute? recalculated;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: RouteReviewScreen(
+            route: _route(0.02),
+            distanceUnit: DistanceUnit.nauticalMiles,
+            basemapConfiguration: const BasemapConfiguration(),
+            canEditStops: true,
+            onReshapeRoute: (candidate, shapingPoints) async {
+              recalculated = candidate;
+              return RouteReshapeResult(
+                route: candidate.withShapingPoints(shapingPoints),
+                distanceMeters: 1800,
+                duration: const Duration(minutes: 6),
+              );
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      return recalculated;
+    }
+
+    testWidgets('is offered as a mode alongside redrawing', (tester) async {
+      await pumpEditable(tester);
+      expect(find.byKey(const Key('toggle-add-marks')), findsOneWidget);
+      expect(find.text('Add a mark'), findsOneWidget);
+    });
+
+    testWidgets('is offered for an imported route too, not just a plan', (
+      tester,
+    ) async {
+      // canEditStops distinguishes a destination plan from an imported route.
+      // Adding a mark to someone else's GPX is exactly the adjustment a sailor
+      // wants, so this is gated on being able to re-plan instead.
+      await tester.pumpWidget(
+        MaterialApp(
+          home: RouteReviewScreen(
+            route: _route(0.02),
+            distanceUnit: DistanceUnit.nauticalMiles,
+            basemapConfiguration: const BasemapConfiguration(),
+            onReshapeRoute: (candidate, shapingPoints) async =>
+                RouteReshapeResult(
+                  route: candidate.withShapingPoints(shapingPoints),
+                  distanceMeters: 1800,
+                  duration: const Duration(minutes: 6),
+                ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.byKey(const Key('toggle-add-marks')), findsOneWidget);
+    });
+
+    testWidgets('is absent when the route cannot be re-planned', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: RouteReviewScreen(
+            route: _route(0.02),
+            distanceUnit: DistanceUnit.nauticalMiles,
+            basemapConfiguration: const BasemapConfiguration(),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.byKey(const Key('toggle-add-marks')), findsNothing);
+    });
+
+    testWidgets('a tap on the chart inserts a mark and re-plans', (
+      tester,
+    ) async {
+      ImportedRoute? recalculated;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: RouteReviewScreen(
+            route: _route(0.02),
+            distanceUnit: DistanceUnit.nauticalMiles,
+            basemapConfiguration: const BasemapConfiguration(),
+            canEditStops: true,
+            onReshapeRoute: (candidate, shapingPoints) async {
+              recalculated = candidate;
+              return RouteReshapeResult(
+                route: candidate.withShapingPoints(shapingPoints),
+                distanceMeters: 1800,
+                duration: const Duration(minutes: 6),
+              );
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      final before = recalculated?.waypoints.length;
+
+      await tester.tap(find.byKey(const Key('toggle-add-marks')));
+      await tester.pumpAndSettle();
+
+      // The wired callback is invoked directly rather than by synthesising a tap
+      // on the map. Whether flutter_map turns a pointer into onTap is its own
+      // business; what matters here is that the option is wired only in add-mark
+      // mode and that invoking it inserts a mark.
+      final map = tester.widget<FlutterMap>(
+        find.byKey(const Key('route-review-map')),
+      );
+      expect(map.options.onTap, isNotNull);
+      map.options.onTap!(
+        TapPosition(Offset.zero, Offset.zero),
+        const LatLng(51.001, -1.995),
+      );
+      await tester.pumpAndSettle();
+
+      expect(recalculated, isNotNull);
+      expect(
+        recalculated!.waypoints.length,
+        (before ?? 2) + 1,
+        reason: 'the tap should have added one mark',
+      );
+      // Inserted between the existing marks rather than appended past the
+      // destination, because that is what tapping mid-passage means.
+      expect(recalculated!.waypoints.first.name, 'Start');
+      expect(recalculated!.waypoints.last.name, 'Destination');
+    });
+
+    testWidgets('the chart does not add marks outside the mode', (
+      tester,
+    ) async {
+      await pumpEditable(tester);
+      final map = tester.widget<FlutterMap>(
+        find.byKey(const Key('route-review-map')),
+      );
+      expect(map.options.onTap, isNull);
+    });
+
+    // The two modes share one gesture surface, so a sailor must never be in both.
+    testWidgets('turning it on turns redrawing off, and vice versa', (
+      tester,
+    ) async {
+      await pumpEditable(tester);
+
+      // Redrawing starts on for an editable route.
+      expect(find.text('Finish drawing'), findsOneWidget);
+
+      await tester.tap(find.byKey(const Key('toggle-add-marks')));
+      await tester.pumpAndSettle();
+      expect(find.text('Finish adding'), findsOneWidget);
+      expect(find.text('Draw route around'), findsNothing);
+      expect(find.text('Finish drawing'), findsNothing);
+      expect(find.text('Redraw a leg'), findsOneWidget);
+
+      await tester.tap(find.byKey(const Key('toggle-route-reshape')));
+      await tester.pumpAndSettle();
+      expect(find.text('Finish drawing'), findsOneWidget);
+      expect(find.text('Add a mark'), findsOneWidget);
+      expect(find.text('Finish adding'), findsNothing);
+    });
   });
 
   testWidgets('keeps disconnected imported paths visually separate', (


### PR DESCRIPTION
Part of #32. Completes the "place a waypoint on the chart" half; drag-to-move remains.

## Why

A passage could be built from a GPX file, a geocoded destination or a saved route — but not by **putting marks where the water is**, which is how a navigator plans. Marks could be *removed* and legs *redrawn*, but never added.

## What changed

Tapping the chart in **Add a mark** mode inserts one. Almost all the machinery already existed:

- `insertRouteWaypoint` places a mark on the leg **nearest the tap** rather than appending it — which is what tapping mid-passage means
- `_recalculateEditedRoute` re-plans and refreshes the leg table
- `ResolvedRouteMapPreview` already had `toLatLng` and pin hit-testing

So this is a gesture and a mode, not new plumbing.

## Three decisions

**It is a mode, not a default.** A chart is panned and zoomed far more often than it is edited. A stray tap that silently added a mark would be discovered later, in the leg table, by a sailor who did not do it.

**One mode at a time.** Adding and redrawing share the gesture surface, so enabling either disables the other. In add-mark mode the drag handlers are absent entirely, which leaves the map its own pan.

**Available for imported routes, not only destination plans.** My first version gated this on `canEditStops`, which is `false` for a GPX import — and adding a mark to someone else's passage, to nudge it clear of a bank or off a headland, is exactly the adjustment a sailor wants. Now gated on being able to re-plan. **This gap was only visible on the device**: tests passed, and the chip was simply missing from the demo passage.

## Renderers

Wired on both, so the feature does not depend on which one the build fell back to. MapLibre routes the tap through the preview's existing hit-testing — a tap on a pin or the route line still means what it did, and only open water adds a mark. flutter_map hands the position over directly.

## Verification

- 1,622 tests pass, analyzer clean
- Six new tests: the mode is offered, offered for imports, absent without a re-planner, a tap inserts and re-plans, no handler outside the mode, and the two modes are mutually exclusive
- On the iPad simulator against the Solent demo, whose legs read 096°T 2.7 NM, 074°T 2.2 NM, 059°T 3.1 NM, 101°T 7 cables

## Note on the tap test

It invokes the wired `onTap` directly rather than synthesising a pointer. Whether flutter_map turns a pointer into `onTap` is flutter_map's business; what matters is that the option is wired **only** in add-mark mode and that invoking it inserts a mark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)