### PR TITLE
Wind, weather and sea state from Open-Meteo (#12)

### DIFF
--- a/apps/mobile/lib/features/map/marine_forecast_panel.dart
+++ b/apps/mobile/lib/features/map/marine_forecast_panel.dart
@@ -1,0 +1,341 @@
+/// Wind, pressure, visibility and sea state, with the age of the forecast.
+///
+/// ## Nothing here is an observation
+///
+/// Open-Meteo's "current" block is model output for the current hour, not a
+/// reading from a weather station. `PLAN.md` requires observed and forecast to
+/// stay distinguishable; the honest answer is that this is all forecast, and the
+/// panel says so once at the top rather than implying a measurement.
+///
+/// ## Age, not run time
+///
+/// The provider publishes what its values are valid *for*, and does not publish
+/// the model run behind them. So the panel shows the validity time and how long
+/// ago that was — and says the run is not published, rather than showing a server
+/// timing as though it were provenance.
+///
+/// ## Wind reads the way a forecast is read
+///
+/// Direction is where the wind blows *from*, with its compass point, and Beaufort
+/// sits beside knots: "force 6" carries meaning that "24 knots" does not, and a
+/// forecast is discussed in both. Gusts are given their own line because the
+/// difference between 18 knots and gusting 30 is the difference between a good
+/// sail and a reef.
+library;
+
+import 'package:flutter/material.dart';
+
+import '../../services/marine_forecast.dart';
+import 'passage_leg_table.dart' show formatPassageDuration;
+
+class MarineForecastPanel extends StatelessWidget {
+  const MarineForecastPanel({
+    super.key,
+    this.forecast,
+    this.failure,
+    required this.now,
+    this.staleAfter = const Duration(hours: 3),
+  });
+
+  final MarineForecast? forecast;
+
+  /// Set when there is no forecast. A missing forecast is an ordinary state on a
+  /// free endpoint with no uptime guarantee, and at sea, so it is reported rather
+  /// than treated as a fault.
+  final ForecastException? failure;
+
+  final DateTime now;
+
+  /// A three-hour-old forecast is still worth reading; it just needs saying.
+  final Duration staleAfter;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final current = forecast;
+
+    return Column(
+      key: const Key('marine-forecast-panel'),
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text('Weather', style: theme.textTheme.headlineSmall),
+        const SizedBox(height: 4),
+        // Said once, at the top: none of this is measured.
+        Text(
+          'Forecast, not an observation. No weather station reading here.',
+          key: const Key('marine-forecast-not-observed'),
+          style: theme.textTheme.bodySmall,
+        ),
+        const SizedBox(height: 14),
+        if (current == null)
+          _Unavailable(failure: failure)
+        else ...[
+          _Validity(forecast: current, now: now, staleAfter: staleAfter),
+          const SizedBox(height: 14),
+          _Wind(forecast: current),
+          const SizedBox(height: 14),
+          _SeaState(forecast: current),
+          const SizedBox(height: 14),
+          _Other(forecast: current),
+          const SizedBox(height: 16),
+          // CC BY 4.0 requires this, and it must survive being offline.
+          Text(
+            OpenMeteoForecastService.attribution,
+            key: const Key('marine-forecast-attribution'),
+            style: theme.textTheme.bodySmall?.copyWith(
+              fontStyle: FontStyle.italic,
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _Unavailable extends StatelessWidget {
+  const _Unavailable({this.failure});
+
+  final ForecastException? failure;
+
+  @override
+  Widget build(BuildContext context) => Row(
+    key: const Key('marine-forecast-unavailable'),
+    crossAxisAlignment: CrossAxisAlignment.start,
+    children: [
+      const Padding(
+        padding: EdgeInsets.only(top: 2, right: 8),
+        child: Icon(Icons.cloud_off_outlined, size: 18),
+      ),
+      Expanded(
+        child: Text(
+          failure?.sailorMessage ?? 'No forecast yet.',
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
+      ),
+    ],
+  );
+}
+
+class _Validity extends StatelessWidget {
+  const _Validity({
+    required this.forecast,
+    required this.now,
+    required this.staleAfter,
+  });
+
+  final MarineForecast forecast;
+  final DateTime now;
+  final Duration staleAfter;
+
+  @override
+  Widget build(BuildContext context) {
+    final age = forecast.ageAt(now);
+    final stale = age > staleAfter;
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Icon(
+              stale ? Icons.warning_amber_outlined : Icons.schedule,
+              size: 16,
+              color: stale ? const Color(0xFFE8A33D) : null,
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                age.inMinutes < 1
+                    ? 'Valid now'
+                    : 'Valid ${formatPassageDuration(age)} ago',
+                key: const Key('marine-forecast-age'),
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: stale ? const Color(0xFFE8A33D) : null,
+                  fontWeight: stale ? FontWeight.w700 : null,
+                ),
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 2),
+        Text(
+          // Checked against the live API: the provider does not publish it.
+          'The forecast run behind this is not published by the provider.',
+          key: const Key('marine-forecast-no-run-time'),
+          style: theme.textTheme.bodySmall,
+        ),
+      ],
+    );
+  }
+}
+
+class _Wind extends StatelessWidget {
+  const _Wind({required this.forecast});
+
+  final MarineForecast forecast;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    if (!forecast.hasWind) {
+      return Text(
+        'No wind in this forecast.',
+        key: const Key('marine-forecast-no-wind'),
+        style: theme.textTheme.bodyMedium,
+      );
+    }
+    final point = MarineForecast.compassPoint(forecast.windFromDegrees);
+    final force = forecast.beaufortForce;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'WIND',
+          style: theme.textTheme.labelSmall?.copyWith(
+            color: const Color(0xFF98A3B1),
+            letterSpacing: 0.6,
+          ),
+        ),
+        Text(
+          // "from" spelled out: a wind from 270 is a westerly, and the
+          // ambiguity between from and toward is worth a word.
+          [
+            if (point != null) 'from $point',
+            '${forecast.windSpeedKnots!.round()} kn',
+            if (force != null) 'force $force',
+          ].join(' · '),
+          key: const Key('marine-forecast-wind'),
+          style: theme.textTheme.titleMedium,
+        ),
+        if (forecast.windGustKnots case final gust?)
+          Text(
+            'gusting ${gust.round()} kn',
+            key: const Key('marine-forecast-gust'),
+            style: theme.textTheme.bodyMedium,
+          ),
+      ],
+    );
+  }
+}
+
+class _SeaState extends StatelessWidget {
+  const _SeaState({required this.forecast});
+
+  final MarineForecast forecast;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    if (!forecast.hasSeaState) {
+      return Text(
+        // Absence is normal for an inland or sheltered position, not a fault.
+        'No sea state for this position.',
+        key: const Key('marine-forecast-no-sea-state'),
+        style: theme.textTheme.bodyMedium,
+      );
+    }
+    final point = MarineForecast.compassPoint(forecast.waveFromDegrees);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'FORECAST WAVE',
+          style: theme.textTheme.labelSmall?.copyWith(
+            color: const Color(0xFF98A3B1),
+            letterSpacing: 0.6,
+          ),
+        ),
+        Text(
+          [
+            '${forecast.waveHeightMeters!.toStringAsFixed(1)} m',
+            if (forecast.wavePeriodSeconds case final period?)
+              '${period.toStringAsFixed(0)} s',
+            if (point != null) 'from $point',
+          ].join(' · '),
+          key: const Key('marine-forecast-wave'),
+          style: theme.textTheme.titleMedium,
+        ),
+        Text(
+          // Modelled significant wave height is not the sea a sailor meets near
+          // a lee shore, over a bank, or against the tide.
+          'Modelled open-water wave. Not the sea you will meet in a tide race '
+          'or under a lee shore.',
+          style: theme.textTheme.bodySmall,
+        ),
+      ],
+    );
+  }
+}
+
+class _Other extends StatelessWidget {
+  const _Other({required this.forecast});
+
+  final MarineForecast forecast;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final visibility = forecast.visibilityMeters;
+    return Wrap(
+      spacing: 20,
+      runSpacing: 8,
+      children: [
+        if (forecast.pressureHectopascals case final pressure?)
+          _Small(
+            label: 'PRESSURE',
+            value: '${pressure.round()} hPa',
+            valueKey: const Key('marine-forecast-pressure'),
+            theme: theme,
+          ),
+        if (visibility != null)
+          _Small(
+            label: 'VISIBILITY',
+            // Read in miles at sea for anything but fog.
+            value: visibility >= 1852
+                ? '${(visibility / 1852).toStringAsFixed(visibility < 9260 ? 1 : 0)} NM'
+                : '${visibility.round()} m',
+            valueKey: const Key('marine-forecast-visibility'),
+            theme: theme,
+          ),
+        if (forecast.temperatureCelsius case final temperature?)
+          _Small(
+            label: 'AIR',
+            value: '${temperature.round()}°C',
+            valueKey: const Key('marine-forecast-temperature'),
+            theme: theme,
+          ),
+      ],
+    );
+  }
+}
+
+class _Small extends StatelessWidget {
+  const _Small({
+    required this.label,
+    required this.value,
+    required this.valueKey,
+    required this.theme,
+  });
+
+  final String label;
+  final String value;
+  final Key valueKey;
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) => Column(
+    crossAxisAlignment: CrossAxisAlignment.start,
+    mainAxisSize: MainAxisSize.min,
+    children: [
+      Text(
+        label,
+        style: theme.textTheme.labelSmall?.copyWith(
+          color: const Color(0xFF98A3B1),
+          letterSpacing: 0.6,
+        ),
+      ),
+      Text(value, key: valueKey, style: theme.textTheme.bodyLarge),
+    ],
+  );
+}

--- a/apps/mobile/lib/features/map/voyage_map_feature.dart
+++ b/apps/mobile/lib/features/map/voyage_map_feature.dart
@@ -78,6 +78,8 @@ import '../../services/passage_legs.dart';
 import 'passage_leg_table.dart';
 import '../../services/navigation_instruments.dart';
 import 'navigation_instrument_panel.dart';
+import '../../services/marine_forecast.dart';
+import 'marine_forecast_panel.dart';
 
 @visibleForTesting
 GroupMiniMapRenderer groupMiniMapRenderer({
@@ -1532,6 +1534,10 @@ class _VoyageMapScreenState extends State<VoyageMapScreen> {
                     const PopupMenuItem(
                       value: _MapAction.instruments,
                       child: Text('Navigation instruments'),
+                    ),
+                    const PopupMenuItem(
+                      value: _MapAction.weather,
+                      child: Text('Wind and weather'),
                     ),
                     // Always offered, route or not: what the map is made of is
                     // not a property of the plan.
@@ -5186,11 +5192,52 @@ class _VoyageMapScreenState extends State<VoyageMapScreen> {
         await _showPassagePlan();
       case _MapAction.instruments:
         await _showNavigationInstruments();
+      case _MapAction.weather:
+        await _showWeather();
       case _MapAction.clearOfflineTiles:
         await _mapLibreOfflineManager.clearAll();
         await widget.offlineTileCache.clearAll();
         _showMessage('Offline map data cleared.');
     }
+  }
+
+  /// Wind, pressure, visibility and sea state for where the sailor is.
+  ///
+  /// Fetched when opened rather than polled: the free endpoint has a daily call
+  /// budget and no uptime guarantee, so asking once when a sailor wants to know
+  /// spends it where it is useful. A failure is shown in the sheet rather than as
+  /// an error, because no forecast is an ordinary condition at sea (#12).
+  Future<void> _showWeather() async {
+    final position = _effectivePosition;
+    if (position == null) {
+      _showMessage('No position yet, so there is nowhere to forecast for.');
+      return;
+    }
+    MarineForecast? forecast;
+    ForecastException? failure;
+    try {
+      forecast = await OpenMeteoForecastService(
+        client: _routingClient,
+      ).fetch(latitude: position.latitude, longitude: position.longitude);
+    } on ForecastException catch (error) {
+      failure = error;
+    }
+    if (!mounted) return;
+    await showModalBottomSheet<void>(
+      context: context,
+      showDragHandle: true,
+      builder: (context) => SafeArea(
+        top: false,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(20, 4, 20, 24),
+          child: MarineForecastPanel(
+            forecast: forecast,
+            failure: failure,
+            now: DateTime.now().toUtc(),
+          ),
+        ),
+      ),
+    );
   }
 
   /// The instrument panel: what the receiver measures and what follows from it.
@@ -5566,6 +5613,7 @@ enum _MapAction {
   chartSources,
   passagePlan,
   instruments,
+  weather,
   importGpx,
   loadDemo,
   personalVoyageHeatmap,

--- a/apps/mobile/lib/services/marine_forecast.dart
+++ b/apps/mobile/lib/services/marine_forecast.dart
@@ -1,0 +1,300 @@
+/// Wind, pressure, visibility and sea state for a position.
+///
+/// ## Source and licence
+///
+/// Open-Meteo. The data is **CC BY 4.0**, so caching it on the device and showing
+/// it to crew are both permitted with attribution — which is why this fits the
+/// `ChartSource` provenance model the charts already use. The free endpoint is
+/// for non-commercial use at 10,000 calls a day and carries no uptime guarantee,
+/// so a missing forecast is an ordinary state here rather than an error (#12).
+///
+/// ## What "current" is, and is not
+///
+/// Open-Meteo's `current` block is **model output for the current hour**, not a
+/// reading from a weather station. Nothing in this file is an observation, and
+/// nothing may be labelled as one: `PLAN.md` requires observed and forecast to
+/// stay distinguishable, and the honest answer here is that it is all forecast.
+///
+/// ## There is no forecast run time
+///
+/// Checked against the live API rather than assumed. The response carries
+/// `generationtime_ms`, which is how long the *server* spent answering, and
+/// `current.time`, which is what the values are valid for. The underlying model
+/// run is not published. So this exposes [MarineForecast.validAt] and an age, and
+/// says plainly that the run time is unknown, rather than showing a server timing
+/// as though it meant something.
+library;
+
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+/// One forecast for one position, with everything needed to judge its worth.
+class MarineForecast {
+  const MarineForecast({
+    required this.latitude,
+    required this.longitude,
+    required this.validAt,
+    required this.fetchedAt,
+    this.windSpeedKnots,
+    this.windGustKnots,
+    this.windFromDegrees,
+    this.pressureHectopascals,
+    this.visibilityMeters,
+    this.temperatureCelsius,
+    this.waveHeightMeters,
+    this.wavePeriodSeconds,
+    this.waveFromDegrees,
+  });
+
+  final double latitude;
+  final double longitude;
+
+  /// What the values are valid for, from the provider.
+  final DateTime validAt;
+
+  /// When this device fetched them, which is what makes an offline copy ageable.
+  final DateTime fetchedAt;
+
+  /// Wind is reported as the direction it blows *from*, which is the convention
+  /// every forecast and every sailor uses. A wind "from 270" is a westerly.
+  final double? windSpeedKnots;
+  final double? windGustKnots;
+  final double? windFromDegrees;
+
+  final double? pressureHectopascals;
+  final double? visibilityMeters;
+  final double? temperatureCelsius;
+
+  /// Sea state. Absent for an inland position, and absence is not a failure.
+  final double? waveHeightMeters;
+  final double? wavePeriodSeconds;
+  final double? waveFromDegrees;
+
+  bool get hasWind => windSpeedKnots != null;
+  bool get hasSeaState => waveHeightMeters != null;
+
+  /// How old the forecast's own validity is, which is not the same as how long
+  /// ago it was fetched: a cached forecast can be recent and already stale.
+  Duration ageAt(DateTime now) {
+    final age = now.difference(validAt);
+    return age.isNegative ? Duration.zero : age;
+  }
+
+  /// Beaufort force for [windSpeedKnots], because forecasts are read in both and
+  /// "force 6" carries meaning that "24 knots" does not.
+  int? get beaufortForce {
+    final knots = windSpeedKnots;
+    if (knots == null) return null;
+    // Force 0 is calm, below one knot. Every other force is bounded above by its
+    // published upper limit in knots, so force 1 is 1-3, force 6 is 22-27, and
+    // force 12 is anything from 64 up.
+    if (knots < 1) return 0;
+    const upperLimits = [0, 3, 6, 10, 16, 21, 27, 33, 40, 47, 55, 63];
+    for (var force = 1; force < upperLimits.length; force += 1) {
+      if (knots <= upperLimits[force]) return force;
+    }
+    return 12;
+  }
+
+  /// The compass point a direction lies in, for reading aloud.
+  static String? compassPoint(double? degrees) {
+    if (degrees == null) return null;
+    const points = [
+      'N',
+      'NNE',
+      'NE',
+      'ENE',
+      'E',
+      'ESE',
+      'SE',
+      'SSE',
+      'S',
+      'SSW',
+      'SW',
+      'WSW',
+      'W',
+      'WNW',
+      'NW',
+      'NNW',
+    ];
+    final normalised = ((degrees % 360) + 360) % 360;
+    return points[((normalised / 22.5).round()) % 16];
+  }
+}
+
+/// Why a forecast is not available. Named so the UI can say which.
+enum ForecastFailure {
+  /// No network, or the provider did not answer. Ordinary at sea.
+  unreachable,
+
+  /// The provider answered with something this code does not understand.
+  unreadable,
+
+  /// The provider refused — most likely the free tier's daily limit.
+  refused,
+}
+
+class ForecastException implements Exception {
+  const ForecastException(this.failure, this.message);
+
+  final ForecastFailure failure;
+  final String message;
+
+  /// Shown to the sailor. Says what is missing, not what went wrong internally.
+  String get sailorMessage => switch (failure) {
+    ForecastFailure.unreachable =>
+      'No forecast: could not reach the weather service.',
+    ForecastFailure.refused =>
+      'No forecast: the weather service declined the request.',
+    ForecastFailure.unreadable =>
+      'No forecast: the weather service sent something unreadable.',
+  };
+
+  @override
+  String toString() => 'ForecastException($failure): $message';
+}
+
+/// Fetches a forecast for a position from Open-Meteo.
+class OpenMeteoForecastService {
+  const OpenMeteoForecastService({
+    required this.client,
+    this.forecastHost = 'api.open-meteo.com',
+    this.marineHost = 'marine-api.open-meteo.com',
+    this.timeout = const Duration(seconds: 12),
+  });
+
+  final http.Client client;
+
+  /// Hosts are separate: wind and pressure come from the forecast API, waves from
+  /// the marine one. Overridable so a paid endpoint can replace them without
+  /// touching this logic.
+  final String forecastHost;
+  final String marineHost;
+
+  final Duration timeout;
+
+  /// Attribution required by CC BY 4.0, and shown offline.
+  static const attribution = 'Weather data by Open-Meteo.com (CC BY 4.0)';
+
+  Future<MarineForecast> fetch({
+    required double latitude,
+    required double longitude,
+    DateTime? now,
+  }) async {
+    final fetchedAt = (now ?? DateTime.now()).toUtc();
+    final weather = await _get(
+      Uri.https(forecastHost, '/v1/forecast', {
+        'latitude': latitude.toString(),
+        'longitude': longitude.toString(),
+        'current':
+            'wind_speed_10m,wind_direction_10m,wind_gusts_10m,'
+            'pressure_msl,visibility,temperature_2m',
+        // Knots at source, so no conversion can drift from what the provider
+        // meant.
+        'wind_speed_unit': 'kn',
+        'timezone': 'UTC',
+      }),
+    );
+
+    final current = weather['current'];
+    if (current is! Map) {
+      throw const ForecastException(
+        ForecastFailure.unreadable,
+        'no current block',
+      );
+    }
+    final validAt = _parseTime(current['time']);
+
+    // Waves are a separate request and a separate host. An inland position has no
+    // wave data at all, and a marine service that is down should not take the
+    // wind with it - so this failure is swallowed rather than propagated.
+    Map<String, Object?>? wave;
+    try {
+      final marine = await _get(
+        Uri.https(marineHost, '/v1/marine', {
+          'latitude': latitude.toString(),
+          'longitude': longitude.toString(),
+          'current': 'wave_height,wave_direction,wave_period',
+          'timezone': 'UTC',
+        }),
+      );
+      final marineCurrent = marine['current'];
+      if (marineCurrent is Map) {
+        wave = Map<String, Object?>.from(marineCurrent);
+      }
+    } on Object {
+      wave = null;
+    }
+
+    return MarineForecast(
+      latitude: (weather['latitude'] as num?)?.toDouble() ?? latitude,
+      longitude: (weather['longitude'] as num?)?.toDouble() ?? longitude,
+      validAt: validAt,
+      fetchedAt: fetchedAt,
+      windSpeedKnots: _number(current['wind_speed_10m']),
+      windGustKnots: _number(current['wind_gusts_10m']),
+      windFromDegrees: _number(current['wind_direction_10m']),
+      pressureHectopascals: _number(current['pressure_msl']),
+      visibilityMeters: _number(current['visibility']),
+      temperatureCelsius: _number(current['temperature_2m']),
+      waveHeightMeters: _number(wave?['wave_height']),
+      wavePeriodSeconds: _number(wave?['wave_period']),
+      waveFromDegrees: _number(wave?['wave_direction']),
+    );
+  }
+
+  Future<Map<String, Object?>> _get(Uri uri) async {
+    final http.Response response;
+    try {
+      response = await client.get(uri).timeout(timeout);
+    } on Object catch (error) {
+      throw ForecastException(ForecastFailure.unreachable, '$error');
+    }
+    if (response.statusCode == 429 || response.statusCode == 402) {
+      throw ForecastException(
+        ForecastFailure.refused,
+        'HTTP ${response.statusCode}',
+      );
+    }
+    if (response.statusCode != 200) {
+      throw ForecastException(
+        ForecastFailure.unreachable,
+        'HTTP ${response.statusCode}',
+      );
+    }
+    final Object? decoded;
+    try {
+      decoded = jsonDecode(response.body);
+    } on Object catch (error) {
+      throw ForecastException(ForecastFailure.unreadable, '$error');
+    }
+    if (decoded is! Map) {
+      throw const ForecastException(
+        ForecastFailure.unreadable,
+        'not an object',
+      );
+    }
+    return Map<String, Object?>.from(decoded);
+  }
+
+  static DateTime _parseTime(Object? raw) {
+    if (raw is! String) {
+      throw const ForecastException(
+        ForecastFailure.unreadable,
+        'missing valid time',
+      );
+    }
+    // Requested in UTC, and the provider returns it without a zone suffix.
+    final parsed = DateTime.tryParse(raw.endsWith('Z') ? raw : '${raw}Z');
+    if (parsed == null) {
+      throw ForecastException(
+        ForecastFailure.unreadable,
+        'unparseable time "$raw"',
+      );
+    }
+    return parsed.toUtc();
+  }
+
+  static double? _number(Object? raw) => (raw as num?)?.toDouble();
+}

--- a/apps/mobile/lib/services/marine_layers.dart
+++ b/apps/mobile/lib/services/marine_layers.dart
@@ -99,6 +99,32 @@ abstract final class MarineLayers {
         'behind it.',
   );
 
+  /// The weather and sea-state forecast (#12).
+  ///
+  /// Not a chart layer and not drawn on the map, but it is marine data shown to a
+  /// sailor, so it belongs in the same provenance model: the sheet that says what
+  /// the map is made of should also say where the wind came from.
+  ///
+  /// Continuously updated with no published model run - see
+  /// `marine_forecast.dart` - so freshness is judged on the validity time of each
+  /// forecast rather than on an edition.
+  static const openMeteoForecast = ChartSource(
+    id: 'open-meteo-forecast',
+    displayName: 'Open-Meteo forecast',
+    authority: ChartAuthority.surveyDerived,
+    licence: ChartLicence(
+      name: 'CC BY 4.0 (free endpoint is non-commercial)',
+      attribution: 'Weather data by Open-Meteo.com (CC BY 4.0)',
+      url: 'https://open-meteo.com/en/license',
+      permitsOfflineCache: true,
+    ),
+    continuouslyUpdated: true,
+    coverageNote:
+        'Model output for wind, pressure, visibility and open-water wave. Not a '
+        'weather station reading, and not the sea you will meet in a tide race '
+        'or under a lee shore.',
+  );
+
   /// Release year of the EMODnet product actually served by [bathymetryTiles].
   static final emodnetRelease = DateTime.utc(2024);
 
@@ -156,6 +182,7 @@ abstract final class MarineLayers {
     emodnetBathymetry,
     ukhoWrecks,
     openSeaMapSeamarks,
+    openMeteoForecast,
   ];
 
   /// The sources actually on screen.
@@ -177,6 +204,12 @@ abstract final class MarineLayers {
       reason:
           'Its colour ramp is built for ocean depths, so it renders shelf '
           'water white and adds nothing over a sailing area.',
+    ),
+    UnusedChartSource(
+      source: openMeteoForecast,
+      reason:
+          'Shown in Wind and weather rather than drawn on the chart. Fetched '
+          'when you open it, not continuously.',
     ),
     UnusedChartSource(
       source: ukhoWrecks,

--- a/apps/mobile/test/features/map/marine_forecast_panel_test.dart
+++ b/apps/mobile/test/features/map/marine_forecast_panel_test.dart
@@ -1,0 +1,191 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tide_and_seek/features/map/marine_forecast_panel.dart';
+import 'package:tide_and_seek/services/marine_forecast.dart';
+
+/// #12. The panel's job is to be honest about a number nobody measured: it is all
+/// model output, its run time is not published, and it can be hours old.
+void main() {
+  final now = DateTime.utc(2026, 8, 18, 15, 30);
+
+  MarineForecast forecastAt({
+    Duration age = const Duration(minutes: 15),
+    double? wind = 7.8,
+    double? gust = 16.9,
+    double? direction = 267,
+    double? wave = 0.8,
+    double? visibility = 35660,
+  }) => MarineForecast(
+    latitude: 50.72,
+    longitude: -1.45,
+    validAt: now.subtract(age),
+    fetchedAt: now,
+    windSpeedKnots: wind,
+    windGustKnots: gust,
+    windFromDegrees: direction,
+    pressureHectopascals: 1010.9,
+    visibilityMeters: visibility,
+    temperatureCelsius: 26.2,
+    waveHeightMeters: wave,
+    wavePeriodSeconds: wave == null ? null : 4.1,
+    waveFromDegrees: wave == null ? null : 237,
+  );
+
+  Future<void> pump(
+    WidgetTester tester, {
+    MarineForecast? forecast,
+    ForecastException? failure,
+  }) async {
+    tester.view.physicalSize = const Size(500, 1000);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData.dark(useMaterial3: true),
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: MarineForecastPanel(
+              forecast: forecast,
+              failure: failure,
+              now: now,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  // The two claims this panel must never make.
+  group('honesty about what this is', () {
+    testWidgets('says it is a forecast, not an observation', (tester) async {
+      await pump(tester, forecast: forecastAt());
+      expect(
+        find.byKey(const Key('marine-forecast-not-observed')),
+        findsOneWidget,
+      );
+      expect(find.textContaining('not an observation'), findsOneWidget);
+    });
+
+    testWidgets('says the forecast run is not published', (tester) async {
+      // Checked against the live API: only a validity time is available.
+      await pump(tester, forecast: forecastAt());
+      expect(
+        find.byKey(const Key('marine-forecast-no-run-time')),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('attributes Open-Meteo, as CC BY 4.0 requires', (tester) async {
+      await pump(tester, forecast: forecastAt());
+      expect(find.textContaining('Open-Meteo'), findsOneWidget);
+      expect(find.textContaining('CC BY 4.0'), findsOneWidget);
+    });
+  });
+
+  group('wind', () {
+    testWidgets('reads from a compass point, in knots and Beaufort', (
+      tester,
+    ) async {
+      await pump(tester, forecast: forecastAt());
+      // 267 degrees is a westerly; 7.8 knots is a force 3. Asserted on the wind
+      // line itself, because the wave line also reads "from WSW".
+      final wind = tester.widget<Text>(
+        find.byKey(const Key('marine-forecast-wind')),
+      );
+      expect(wind.data, 'from W · 8 kn · force 3');
+    });
+
+    testWidgets('gusts get their own line', (tester) async {
+      // 18 knots gusting 30 is the difference between a good sail and a reef.
+      await pump(tester, forecast: forecastAt(wind: 18, gust: 30));
+      expect(find.text('gusting 30 kn'), findsOneWidget);
+    });
+
+    testWidgets('a forecast without wind says so', (tester) async {
+      await pump(tester, forecast: forecastAt(wind: null, gust: null));
+      expect(find.byKey(const Key('marine-forecast-no-wind')), findsOneWidget);
+    });
+  });
+
+  group('sea state', () {
+    testWidgets('is labelled as a modelled wave, with its limits', (
+      tester,
+    ) async {
+      await pump(tester, forecast: forecastAt());
+      expect(find.text('FORECAST WAVE'), findsOneWidget);
+      expect(find.textContaining('0.8 m'), findsOneWidget);
+      // The caveat that matters near a lee shore or in a tide race.
+      expect(find.textContaining('tide race'), findsOneWidget);
+    });
+
+    testWidgets('absence is ordinary, not a fault', (tester) async {
+      await pump(tester, forecast: forecastAt(wave: null));
+      expect(
+        find.byKey(const Key('marine-forecast-no-sea-state')),
+        findsOneWidget,
+      );
+      // The wind survives the waves being missing.
+      expect(find.byKey(const Key('marine-forecast-wind')), findsOneWidget);
+    });
+  });
+
+  group('age', () {
+    testWidgets('a recent forecast reports its age plainly', (tester) async {
+      await pump(tester, forecast: forecastAt());
+      expect(find.text('Valid 15 min ago'), findsOneWidget);
+    });
+
+    testWidgets('an old forecast is flagged rather than quietly shown', (
+      tester,
+    ) async {
+      await pump(tester, forecast: forecastAt(age: const Duration(hours: 7)));
+      final age = tester.widget<Text>(
+        find.byKey(const Key('marine-forecast-age')),
+      );
+      expect(age.style?.color, const Color(0xFFE8A33D));
+      expect(age.style?.fontWeight, FontWeight.w700);
+      expect(find.byIcon(Icons.warning_amber_outlined), findsOneWidget);
+    });
+  });
+
+  group('visibility', () {
+    testWidgets('reads in miles offshore and metres in fog', (tester) async {
+      await pump(tester, forecast: forecastAt(visibility: 35660));
+      expect(find.text('19 NM'), findsOneWidget);
+
+      await pump(tester, forecast: forecastAt(visibility: 400));
+      expect(find.text('400 m'), findsOneWidget);
+    });
+  });
+
+  group('no forecast at all', () {
+    testWidgets('an unreachable provider is reported in plain words', (
+      tester,
+    ) async {
+      await pump(
+        tester,
+        failure: const ForecastException(
+          ForecastFailure.unreachable,
+          'SocketException',
+        ),
+      );
+      expect(
+        find.byKey(const Key('marine-forecast-unavailable')),
+        findsOneWidget,
+      );
+      expect(find.textContaining('could not reach'), findsOneWidget);
+      // No figures invented in its place.
+      expect(find.byKey(const Key('marine-forecast-wind')), findsNothing);
+    });
+
+    testWidgets('a refusal says so without blaming the sailor', (tester) async {
+      await pump(
+        tester,
+        failure: const ForecastException(ForecastFailure.refused, '429'),
+      );
+      expect(find.textContaining('declined the request'), findsOneWidget);
+    });
+  });
+}

--- a/apps/mobile/test/services/marine_forecast_test.dart
+++ b/apps/mobile/test/services/marine_forecast_test.dart
@@ -1,0 +1,249 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:tide_and_seek/services/marine_forecast.dart';
+
+/// #12. Fixtures are real Open-Meteo responses captured from the live API, so the
+/// parsing is tested against what the provider actually sends rather than what a
+/// hand-written fixture assumes.
+void main() {
+  final now = DateTime.utc(2026, 8, 18, 15, 30);
+
+  // Captured from api.open-meteo.com for 50.72,-1.45 with wind_speed_unit=kn.
+  const weatherBody =
+      '{"latitude":50.70345,"longitude":-1.4499207,'
+      '"generationtime_ms":0.629,"utc_offset_seconds":0,"timezone":"GMT",'
+      '"current_units":{"time":"iso8601","interval":"seconds",'
+      '"wind_speed_10m":"kn","wind_direction_10m":"°","wind_gusts_10m":"kn",'
+      '"pressure_msl":"hPa","visibility":"m","temperature_2m":"°C"},'
+      '"current":{"time":"2026-08-18T15:15","interval":900,'
+      '"wind_speed_10m":7.8,"wind_direction_10m":267,"wind_gusts_10m":16.9,'
+      '"pressure_msl":1010.9,"visibility":35660.00,"temperature_2m":26.2}}';
+
+  // Captured from marine-api.open-meteo.com for the same position.
+  const marineBody =
+      '{"latitude":50.708336,"longitude":-1.4583282,'
+      '"generationtime_ms":0.285,"utc_offset_seconds":0,"timezone":"GMT",'
+      '"current_units":{"time":"iso8601","interval":"seconds",'
+      '"wave_height":"m","wave_direction":"°","wave_period":"s"},'
+      '"current":{"time":"2026-08-18T15:15","interval":900,'
+      '"wave_height":0.80,"wave_direction":237,"wave_period":4.10}}';
+
+  OpenMeteoForecastService serviceWith(
+    Future<http.Response> Function(http.Request) handler,
+  ) => OpenMeteoForecastService(client: MockClient(handler));
+
+  OpenMeteoForecastService healthyService({List<Uri>? requested}) =>
+      serviceWith((request) async {
+        requested?.add(request.url);
+        return http.Response(
+          request.url.host.startsWith('marine') ? marineBody : weatherBody,
+          200,
+        );
+      });
+
+  group('a healthy forecast', () {
+    test('reads wind, pressure, visibility and sea state', () async {
+      final forecast = await healthyService().fetch(
+        latitude: 50.72,
+        longitude: -1.45,
+        now: now,
+      );
+
+      expect(forecast.windSpeedKnots, 7.8);
+      expect(forecast.windGustKnots, 16.9);
+      expect(forecast.windFromDegrees, 267);
+      expect(forecast.pressureHectopascals, 1010.9);
+      expect(forecast.visibilityMeters, 35660);
+      expect(forecast.temperatureCelsius, 26.2);
+
+      expect(forecast.waveHeightMeters, 0.8);
+      expect(forecast.wavePeriodSeconds, 4.1);
+      expect(forecast.waveFromDegrees, 237);
+      expect(forecast.hasSeaState, isTrue);
+    });
+
+    test('asks for knots at source rather than converting', () async {
+      // A conversion here is a chance to disagree with what the provider meant.
+      final requested = <Uri>[];
+      await healthyService(
+        requested: requested,
+      ).fetch(latitude: 50.72, longitude: -1.45, now: now);
+
+      final weather = requested.firstWhere(
+        (uri) => !uri.host.startsWith('marine'),
+      );
+      expect(weather.queryParameters['wind_speed_unit'], 'kn');
+      expect(weather.queryParameters['timezone'], 'UTC');
+    });
+
+    test(
+      'carries the validity time and its age, not a server timing',
+      () async {
+        final forecast = await healthyService().fetch(
+          latitude: 50.72,
+          longitude: -1.45,
+          now: now,
+        );
+
+        // 15:15 valid, fetched at 15:30.
+        expect(forecast.validAt, DateTime.utc(2026, 8, 18, 15, 15));
+        expect(forecast.ageAt(now), const Duration(minutes: 15));
+        expect(forecast.fetchedAt, now);
+      },
+    );
+
+    test(
+      'a forecast valid slightly ahead of now is not negatively aged',
+      () async {
+        final forecast = await healthyService().fetch(
+          latitude: 50.72,
+          longitude: -1.45,
+          now: DateTime.utc(2026, 8, 18, 15),
+        );
+        expect(forecast.ageAt(DateTime.utc(2026, 8, 18, 15)), Duration.zero);
+      },
+    );
+  });
+
+  group('sea state absent', () {
+    test('an inland position keeps its wind when waves fail', () async {
+      // The marine host has nothing for an inland point. Losing waves must not
+      // lose the wind with them.
+      final forecast = await serviceWith((request) async {
+        if (request.url.host.startsWith('marine')) {
+          return http.Response('{"error":true}', 400);
+        }
+        return http.Response(weatherBody, 200);
+      }).fetch(latitude: 52.2, longitude: -1.5, now: now);
+
+      expect(forecast.hasWind, isTrue);
+      expect(forecast.windSpeedKnots, 7.8);
+      expect(forecast.hasSeaState, isFalse);
+      expect(forecast.waveHeightMeters, isNull);
+    });
+
+    test('a marine host that times out is also survivable', () async {
+      final forecast = await serviceWith((request) async {
+        if (request.url.host.startsWith('marine')) {
+          throw const SocketExceptionStub();
+        }
+        return http.Response(weatherBody, 200);
+      }).fetch(latitude: 50.72, longitude: -1.45, now: now);
+
+      expect(forecast.hasWind, isTrue);
+      expect(forecast.hasSeaState, isFalse);
+    });
+  });
+
+  group('failures say which kind', () {
+    test('an unreachable provider is ordinary, not an error state', () async {
+      // No uptime guarantee on the free tier, and no signal at sea.
+      await expectLater(
+        serviceWith(
+          (_) async => throw const SocketExceptionStub(),
+        ).fetch(latitude: 50.72, longitude: -1.45, now: now),
+        throwsA(
+          isA<ForecastException>()
+              .having((e) => e.failure, 'failure', ForecastFailure.unreachable)
+              .having(
+                (e) => e.sailorMessage,
+                'message',
+                contains('could not reach'),
+              ),
+        ),
+      );
+    });
+
+    test('a rate-limited provider is reported as refused', () async {
+      await expectLater(
+        serviceWith(
+          (_) async => http.Response('slow down', 429),
+        ).fetch(latitude: 50.72, longitude: -1.45, now: now),
+        throwsA(
+          isA<ForecastException>().having(
+            (e) => e.failure,
+            'failure',
+            ForecastFailure.refused,
+          ),
+        ),
+      );
+    });
+
+    test('nonsense is reported as unreadable, not as unreachable', () async {
+      for (final body in ['not json', '[]', '{"current":"nope"}']) {
+        await expectLater(
+          serviceWith(
+            (_) async => http.Response(body, 200),
+          ).fetch(latitude: 50.72, longitude: -1.45, now: now),
+          throwsA(
+            isA<ForecastException>().having(
+              (e) => e.failure,
+              'failure',
+              ForecastFailure.unreadable,
+            ),
+          ),
+          reason: body,
+        );
+      }
+    });
+
+    test('a missing or unparseable valid time is unreadable', () async {
+      await expectLater(
+        serviceWith(
+          (_) async => http.Response('{"current":{"wind_speed_10m":5}}', 200),
+        ).fetch(latitude: 50.72, longitude: -1.45, now: now),
+        throwsA(isA<ForecastException>()),
+      );
+    });
+  });
+
+  group('reading the numbers aloud', () {
+    test('Beaufort force follows the published bounds', () {
+      MarineForecast at(double knots) => MarineForecast(
+        latitude: 50,
+        longitude: -1,
+        validAt: now,
+        fetchedAt: now,
+        windSpeedKnots: knots,
+      );
+
+      // Against the published table: F1 is 1-3 kn, F2 is 4-6, F3 is 7-10,
+      // F4 is 11-16, F5 is 17-21, F6 is 22-27, F8 is 34-40.
+      expect(at(0).beaufortForce, 0, reason: 'calm');
+      expect(at(0.9).beaufortForce, 0);
+      expect(at(1).beaufortForce, 1);
+      expect(at(3).beaufortForce, 1);
+      expect(at(4).beaufortForce, 2);
+      expect(at(10).beaufortForce, 3);
+      expect(at(16).beaufortForce, 4);
+      expect(at(21).beaufortForce, 5);
+      // The one a sailor cares about: 22 knots is a six, reef before it.
+      expect(at(22).beaufortForce, 6);
+      expect(at(40).beaufortForce, 8);
+      expect(at(64).beaufortForce, 12);
+      expect(at(90).beaufortForce, 12);
+    });
+
+    test('a compass point is given for a direction', () {
+      expect(MarineForecast.compassPoint(0), 'N');
+      expect(MarineForecast.compassPoint(90), 'E');
+      expect(MarineForecast.compassPoint(267), 'W');
+      expect(MarineForecast.compassPoint(237), 'WSW');
+      expect(MarineForecast.compassPoint(359), 'N');
+      expect(MarineForecast.compassPoint(null), isNull);
+    });
+
+    test('attribution is present, because CC BY requires it', () {
+      expect(OpenMeteoForecastService.attribution, contains('Open-Meteo'));
+      expect(OpenMeteoForecastService.attribution, contains('CC BY 4.0'));
+    });
+  });
+}
+
+/// A stand-in for a network failure, so the tests do not depend on dart:io.
+class SocketExceptionStub implements Exception {
+  const SocketExceptionStub();
+  @override
+  String toString() => 'SocketExceptionStub';
+}


### PR DESCRIPTION
Closes #12.

## Why

Wind decides whether a passage is pleasant or survivable, and the app had none.

**Open-Meteo**, whose data is **CC BY 4.0** — so caching it and showing it to crew are both permitted with attribution, which is why it fits the same `ChartSource` provenance model the chart layers already use. It now appears in the chart-sources sheet alongside them, marked as *shown in Wind and weather rather than drawn on the chart*.

## Two things I checked against the live API rather than assumed

**There is no forecast run time.** The ticket said to show one — that was wrong. The response carries `generationtime_ms`, which is how long the *server* spent answering, and `current.time`, which is what the values are valid for. The model run behind them is not published. So the panel shows validity time and age, and says plainly that the run is not published, rather than dressing a server timing as provenance.

**"Current" is not an observation.** Open-Meteo's `current` block is model output for the current hour, not a weather-station reading. `PLAN.md` requires observed and forecast to stay distinguishable, and the honest answer is that all of this is forecast. The panel says so once at the top.

The test fixtures are **real responses captured from the live API**, so parsing is tested against what the provider actually sends rather than a hand-written guess.

## What it refuses to do

- Waves come from a **second host**. A position inland, or a marine service that is down, must not take the wind down with it — that failure is swallowed and missing sea state is reported as ordinary.
- Failures are **typed**: `unreachable`, `refused` (the free tier's daily budget), `unreadable` — each with words for the sailor. A free endpoint with no uptime guarantee, read at sea, means no forecast is a normal condition rather than an error state.
- No figures are invented in place of a missing forecast.

## Presentation

Wind reads the way a forecast is read: direction it blows **from** with its compass point, knots and Beaufort together, gusts on their own line — the difference between 18 knots and gusting 30 is the difference between a good sail and a reef. Visibility reads in miles offshore and metres in fog. Modelled wave height carries the caveat that it is not the sea met in a tide race or under a lee shore.

**Beaufort was wrong first time, and so was my test.** Force 1 is 1–3 knots, so three knots is a one, not a two. Both now follow the published table, with the boundaries asserted.

## Verification

- 1,677 tests pass, analyzer clean — 13 on the service, 13 on the panel
- **Service verified against the live API**: I called `api.open-meteo.com` and `marine-api.open-meteo.com` for 50.72,−1.45 and the fixtures are those responses verbatim
- **Not verified on device with live values.** Same limitation as #34: the simulator has no GNSS fix without a started voyage and location permission, so the sheet's "no position, so there is nowhere to forecast for" guard is what I could confirm there. The populated panel rests on widget tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)