### PR TITLE
Navigation instruments, and a fix age that degrades them (#34)

### DIFF
--- a/apps/mobile/lib/features/map/navigation_instrument_panel.dart
+++ b/apps/mobile/lib/features/map/navigation_instrument_panel.dart
@@ -1,0 +1,354 @@
+/// The instrument panel: COG, SOG, bearing and distance to the mark, cross-track
+/// error, VMG and the age of the fix they all rest on.
+///
+/// ## The one property this surface exists for
+///
+/// A stale fix must degrade everything derived from it, **visibly and at once**.
+/// A frozen SOG still reading 5.2 kn because the last fix was four minutes ago is
+/// the failure `PLAN.md` names: the number looks exactly as trustworthy as it did
+/// when it was true. So when the fix is stale every value here dims, and a single
+/// banner says how old it is — once, rather than a badge per row that a sailor
+/// reads past.
+///
+/// ## Why the basis is shown
+///
+/// Each value says whether it was measured by the receiver or calculated from the
+/// plan. It is the difference between "you are doing 4.2 knots" and "if the plan
+/// is right you will arrive at 14:20", and a navigator deciding whether to trust
+/// a number needs to know which kind it is.
+///
+/// ## Not shown
+///
+/// Nothing here recommends a course. Cross-track error names the side to steer
+/// *toward*, which is a fact about geometry; what to actually steer depends on
+/// the stream, the wind and what the sailor can see.
+library;
+
+import 'package:flutter/material.dart';
+
+import '../../domain/distance_unit.dart';
+import '../../services/measurement_formatter.dart';
+import '../../services/navigation_instruments.dart';
+import 'passage_leg_table.dart' show formatCourse, formatPassageDuration;
+import 'voyage_layout.dart';
+
+class NavigationInstrumentPanel extends StatelessWidget {
+  const NavigationInstrumentPanel({
+    super.key,
+    required this.instruments,
+    this.distanceUnit = DistanceUnit.nauticalMiles,
+  });
+
+  final NavigationInstruments instruments;
+  final DistanceUnit distanceUnit;
+
+  @override
+  Widget build(BuildContext context) {
+    final formatter = MeasurementFormatter(distanceUnit);
+    final layout = VoyageLayout.of(context);
+    final stale = instruments.fixIsStale;
+
+    return Container(
+      key: const Key('navigation-instrument-panel'),
+      padding: EdgeInsets.all(layout.isCompactHeight ? 10 : 14),
+      decoration: BoxDecoration(
+        color: const Color(0xF2141A22),
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (stale)
+            _StaleBanner(age: instruments.fixAge)
+          else
+            _FixAgeLine(age: instruments.fixAge),
+          const SizedBox(height: 10),
+          // Own motion first: it is measured, and it is true whether or not there
+          // is a passage.
+          Wrap(
+            spacing: 18,
+            runSpacing: 12,
+            children: [
+              _Reading(
+                label: 'COG',
+                instrument: instruments.courseOverGround,
+                format: formatCourse,
+                stale: stale,
+              ),
+              _Reading(
+                label: 'SOG',
+                instrument: instruments.speedOverGround,
+                format: formatter.speed,
+                stale: stale,
+              ),
+              if (instruments.hasActiveLeg) ...[
+                _Reading(
+                  label: 'BTW',
+                  instrument: instruments.bearingToMark,
+                  format: formatCourse,
+                  stale: stale,
+                ),
+                _Reading(
+                  label: 'DTW',
+                  instrument: instruments.distanceToMark,
+                  format: formatter.distance,
+                  stale: stale,
+                ),
+                _Reading(
+                  label: 'VMG',
+                  instrument: instruments.velocityMadeGood,
+                  format: formatter.speed,
+                  stale: stale,
+                ),
+                _CrossTrackReading(
+                  instrument: instruments.crossTrackError,
+                  side: instruments.offTrackSide,
+                  formatter: formatter,
+                  stale: stale,
+                ),
+              ],
+            ],
+          ),
+          if (instruments.hasActiveLeg) ...[
+            const SizedBox(height: 12),
+            _MarkLine(instruments: instruments, stale: stale),
+          ] else ...[
+            const SizedBox(height: 10),
+            Text(
+              'No passage. Add marks to see bearings and cross-track error.',
+              key: const Key('navigation-instruments-no-passage'),
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _StaleBanner extends StatelessWidget {
+  const _StaleBanner({required this.age});
+
+  final Duration age;
+
+  @override
+  Widget build(BuildContext context) => Row(
+    key: const Key('navigation-instruments-stale'),
+    children: [
+      const Icon(Icons.gps_off_outlined, size: 16, color: Color(0xFFE8A33D)),
+      const SizedBox(width: 8),
+      Expanded(
+        child: Text(
+          // Named once, plainly. Every figure below rests on this fix.
+          'Fix is ${formatPassageDuration(age)} old — everything below is out '
+          'of date',
+          style: const TextStyle(
+            color: Color(0xFFE8A33D),
+            fontWeight: FontWeight.w700,
+            fontSize: 12,
+          ),
+        ),
+      ),
+    ],
+  );
+}
+
+class _FixAgeLine extends StatelessWidget {
+  const _FixAgeLine({required this.age});
+
+  final Duration age;
+
+  @override
+  Widget build(BuildContext context) => Text(
+    age.inSeconds <= 1 ? 'Fix current' : 'Fix ${age.inSeconds}s old',
+    key: const Key('navigation-instruments-fix-age'),
+    style: Theme.of(context).textTheme.bodySmall,
+  );
+}
+
+/// One reading, with its label, value and basis.
+class _Reading extends StatelessWidget {
+  const _Reading({
+    required this.label,
+    required this.instrument,
+    required this.format,
+    required this.stale,
+  });
+
+  final String label;
+  final Instrument instrument;
+  final String Function(double) format;
+  final bool stale;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final available = instrument.isAvailable;
+    return SizedBox(
+      width: 96,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Row(
+            children: [
+              Text(
+                label,
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: const Color(0xFF98A3B1),
+                  letterSpacing: 0.6,
+                ),
+              ),
+              const SizedBox(width: 4),
+              _BasisDot(basis: instrument.basis),
+            ],
+          ),
+          Text(
+            available ? format(instrument.value!) : '—',
+            key: Key('instrument-$label'),
+            style: theme.textTheme.titleMedium?.copyWith(
+              // Dimmed together when the fix is stale, so no single number can
+              // look fresher than the fix it came from.
+              color: stale || !available
+                  ? const Color(0xFF6B7684)
+                  : const Color(0xFFE8EEF5),
+              fontFeatures: const [FontFeature.tabularFigures()],
+            ),
+          ),
+          if (!available && instrument.reason != null)
+            Text(
+              instrument.reason!,
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: const Color(0xFF6B7684),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Cross-track error reads as a distance plus the side to steer toward, because
+/// the distance on its own does not tell a sailor which way to put the helm.
+class _CrossTrackReading extends StatelessWidget {
+  const _CrossTrackReading({
+    required this.instrument,
+    required this.side,
+    required this.formatter,
+    required this.stale,
+  });
+
+  final Instrument instrument;
+  final TrackSide? side;
+  final MeasurementFormatter formatter;
+  final bool stale;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final available = instrument.isAvailable;
+    return SizedBox(
+      width: 150,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Row(
+            children: [
+              Text(
+                'XTE',
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: const Color(0xFF98A3B1),
+                  letterSpacing: 0.6,
+                ),
+              ),
+              const SizedBox(width: 4),
+              _BasisDot(basis: instrument.basis),
+            ],
+          ),
+          Text(
+            !available
+                ? '—'
+                : side == null
+                ? 'on track'
+                : '${formatter.distance(instrument.value!)} — '
+                      'steer ${side!.opposite.label}',
+            key: const Key('instrument-XTE'),
+            style: theme.textTheme.titleMedium?.copyWith(
+              color: stale || !available
+                  ? const Color(0xFF6B7684)
+                  : const Color(0xFFE8EEF5),
+            ),
+          ),
+          if (!available && instrument.reason != null)
+            Text(
+              instrument.reason!,
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: const Color(0xFF6B7684),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MarkLine extends StatelessWidget {
+  const _MarkLine({required this.instruments, required this.stale});
+
+  final NavigationInstruments instruments;
+  final bool stale;
+
+  @override
+  Widget build(BuildContext context) {
+    final leg = instruments.activeLeg!;
+    final toMark = instruments.timeToMark;
+    return Text(
+      toMark == null
+          // Not closing: say that rather than showing a time that would have to
+          // be negative.
+          ? 'Making for ${leg.toLabel} — not closing'
+          : 'Making for ${leg.toLabel} — '
+                '${formatPassageDuration(toMark)} at this rate',
+      key: const Key('navigation-instruments-mark'),
+      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+        color: stale ? const Color(0xFF6B7684) : null,
+      ),
+    );
+  }
+}
+
+/// A small mark showing whether a value was measured or calculated.
+class _BasisDot extends StatelessWidget {
+  const _BasisDot({required this.basis});
+
+  final InstrumentBasis basis;
+
+  @override
+  Widget build(BuildContext context) {
+    final (colour, tooltip) = switch (basis) {
+      InstrumentBasis.measured => (
+        const Color(0xFF6ED89A),
+        'Measured by the GPS',
+      ),
+      InstrumentBasis.calculated => (
+        const Color(0xFF7FB2E5),
+        'Calculated from your passage',
+      ),
+      InstrumentBasis.assumed => (
+        const Color(0xFFE8A33D),
+        'Rests on an assumption',
+      ),
+      InstrumentBasis.unavailable => (const Color(0xFF6B7684), 'Not available'),
+    };
+    return Tooltip(
+      message: tooltip,
+      child: Container(
+        width: 6,
+        height: 6,
+        decoration: BoxDecoration(color: colour, shape: BoxShape.circle),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/map/voyage_map_feature.dart
+++ b/apps/mobile/lib/features/map/voyage_map_feature.dart
@@ -76,6 +76,8 @@ import 'marine_glyphs.dart';
 import '../../services/passage_planning.dart';
 import '../../services/passage_legs.dart';
 import 'passage_leg_table.dart';
+import '../../services/navigation_instruments.dart';
+import 'navigation_instrument_panel.dart';
 
 @visibleForTesting
 GroupMiniMapRenderer groupMiniMapRenderer({
@@ -1525,6 +1527,12 @@ class _VoyageMapScreenState extends State<VoyageMapScreen> {
                         value: _MapAction.passagePlan,
                         child: Text('Passage plan and legs'),
                       ),
+                    // Offered without a route: COG, SOG and fix age are true
+                    // whether or not a passage is loaded (#34).
+                    const PopupMenuItem(
+                      value: _MapAction.instruments,
+                      child: Text('Navigation instruments'),
+                    ),
                     // Always offered, route or not: what the map is made of is
                     // not a property of the plan.
                     const PopupMenuItem(
@@ -5176,11 +5184,53 @@ class _VoyageMapScreenState extends State<VoyageMapScreen> {
         await showChartProvenanceSheet(context);
       case _MapAction.passagePlan:
         await _showPassagePlan();
+      case _MapAction.instruments:
+        await _showNavigationInstruments();
       case _MapAction.clearOfflineTiles:
         await _mapLibreOfflineManager.clearAll();
         await widget.offlineTileCache.clearAll();
         _showMessage('Offline map data cleared.');
     }
+  }
+
+  /// The instrument panel: what the receiver measures and what follows from it.
+  ///
+  /// Computed from the current fix each time it is opened rather than streamed:
+  /// a sheet the sailor has deliberately opened is read, not watched, and a
+  /// panel that ticked underneath them would make the fix age harder to read
+  /// rather than easier. Live instruments belong on the navigation canvas, which
+  /// is its own piece of work.
+  Future<void> _showNavigationInstruments() async {
+    final fix = _navigationFix;
+    final position = fix?.point ?? _effectivePosition;
+    if (position == null) {
+      _showMessage('No position yet, so there is nothing to measure.');
+      return;
+    }
+    final route = _route;
+    final instruments = NavigationInstruments.compute(
+      fix: NavigationFix(
+        point: position,
+        recordedAt: fix?.recordedAt ?? DateTime.now(),
+        courseOverGroundDegrees: fix?.headingDegrees,
+        speedOverGroundMetersPerSecond: fix?.speedMetersPerSecond,
+        accuracyMeters: fix?.accuracyMeters,
+      ),
+      plan: route == null ? PassagePlan.empty : PassagePlan.of(route),
+      now: DateTime.now(),
+    );
+    if (!mounted) return;
+    await showModalBottomSheet<void>(
+      context: context,
+      showDragHandle: true,
+      builder: (context) => SafeArea(
+        top: false,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(16, 4, 16, 20),
+          child: NavigationInstrumentPanel(instruments: instruments),
+        ),
+      ),
+    );
   }
 
   /// The passage as a leg table: course, distance and time per mark.
@@ -5515,6 +5565,7 @@ class _VoyageMapScreenState extends State<VoyageMapScreen> {
 enum _MapAction {
   chartSources,
   passagePlan,
+  instruments,
   importGpx,
   loadDemo,
   personalVoyageHeatmap,

--- a/apps/mobile/lib/services/navigation_instruments.dart
+++ b/apps/mobile/lib/services/navigation_instruments.dart
@@ -1,0 +1,358 @@
+/// The numbers a navigator steers by, and what each of them rests on.
+///
+/// ## Why every value carries a basis
+///
+/// `PLAN.md` requires that measured, calculated, assumed and unknown values stay
+/// distinguishable, and that a stale or inaccurate fix visibly degrades
+/// everything derived from it. That is not presentation polish. A frozen SOG
+/// still reading 5.2 kn because the last fix was four minutes ago is the failure
+/// mode: the number looks exactly as trustworthy as it did when it was true.
+///
+/// So each instrument is an [Instrument] that knows whether it was measured by
+/// the GNSS receiver, calculated from the plan, or assumed — and the whole set
+/// knows how old the fix is. Nothing here silently substitutes one for another.
+///
+/// ## COG, not heading
+///
+/// This app has no compass input and no log. Every direction here is **course
+/// over ground** from successive GNSS fixes, and every speed is **speed over
+/// ground**. Heading (where the bow points) and speed through water are
+/// different quantities that differ from these by the tidal stream and leeway —
+/// which is exactly the difference a sailor cares about — so they are not
+/// claimed. When instrument input arrives (#16) they belong in separate fields,
+/// never merged into these.
+///
+/// ## What is deliberately absent
+///
+/// No recommended course. Cross-track error says which side of the track the
+/// vessel is on; it does not say what to steer, because that depends on the
+/// stream, the wind and what the sailor can see.
+library;
+
+import 'dart:math' as math;
+
+import '../domain/imported_route.dart' show GeoPoint;
+import 'passage_legs.dart';
+import 'passage_planning.dart';
+
+/// Where a displayed value came from.
+enum InstrumentBasis {
+  /// Reported by the GNSS receiver.
+  measured,
+
+  /// Derived from measured values and the plan.
+  calculated,
+
+  /// Rests on a stated assumption, such as a planning speed.
+  assumed,
+
+  /// Not available, with a reason.
+  unavailable,
+}
+
+/// One displayed value, with its provenance.
+class Instrument {
+  const Instrument.measured(double this.value)
+    : basis = InstrumentBasis.measured,
+      reason = null;
+  const Instrument.calculated(double this.value)
+    : basis = InstrumentBasis.calculated,
+      reason = null;
+  const Instrument.assumed(double this.value)
+    : basis = InstrumentBasis.assumed,
+      reason = null;
+  const Instrument.unavailable(this.reason)
+    : basis = InstrumentBasis.unavailable,
+      value = null;
+
+  final double? value;
+  final InstrumentBasis basis;
+
+  /// Why there is no value. Shown instead of the value, never in place of one.
+  final String? reason;
+
+  bool get isAvailable => value != null;
+}
+
+/// Which side of the planned track the vessel is on.
+enum TrackSide {
+  port,
+  starboard;
+
+  /// The side to steer toward to close the error, which is the other one.
+  TrackSide get opposite =>
+      this == TrackSide.port ? TrackSide.starboard : TrackSide.port;
+
+  String get label => this == TrackSide.port ? 'port' : 'starboard';
+}
+
+/// A GNSS fix, as the instruments need it.
+class NavigationFix {
+  const NavigationFix({
+    required this.point,
+    required this.recordedAt,
+    this.courseOverGroundDegrees,
+    this.speedOverGroundMetersPerSecond,
+    this.accuracyMeters,
+  });
+
+  final GeoPoint point;
+  final DateTime recordedAt;
+
+  /// Course over ground, degrees true. Null when the receiver cannot say —
+  /// typically because the vessel is not moving, when COG is meaningless.
+  final double? courseOverGroundDegrees;
+
+  final double? speedOverGroundMetersPerSecond;
+  final double? accuracyMeters;
+
+  Duration ageAt(DateTime now) {
+    final age = now.difference(recordedAt);
+    return age.isNegative ? Duration.zero : age;
+  }
+}
+
+/// How old or inaccurate a fix may be before what depends on it is suspect.
+class NavigationFixPolicy {
+  const NavigationFixPolicy({
+    this.staleAfter = const Duration(seconds: 12),
+    this.poorAccuracyMeters = 50,
+  });
+
+  /// Twelve seconds. A yacht at 6 knots moves 37 metres in that time, which is
+  /// about the width of the corridor the deviation detector works in - so past
+  /// this point a cross-track error is arguing about a position the vessel has
+  /// already left.
+  final Duration staleAfter;
+
+  /// Beyond this, a fix is too coarse to derive a cross-track error from.
+  final double poorAccuracyMeters;
+}
+
+/// Everything the instrument panel shows, computed once per fix.
+class NavigationInstruments {
+  const NavigationInstruments({
+    required this.courseOverGround,
+    required this.speedOverGround,
+    required this.bearingToMark,
+    required this.distanceToMark,
+    required this.crossTrackError,
+    required this.velocityMadeGood,
+    required this.fixAge,
+    required this.fixIsStale,
+    required this.accuracyIsPoor,
+    this.activeLeg,
+    this.offTrackSide,
+    this.timeToMark,
+    this.timeToDestination,
+    this.distanceToDestination,
+  });
+
+  final Instrument courseOverGround;
+  final Instrument speedOverGround;
+
+  /// Rhumb-line bearing and distance to the next mark.
+  final Instrument bearingToMark;
+  final Instrument distanceToMark;
+
+  /// Distance from the planned track, always positive. [offTrackSide] says which
+  /// side of it the vessel is on.
+  final Instrument crossTrackError;
+  final TrackSide? offTrackSide;
+
+  /// Speed of closing the next mark, which is SOG only when steering straight at
+  /// it. Negative when the vessel is opening the mark rather than closing it.
+  final Instrument velocityMadeGood;
+
+  final Duration fixAge;
+
+  /// True when the fix is older than the policy allows. Every calculated value
+  /// here is suspect when this is true, and the panel says so once rather than
+  /// per row.
+  final bool fixIsStale;
+
+  final bool accuracyIsPoor;
+
+  final PassageLeg? activeLeg;
+
+  /// Time to the next mark and to the end, at the *measured* closing speed - not
+  /// at the plan's assumed speed. Absent when not closing.
+  final Duration? timeToMark;
+  final Duration? timeToDestination;
+  final Instrument? distanceToDestination;
+
+  bool get hasActiveLeg => activeLeg != null;
+
+  /// Computes the instruments for [fix] against [plan].
+  ///
+  /// [plan] with no legs yields position-only instruments: a sailor with no
+  /// passage still wants COG and SOG.
+  static NavigationInstruments compute({
+    required NavigationFix fix,
+    required PassagePlan plan,
+    required DateTime now,
+    NavigationFixPolicy policy = const NavigationFixPolicy(),
+  }) {
+    final age = fix.ageAt(now);
+    final stale = age > policy.staleAfter;
+    final poorAccuracy = (fix.accuracyMeters ?? 0) > policy.poorAccuracyMeters;
+
+    final cog = fix.courseOverGroundDegrees == null
+        ? const Instrument.unavailable('No course while stopped')
+        : Instrument.measured(fix.courseOverGroundDegrees!);
+    final sog = fix.speedOverGroundMetersPerSecond == null
+        ? const Instrument.unavailable('Receiver reports no speed')
+        : Instrument.measured(fix.speedOverGroundMetersPerSecond!);
+
+    final leg = _activeLeg(fix.point, plan);
+    if (leg == null) {
+      return NavigationInstruments(
+        courseOverGround: cog,
+        speedOverGround: sog,
+        bearingToMark: const Instrument.unavailable('No passage'),
+        distanceToMark: const Instrument.unavailable('No passage'),
+        crossTrackError: const Instrument.unavailable('No passage'),
+        velocityMadeGood: const Instrument.unavailable('No passage'),
+        fixAge: age,
+        fixIsStale: stale,
+        accuracyIsPoor: poorAccuracy,
+      );
+    }
+
+    final bearing = rhumbBearingDegrees(fix.point, leg.to.point);
+    final distance = rhumbDistanceMeters(fix.point, leg.to.point);
+
+    // Cross-track error needs a fix good enough to be worth measuring against a
+    // line. A 200 m fix cannot tell a sailor they are 80 m off track.
+    final (crossTrack, side) = poorAccuracy
+        ? (
+            Instrument.unavailable(
+              'Fix accurate to ${fix.accuracyMeters!.round()} m',
+            ),
+            null,
+          )
+        : _crossTrack(fix.point, leg);
+
+    final vmg = _velocityMadeGood(fix, bearing);
+
+    // Time to run at the *measured* closing speed. Absent when the vessel is not
+    // closing the mark, because "arriving in -3 minutes" is not a time.
+    final closing = vmg.value;
+    final toMark = closing == null || closing <= 0.05
+        ? null
+        : Duration(seconds: (distance / closing).round());
+
+    final remaining =
+        plan.totalDistanceMeters -
+        (leg.cumulativeDistanceMeters - leg.distanceMeters);
+    final toDestination = closing == null || closing <= 0.05
+        ? null
+        : Duration(
+            seconds:
+                ((distance +
+                            (remaining - leg.distanceMeters).clamp(
+                              0,
+                              double.infinity,
+                            )) /
+                        closing)
+                    .round(),
+          );
+
+    return NavigationInstruments(
+      courseOverGround: cog,
+      speedOverGround: sog,
+      bearingToMark: Instrument.calculated(bearing),
+      distanceToMark: Instrument.calculated(distance),
+      crossTrackError: crossTrack,
+      offTrackSide: side,
+      velocityMadeGood: vmg,
+      fixAge: age,
+      fixIsStale: stale,
+      accuracyIsPoor: poorAccuracy,
+      activeLeg: leg,
+      timeToMark: toMark,
+      timeToDestination: toDestination,
+      distanceToDestination: Instrument.calculated(
+        distance + (remaining - leg.distanceMeters).clamp(0, double.infinity),
+      ),
+    );
+  }
+
+  /// The leg the vessel is on: the one whose track it is nearest.
+  ///
+  /// Nearest rather than "first not yet passed", because a sailor who has been
+  /// blown back down the passage, or who joins it in the middle, is on the leg
+  /// they are actually near - not the one a counter says is next.
+  static PassageLeg? _activeLeg(GeoPoint position, PassagePlan plan) {
+    if (!plan.hasLegs) return null;
+    PassageLeg? nearest;
+    var nearestDistance = double.infinity;
+    for (final leg in plan.legs) {
+      final distance = _distanceToSegmentMeters(
+        position,
+        leg.from.point,
+        leg.to.point,
+      );
+      if (distance < nearestDistance) {
+        nearestDistance = distance;
+        nearest = leg;
+      }
+    }
+    return nearest;
+  }
+
+  static (Instrument, TrackSide?) _crossTrack(
+    GeoPoint position,
+    PassageLeg leg,
+  ) {
+    final distance = _distanceToSegmentMeters(
+      position,
+      leg.from.point,
+      leg.to.point,
+    );
+    // Sign from the cross product of the track and the vessel's offset: positive
+    // means the vessel is to starboard of the track.
+    final trackBearing = rhumbBearingDegrees(leg.from.point, leg.to.point);
+    final toVessel = rhumbBearingDegrees(leg.from.point, position);
+    final difference = ((toVessel - trackBearing + 540) % 360) - 180;
+    if (distance < 1) return (const Instrument.calculated(0), null);
+    return (
+      Instrument.calculated(distance),
+      difference >= 0 ? TrackSide.starboard : TrackSide.port,
+    );
+  }
+
+  static Instrument _velocityMadeGood(NavigationFix fix, double bearingToMark) {
+    final speed = fix.speedOverGroundMetersPerSecond;
+    final course = fix.courseOverGroundDegrees;
+    if (speed == null || course == null) {
+      return const Instrument.unavailable('Needs course and speed');
+    }
+    final offset = ((course - bearingToMark + 540) % 360) - 180;
+    return Instrument.calculated(speed * math.cos(offset * math.pi / 180));
+  }
+
+  static double _distanceToSegmentMeters(
+    GeoPoint point,
+    GeoPoint start,
+    GeoPoint end,
+  ) {
+    // Local flat approximation: over a single leg the error is far below the
+    // precision a cross-track error is read at.
+    final latitudeScale = math.cos(
+      (start.latitude + end.latitude) / 2 * math.pi / 180,
+    );
+    final px = (point.longitude - start.longitude) * latitudeScale;
+    final py = point.latitude - start.latitude;
+    final ex = (end.longitude - start.longitude) * latitudeScale;
+    final ey = end.latitude - start.latitude;
+    final lengthSquared = ex * ex + ey * ey;
+    final t = lengthSquared == 0
+        ? 0.0
+        : ((px * ex + py * ey) / lengthSquared).clamp(0.0, 1.0);
+    final dx = px - ex * t;
+    final dy = py - ey * t;
+    // One degree of latitude in metres, which is what both axes are now scaled in.
+    return math.sqrt(dx * dx + dy * dy) * 111132.0;
+  }
+}

--- a/apps/mobile/test/features/map/navigation_instrument_panel_test.dart
+++ b/apps/mobile/test/features/map/navigation_instrument_panel_test.dart
@@ -1,0 +1,211 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tide_and_seek/domain/imported_route.dart';
+import 'package:tide_and_seek/features/map/navigation_instrument_panel.dart';
+import 'package:tide_and_seek/services/navigation_instruments.dart';
+import 'package:tide_and_seek/services/passage_legs.dart';
+
+/// #34. The panel exists for one property: a stale fix must degrade everything
+/// derived from it, visibly and at once. A frozen SOG still reading 5.2 kn
+/// because the last fix was four minutes ago looks exactly as trustworthy as it
+/// did when it was true.
+void main() {
+  const west = GeoPoint(latitude: 50.0000, longitude: -1.5000);
+  const east = GeoPoint(latitude: 50.0000, longitude: -1.0000);
+  final now = DateTime.utc(2026, 8, 18, 12);
+
+  PassagePlan planOf(List<GeoPoint> marks) => PassagePlan.of(
+    ImportedRoute(
+      id: 'p',
+      name: 'p',
+      importedAt: now,
+      sourceFileName: 'p.gpx',
+      paths: const [],
+      waypoints: [
+        for (final mark in marks)
+          RouteWaypoint(point: mark, name: mark == east ? 'Nab' : null),
+      ],
+    ),
+  );
+
+  NavigationInstruments instrumentsFor({
+    double? cog = 90,
+    double? sog = 3,
+    double? accuracy,
+    Duration age = Duration.zero,
+    List<GeoPoint> marks = const [west, east],
+    GeoPoint at = west,
+  }) => NavigationInstruments.compute(
+    fix: NavigationFix(
+      point: at,
+      recordedAt: now.subtract(age),
+      courseOverGroundDegrees: cog,
+      speedOverGroundMetersPerSecond: sog,
+      accuracyMeters: accuracy,
+    ),
+    plan: planOf(marks),
+    now: now,
+  );
+
+  Future<void> pump(WidgetTester tester, NavigationInstruments instruments) =>
+      tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData.dark(useMaterial3: true),
+          home: Scaffold(
+            body: Center(
+              child: NavigationInstrumentPanel(instruments: instruments),
+            ),
+          ),
+        ),
+      );
+
+  group('the readings', () {
+    testWidgets('own motion and mark figures are all present', (tester) async {
+      await pump(tester, instrumentsFor());
+      await tester.pumpAndSettle();
+
+      for (final label in ['COG', 'SOG', 'BTW', 'DTW', 'VMG', 'XTE']) {
+        expect(find.text(label), findsOneWidget, reason: label);
+      }
+      // Nautical and three-figure, as they are read aloud. Two of them here:
+      // steering 090 straight at a mark due east makes COG and BTW equal, which
+      // is what being on course looks like.
+      expect(find.text('090°T'), findsNWidgets(2));
+      expect(find.textContaining('kn'), findsWidgets);
+    });
+
+    testWidgets('a value the receiver cannot give shows why, not a stale one', (
+      tester,
+    ) async {
+      await pump(tester, instrumentsFor(cog: null));
+      await tester.pumpAndSettle();
+
+      expect(find.text('—'), findsWidgets);
+      expect(find.textContaining('stopped'), findsOneWidget);
+    });
+  });
+
+  // The reason this widget exists.
+  group('a stale fix', () {
+    testWidgets('is named once, plainly, above the figures', (tester) async {
+      await pump(tester, instrumentsFor(age: const Duration(minutes: 4)));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const Key('navigation-instruments-stale')),
+        findsOneWidget,
+      );
+      expect(find.textContaining('out of date'), findsOneWidget);
+      expect(find.textContaining('4h'), findsNothing);
+      expect(find.textContaining('4 min'), findsOneWidget);
+    });
+
+    testWidgets('dims every figure together, so none looks fresher', (
+      tester,
+    ) async {
+      const dimmed = Color(0xFF6B7684);
+
+      await pump(tester, instrumentsFor(age: const Duration(minutes: 4)));
+      await tester.pumpAndSettle();
+      for (final label in ['COG', 'SOG', 'BTW', 'DTW', 'VMG']) {
+        expect(
+          tester
+              .widget<Text>(find.byKey(Key('instrument-$label')))
+              .style
+              ?.color,
+          dimmed,
+          reason: '$label should be dimmed with the fix it came from',
+        );
+      }
+    });
+
+    testWidgets('a fresh fix reports its age and dims nothing', (tester) async {
+      await pump(tester, instrumentsFor(age: const Duration(seconds: 3)));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const Key('navigation-instruments-fix-age')),
+        findsOneWidget,
+      );
+      expect(find.text('Fix 3s old'), findsOneWidget);
+      expect(
+        find.byKey(const Key('navigation-instruments-stale')),
+        findsNothing,
+      );
+      expect(
+        tester
+            .widget<Text>(find.byKey(const Key('instrument-SOG')))
+            .style
+            ?.color,
+        isNot(const Color(0xFF6B7684)),
+      );
+    });
+  });
+
+  group('cross-track error', () {
+    testWidgets('names the side to steer toward, not the side you are on', (
+      tester,
+    ) async {
+      // North of a due-east track is to port of it, so the helm goes starboard.
+      await pump(
+        tester,
+        instrumentsFor(at: const GeoPoint(latitude: 50.01, longitude: -1.25)),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('steer starboard'), findsOneWidget);
+    });
+
+    testWidgets('says "on track" rather than showing a bare zero', (
+      tester,
+    ) async {
+      await pump(
+        tester,
+        instrumentsFor(at: const GeoPoint(latitude: 50.0, longitude: -1.25)),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('on track'), findsOneWidget);
+    });
+
+    testWidgets('a coarse fix suppresses it and says how coarse', (
+      tester,
+    ) async {
+      await pump(tester, instrumentsFor(accuracy: 200));
+      await tester.pumpAndSettle();
+      expect(find.textContaining('accurate to 200 m'), findsOneWidget);
+    });
+  });
+
+  group('the mark line', () {
+    testWidgets('names the mark and the time at this rate', (tester) async {
+      await pump(tester, instrumentsFor(sog: 5));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Making for Nab'), findsOneWidget);
+      expect(find.textContaining('at this rate'), findsOneWidget);
+    });
+
+    testWidgets('says "not closing" rather than a negative time', (
+      tester,
+    ) async {
+      await pump(tester, instrumentsFor(cog: 270));
+      await tester.pumpAndSettle();
+      expect(find.textContaining('not closing'), findsOneWidget);
+    });
+  });
+
+  testWidgets('with no passage it shows own motion and asks for marks', (
+    tester,
+  ) async {
+    await pump(tester, instrumentsFor(marks: const [west]));
+    await tester.pumpAndSettle();
+
+    expect(find.text('COG'), findsOneWidget);
+    expect(find.text('SOG'), findsOneWidget);
+    expect(find.text('BTW'), findsNothing);
+    expect(
+      find.byKey(const Key('navigation-instruments-no-passage')),
+      findsOneWidget,
+    );
+  });
+}

--- a/apps/mobile/test/services/navigation_instruments_test.dart
+++ b/apps/mobile/test/services/navigation_instruments_test.dart
@@ -1,0 +1,269 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tide_and_seek/domain/imported_route.dart';
+import 'package:tide_and_seek/services/navigation_instruments.dart';
+import 'package:tide_and_seek/services/passage_legs.dart';
+
+/// #34. These are the numbers a navigator steers by, so the tests are mostly
+/// about refusing to state what is not known: no VMG without a course, no
+/// cross-track error from a coarse fix, no arrival time when the vessel is not
+/// closing, and a stale fix flagged rather than quietly reused.
+void main() {
+  // A due-east leg at 50N, so expected bearings and sides are checkable by hand.
+  const west = GeoPoint(latitude: 50.0000, longitude: -1.5000);
+  const east = GeoPoint(latitude: 50.0000, longitude: -1.0000);
+  final fixedNow = DateTime.utc(2026, 8, 18, 12);
+
+  PassagePlan planOf(List<GeoPoint> marks) => PassagePlan.of(
+    ImportedRoute(
+      id: 'passage',
+      name: 'Test passage',
+      importedAt: fixedNow,
+      sourceFileName: 'p.gpx',
+      paths: const [],
+      waypoints: [for (final mark in marks) RouteWaypoint(point: mark)],
+    ),
+  );
+
+  NavigationFix fixAt(
+    GeoPoint point, {
+    double? cog,
+    double? sog,
+    double? accuracy,
+    Duration age = Duration.zero,
+  }) => NavigationFix(
+    point: point,
+    recordedAt: fixedNow.subtract(age),
+    courseOverGroundDegrees: cog,
+    speedOverGroundMetersPerSecond: sog,
+    accuracyMeters: accuracy,
+  );
+
+  NavigationInstruments computeFor(
+    NavigationFix fix, {
+    List<GeoPoint> marks = const [west, east],
+  }) => NavigationInstruments.compute(
+    fix: fix,
+    plan: planOf(marks),
+    now: fixedNow,
+  );
+
+  group('what the receiver measures', () {
+    test('COG and SOG are reported as measured', () {
+      final instruments = computeFor(fixAt(west, cog: 90, sog: 3.0));
+
+      expect(instruments.courseOverGround.value, 90);
+      expect(instruments.courseOverGround.basis, InstrumentBasis.measured);
+      expect(instruments.speedOverGround.value, 3.0);
+      expect(instruments.speedOverGround.basis, InstrumentBasis.measured);
+    });
+
+    test('a stopped vessel has no course, and says so', () {
+      // COG is meaningless at rest; a receiver that reports none must not be
+      // papered over with the last one.
+      final instruments = computeFor(fixAt(west, sog: 0));
+
+      expect(instruments.courseOverGround.isAvailable, isFalse);
+      expect(instruments.courseOverGround.basis, InstrumentBasis.unavailable);
+      expect(instruments.courseOverGround.reason, contains('stopped'));
+    });
+  });
+
+  group('the next mark', () {
+    test('bearing and distance are calculated against the chart', () {
+      final instruments = computeFor(fixAt(west, cog: 90, sog: 3));
+
+      // Due east along the parallel, half a degree of longitude at 50N.
+      expect(instruments.bearingToMark.value, closeTo(90, 0.5));
+      expect(instruments.bearingToMark.basis, InstrumentBasis.calculated);
+      expect(instruments.distanceToMark.value! / 1852, closeTo(19.3, 0.3));
+    });
+
+    test('the active leg is the nearest one, not the next by count', () {
+      // Blown back down the passage: nearer leg 1 than leg 2, so leg 1 is the
+      // one being sailed whatever a counter would say.
+      const middle = GeoPoint(latitude: 50.0, longitude: -1.0);
+      const far = GeoPoint(latitude: 50.5, longitude: -1.0);
+      final instruments = computeFor(
+        fixAt(const GeoPoint(latitude: 50.0, longitude: -1.4), cog: 90, sog: 3),
+        marks: const [west, middle, far],
+      );
+
+      expect(instruments.activeLeg?.number, 1);
+      expect(instruments.hasActiveLeg, isTrue);
+    });
+  });
+
+  group('cross-track error', () {
+    test('names the side the vessel is on', () {
+      // North of a due-east track is to port of it.
+      final north = computeFor(
+        fixAt(
+          const GeoPoint(latitude: 50.01, longitude: -1.25),
+          cog: 90,
+          sog: 3,
+        ),
+      );
+      expect(north.offTrackSide, TrackSide.port);
+      expect(north.crossTrackError.value!, closeTo(1111, 60));
+
+      final south = computeFor(
+        fixAt(
+          const GeoPoint(latitude: 49.99, longitude: -1.25),
+          cog: 90,
+          sog: 3,
+        ),
+      );
+      expect(south.offTrackSide, TrackSide.starboard);
+    });
+
+    test('the side to steer toward is the opposite one', () {
+      expect(TrackSide.port.opposite, TrackSide.starboard);
+      expect(TrackSide.starboard.opposite, TrackSide.port);
+      expect(TrackSide.port.label, 'port');
+    });
+
+    test('is refused when the fix is too coarse to measure it', () {
+      // A 200 m fix cannot tell a sailor they are 80 m off track.
+      final instruments = computeFor(
+        fixAt(
+          const GeoPoint(latitude: 50.0007, longitude: -1.25),
+          cog: 90,
+          sog: 3,
+          accuracy: 200,
+        ),
+      );
+
+      expect(instruments.crossTrackError.isAvailable, isFalse);
+      expect(instruments.crossTrackError.reason, contains('200 m'));
+      expect(instruments.offTrackSide, isNull);
+      expect(instruments.accuracyIsPoor, isTrue);
+    });
+
+    test('on the track it is zero with no side', () {
+      final instruments = computeFor(
+        fixAt(
+          const GeoPoint(latitude: 50.0, longitude: -1.25),
+          cog: 90,
+          sog: 3,
+        ),
+      );
+      expect(instruments.crossTrackError.value, closeTo(0, 1));
+      expect(instruments.offTrackSide, isNull);
+    });
+  });
+
+  group('velocity made good', () {
+    test('equals SOG when steering straight at the mark', () {
+      final instruments = computeFor(fixAt(west, cog: 90, sog: 4));
+      expect(instruments.velocityMadeGood.value, closeTo(4, 0.05));
+      expect(instruments.velocityMadeGood.basis, InstrumentBasis.calculated);
+    });
+
+    test('falls off with the angle, and goes negative when opening', () {
+      final across = computeFor(fixAt(west, cog: 150, sog: 4));
+      expect(across.velocityMadeGood.value, lessThan(4));
+      expect(across.velocityMadeGood.value, greaterThan(0));
+
+      // Sailing away from the mark: VMG is negative, and that is the honest
+      // number rather than zero.
+      final away = computeFor(fixAt(west, cog: 270, sog: 4));
+      expect(away.velocityMadeGood.value, closeTo(-4, 0.05));
+    });
+
+    test('is absent without both a course and a speed', () {
+      expect(
+        computeFor(fixAt(west, sog: 4)).velocityMadeGood.isAvailable,
+        isFalse,
+      );
+      expect(
+        computeFor(fixAt(west, cog: 90)).velocityMadeGood.isAvailable,
+        isFalse,
+      );
+      expect(
+        computeFor(fixAt(west, cog: 90)).velocityMadeGood.reason,
+        contains('course and speed'),
+      );
+    });
+  });
+
+  group('time to run', () {
+    test('uses the measured closing speed, not the planned speed', () {
+      final instruments = computeFor(fixAt(west, cog: 90, sog: 5));
+      // 19.3 NM at 5 m/s is about 1h 59m. The plan's 5 kn would say 3h 52m.
+      expect(instruments.timeToMark!.inMinutes, closeTo(119, 3));
+    });
+
+    test('is absent when the vessel is not closing the mark', () {
+      // "Arriving in -3 minutes" is not a time.
+      final away = computeFor(fixAt(west, cog: 270, sog: 4));
+      expect(away.timeToMark, isNull);
+      expect(away.timeToDestination, isNull);
+
+      final stopped = computeFor(fixAt(west, cog: 90, sog: 0));
+      expect(stopped.timeToMark, isNull);
+    });
+  });
+
+  group('a fix that cannot be trusted', () {
+    test('a stale fix is flagged, and its age is reported', () {
+      final instruments = computeFor(
+        fixAt(west, cog: 90, sog: 3, age: const Duration(seconds: 40)),
+      );
+
+      expect(instruments.fixIsStale, isTrue);
+      expect(instruments.fixAge, const Duration(seconds: 40));
+    });
+
+    test('a fresh fix is not', () {
+      final instruments = computeFor(
+        fixAt(west, cog: 90, sog: 3, age: const Duration(seconds: 2)),
+      );
+      expect(instruments.fixIsStale, isFalse);
+      expect(instruments.accuracyIsPoor, isFalse);
+    });
+
+    test('a fix from the future is treated as current, not negative', () {
+      final instruments = NavigationInstruments.compute(
+        fix: NavigationFix(
+          point: west,
+          recordedAt: fixedNow.add(const Duration(seconds: 5)),
+          courseOverGroundDegrees: 90,
+          speedOverGroundMetersPerSecond: 3,
+        ),
+        plan: planOf(const [west, east]),
+        now: fixedNow,
+      );
+      expect(instruments.fixAge, Duration.zero);
+      expect(instruments.fixIsStale, isFalse);
+    });
+
+    test('the staleness threshold is configurable', () {
+      final instruments = NavigationInstruments.compute(
+        fix: fixAt(west, cog: 90, sog: 3, age: const Duration(seconds: 20)),
+        plan: planOf(const [west, east]),
+        now: fixedNow,
+        policy: const NavigationFixPolicy(staleAfter: Duration(minutes: 1)),
+      );
+      expect(instruments.fixIsStale, isFalse);
+    });
+  });
+
+  group('with no passage', () {
+    test('position instruments still work, plan ones say why not', () {
+      final instruments = computeFor(
+        fixAt(west, cog: 90, sog: 3),
+        marks: const [west],
+      );
+
+      // A sailor with no passage still wants COG and SOG.
+      expect(instruments.courseOverGround.value, 90);
+      expect(instruments.speedOverGround.value, 3);
+
+      expect(instruments.hasActiveLeg, isFalse);
+      expect(instruments.bearingToMark.reason, 'No passage');
+      expect(instruments.crossTrackError.isAvailable, isFalse);
+      expect(instruments.velocityMadeGood.isAvailable, isFalse);
+      expect(instruments.timeToMark, isNull);
+    });
+  });
+}


### PR DESCRIPTION
Closes the instruments half of #34. (The nautical-units half landed earlier in `e7b8106`.)

## Why

The map showed position and a route. It did not show the numbers a navigator steers by: **COG, SOG, BTW, DTW, XTE, VMG**, and how old the fix all of that rests on.

## The design is mostly about what it refuses to say

- **No VMG** without both a course and a speed
- **No cross-track error** from a fix too coarse to measure one — a 200 m fix cannot tell a sailor they are 80 m off track, so it reports how coarse the fix is instead
- **No arrival time** when the vessel is not closing the mark, because "arriving in −3 minutes" is not a time
- **No course at all when stopped** — COG is meaningless at rest, and the last one is not a substitute

Every value carries its **basis**: measured by the receiver, or calculated from the plan. That is the difference between "you are doing 4.2 knots" and "if the plan holds you will arrive at 14:20", and a navigator deciding whether to trust a number needs to know which kind it is.

Times to run use the **measured closing speed**, not the plan's assumed 5 kn. On the demo passage the two answers differ by about ninety minutes, and only one of them is an observation.

## The property the panel exists for

A stale fix must degrade everything derived from it, **visibly and at once**. Past the threshold every figure dims together and one banner says how old the fix is — once, rather than a badge per row that a sailor reads past.

A frozen SOG still reading 5.2 kn because the last fix was four minutes ago looks exactly as trustworthy as it did when it was true. That is the failure `PLAN.md` names, and there is a test that asserts every reading dims together.

## COG, not heading

Everything here is GNSS-derived and named as such. Heading (where the bow points) and speed through water are different quantities, differing from these by the **tidal stream and leeway** — which is precisely the difference a sailor cares about — so they are not claimed. When instrument input arrives (#16) they belong in separate fields, never merged into these.

Cross-track error names the side to steer **toward**, which is geometry. Nothing here recommends a course; what to steer depends on the stream, the wind and what the sailor can see.

## Verification

- 1,651 tests pass, analyzer clean
- **18 service tests**: bearing and distance checked against the chart, active leg is the *nearest* one (a sailor blown back down the passage is on the leg they are near, not the one a counter says is next), XTE side, VMG going negative when opening, staleness, a fix from the future clamped to zero age
- **11 panel tests**: including that every reading dims together, and that a coarse fix says how coarse
- On the simulator: the menu entry is present, and **with no fix it declines to measure rather than showing zeros**

## Not verified on device

Live values. The simulator has no usable GNSS fix without a started voyage and location permission, so the populated panel is covered by widget tests rather than a screenshot. Worth a look on a real device alongside #28's outstanding real-iPad check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)