### PR TITLE
fix: format the relay so Server CI can go green again (#45)

### DIFF
--- a/apps/server/src/tide_and_seek_server/push.py
+++ b/apps/server/src/tide_and_seek_server/push.py
@@ -20,7 +20,7 @@ from sqlalchemy.orm import Session
 from .config import Settings
 from .crypto import DataCipher, base64url, sha256, token_hash
 from .membership import MembershipEvent, project_membership_events
-from .models import PushDelivery, PushRegistration, Voyage, VoyageMember, StoredEvent
+from .models import PushDelivery, PushRegistration, StoredEvent, Voyage, VoyageMember
 from .schemas import PushRegistrationRequest
 from .service import RelayServiceError
 
@@ -332,7 +332,9 @@ class PushDispatcher:
                 state=row.state,
                 last_seen_at=_as_utc(row.last_seen_at),
             )
-            for row in session.scalars(select(VoyageMember).where(VoyageMember.voyage_id == voyage_id))
+            for row in session.scalars(
+                select(VoyageMember).where(VoyageMember.voyage_id == voyage_id)
+            )
         }
         for membership in result.values():
             if membership.state == "left":
@@ -352,7 +354,9 @@ class PushDispatcher:
         session.execute(delete(VoyageMember).where(VoyageMember.voyage_id == voyage.id))
         events: list[MembershipEvent] = []
         rows = session.scalars(
-            select(StoredEvent).where(StoredEvent.voyage_id == voyage.id).order_by(StoredEvent.sequence)
+            select(StoredEvent)
+            .where(StoredEvent.voyage_id == voyage.id)
+            .order_by(StoredEvent.sequence)
         ).all()
         for row in rows:
             try:

--- a/apps/server/src/tide_and_seek_server/service.py
+++ b/apps/server/src/tide_and_seek_server/service.py
@@ -21,10 +21,10 @@ from .models import (
     IdempotencyReplay,
     ObserverGrant,
     PreStartPosition,
+    StoredEvent,
     Voyage,
     VoyageJoinCode,
     VoyagePlan,
-    StoredEvent,
 )
 from .schemas import PresenceSyncRequest, SyncRequest, SyncResponse
 
@@ -196,7 +196,9 @@ class RelayService:
                 )
                 voyage.last_seen_at = now
                 if voyage.ended_at is None:
-                    voyage.delete_after = now + timedelta(hours=self._settings.voyage_retention_hours)
+                    voyage.delete_after = now + timedelta(
+                        hours=self._settings.voyage_retention_hours
+                    )
                 return response
 
             existing_event_ids = self._validate_event_conflicts(session, voyage_id, events)
@@ -220,7 +222,9 @@ class RelayService:
                 if event.event_type in ("voyageEnded", "voyageReopened")
             ]
             if lifecycle and lifecycle[-1] == "voyageEnded":
-                session.execute(delete(PreStartPosition).where(PreStartPosition.voyage_id == voyage_id))
+                session.execute(
+                    delete(PreStartPosition).where(PreStartPosition.voyage_id == voyage_id)
+                )
             response = self._build_response(
                 session,
                 voyage_id=voyage_id,
@@ -294,7 +298,9 @@ class RelayService:
             phase = self._voyage_presence_phase(session, voyage_id)
             members = self._presence_members(session, voyage_id)
             if phase == "ended":
-                session.execute(delete(PreStartPosition).where(PreStartPosition.voyage_id == voyage_id))
+                session.execute(
+                    delete(PreStartPosition).where(PreStartPosition.voyage_id == voyage_id)
+                )
                 positions: list[dict[str, Any]] = []
             else:
                 existing = session.get(
@@ -675,7 +681,9 @@ class RelayService:
     ) -> None:
         replay_count = (
             session.scalar(
-                select(func.count(IdempotencyReplay.id)).where(IdempotencyReplay.voyage_id == voyage_id)
+                select(func.count(IdempotencyReplay.id)).where(
+                    IdempotencyReplay.voyage_id == voyage_id
+                )
             )
             or 0
         )

--- a/apps/server/tests/test_boundaries.py
+++ b/apps/server/tests/test_boundaries.py
@@ -10,7 +10,7 @@ from sqlalchemy import event as sqlalchemy_event
 from sqlalchemy import func, select
 
 from tide_and_seek_server.app import create_app
-from tide_and_seek_server.models import Voyage, StoredEvent
+from tide_and_seek_server.models import StoredEvent, Voyage
 from tide_and_seek_server.rate_limit import SlidingWindowRateLimiter
 from tide_and_seek_server.service import purge_expired
 

--- a/apps/server/tests/test_join_codes.py
+++ b/apps/server/tests/test_join_codes.py
@@ -131,7 +131,9 @@ def test_voyage_code_registration_requires_matching_credential(client) -> None:
             "inviteSecret": SECRET,
             "resolveToken": RESOLVE_TOKEN,
         },
-        headers={"authorization": f"Bearer {voyage_token('voyage-join-code', 'wrong-secret-value')}"},
+        headers={
+            "authorization": f"Bearer {voyage_token('voyage-join-code', 'wrong-secret-value')}"
+        },
     )
     assert response.status_code == 403
 

--- a/apps/server/tests/test_live_presence.py
+++ b/apps/server/tests/test_live_presence.py
@@ -93,9 +93,12 @@ def _start(client, synchronize, voyage_id: str, device_id: str = "skipper"):
 def test_presence_survives_the_voyage_started_transition(client, synchronize) -> None:
     voyage_id = "voyage-continuity"
     assert (
-        synchronize(client, voyage_id=voyage_id, secret=SECRET, device_id="skipper").status_code == 200
+        synchronize(client, voyage_id=voyage_id, secret=SECRET, device_id="skipper").status_code
+        == 200
     )
-    assert _presence(client, voyage_id, "skipper", position=_position(51.0, name="Lead")).status_code
+    assert _presence(
+        client, voyage_id, "skipper", position=_position(51.0, name="Lead")
+    ).status_code
     before = _presence(client, voyage_id, "sailor-a", position=_position(51.5)).json()
     assert {item["sailorId"] for item in before["positions"]} == {"skipper", "sailor-a"}
     assert before["phase"] == "open"
@@ -114,7 +117,8 @@ def test_a_sailor_joining_an_already_started_voyage_appears_without_a_cursor(
 ) -> None:
     voyage_id = "voyage-late-join"
     assert (
-        synchronize(client, voyage_id=voyage_id, secret=SECRET, device_id="skipper").status_code == 200
+        synchronize(client, voyage_id=voyage_id, secret=SECRET, device_id="skipper").status_code
+        == 200
     )
     assert (
         synchronize(
@@ -140,7 +144,9 @@ def test_a_sailor_joining_an_already_started_voyage_appears_without_a_cursor(
         == 200
     )
     assert (
-        _presence(client, voyage_id, "sailor-late", position=_position(51.9, name="Bill")).status_code
+        _presence(
+            client, voyage_id, "sailor-late", position=_position(51.9, name="Bill")
+        ).status_code
         == 200
     )
 
@@ -157,7 +163,8 @@ def test_a_sailor_joining_an_already_started_voyage_appears_without_a_cursor(
 def test_roster_is_served_even_when_the_event_batch_never_advances(client, synchronize) -> None:
     voyage_id = "voyage-wedged-batch"
     assert (
-        synchronize(client, voyage_id=voyage_id, secret=SECRET, device_id="skipper").status_code == 200
+        synchronize(client, voyage_id=voyage_id, secret=SECRET, device_id="skipper").status_code
+        == 200
     )
     assert (
         synchronize(
@@ -179,7 +186,8 @@ def test_roster_is_served_even_when_the_event_batch_never_advances(client, synch
 def test_sailor_left_marks_the_member_rather_than_hiding_the_history(client, synchronize) -> None:
     voyage_id = "voyage-left"
     assert (
-        synchronize(client, voyage_id=voyage_id, secret=SECRET, device_id="skipper").status_code == 200
+        synchronize(client, voyage_id=voyage_id, secret=SECRET, device_id="skipper").status_code
+        == 200
     )
     assert (
         synchronize(
@@ -216,7 +224,8 @@ def test_sailor_left_marks_the_member_rather_than_hiding_the_history(client, syn
 def test_a_rejoin_clears_the_departure_and_its_time(client, synchronize) -> None:
     voyage_id = "voyage-left-then-back"
     assert (
-        synchronize(client, voyage_id=voyage_id, secret=SECRET, device_id="skipper").status_code == 200
+        synchronize(client, voyage_id=voyage_id, secret=SECRET, device_id="skipper").status_code
+        == 200
     )
     assert (
         synchronize(
@@ -252,7 +261,8 @@ def test_a_rejoin_clears_the_departure_and_its_time(client, synchronize) -> None
 def test_voyage_ended_discards_live_positions(client, synchronize) -> None:
     voyage_id = "voyage-ended-presence"
     assert (
-        synchronize(client, voyage_id=voyage_id, secret=SECRET, device_id="skipper").status_code == 200
+        synchronize(client, voyage_id=voyage_id, secret=SECRET, device_id="skipper").status_code
+        == 200
     )
     assert _presence(client, voyage_id, "sailor-a", position=_position(51.0)).status_code == 200
     assert (
@@ -290,7 +300,8 @@ def test_reopening_a_voyage_restores_its_running_phase(client, synchronize) -> N
     """
     voyage_id = "voyage-reopened-presence"
     assert (
-        synchronize(client, voyage_id=voyage_id, secret=SECRET, device_id="skipper").status_code == 200
+        synchronize(client, voyage_id=voyage_id, secret=SECRET, device_id="skipper").status_code
+        == 200
     )
     for index, event_type in enumerate(("voyageStarted", "voyageEnded", "voyageReopened")):
         assert (
@@ -325,7 +336,8 @@ def test_reopening_a_voyage_restores_its_running_phase(client, synchronize) -> N
 def test_ending_after_a_reopen_ends_the_voyage_again(client, synchronize) -> None:
     voyage_id = "voyage-reended-presence"
     assert (
-        synchronize(client, voyage_id=voyage_id, secret=SECRET, device_id="skipper").status_code == 200
+        synchronize(client, voyage_id=voyage_id, secret=SECRET, device_id="skipper").status_code
+        == 200
     )
     assert _presence(client, voyage_id, "sailor-a", position=_position(51.0)).status_code == 200
     for index, event_type in enumerate(("voyageEnded", "voyageReopened", "voyageEnded")):
@@ -363,11 +375,16 @@ def test_a_legacy_publisher_stays_visible_to_a_live_presence_peer_and_is_flagged
     device is told the peer's build is older."""
     voyage_id = "voyage-mixed-versions"
     assert (
-        synchronize(client, voyage_id=voyage_id, secret=SECRET, device_id="skipper").status_code == 200
+        synchronize(client, voyage_id=voyage_id, secret=SECRET, device_id="skipper").status_code
+        == 200
     )
     assert (
         _presence(
-            client, voyage_id, "sailor-old", capabilities=LEGACY, position=_position(51.3, name="Bill")
+            client,
+            voyage_id,
+            "sailor-old",
+            capabilities=LEGACY,
+            position=_position(51.3, name="Bill"),
         ).status_code
         == 200
     )
@@ -377,7 +394,9 @@ def test_a_legacy_publisher_stays_visible_to_a_live_presence_peer_and_is_flagged
     )
     assert _start(client, synchronize, voyage_id).status_code == 200
 
-    observed = _presence(client, voyage_id, "skipper", position=_position(51.01, name="Lead")).json()
+    observed = _presence(
+        client, voyage_id, "skipper", position=_position(51.01, name="Lead")
+    ).json()
 
     flags = {item["sailorId"]: item["livePresence"] for item in observed["positions"]}
     assert flags["sailor-old"] is False
@@ -389,7 +408,8 @@ def test_a_legacy_reader_after_start_does_not_destroy_a_live_peers_position(
 ) -> None:
     voyage_id = "voyage-legacy-nondestructive"
     assert (
-        synchronize(client, voyage_id=voyage_id, secret=SECRET, device_id="skipper").status_code == 200
+        synchronize(client, voyage_id=voyage_id, secret=SECRET, device_id="skipper").status_code
+        == 200
     )
     assert _presence(client, voyage_id, "sailor-a", position=_position(51.4)).status_code == 200
     assert _start(client, synchronize, voyage_id).status_code == 200
@@ -403,7 +423,8 @@ def test_a_legacy_reader_after_start_does_not_destroy_a_live_peers_position(
 def test_unknown_capability_strings_are_ignored(client, synchronize) -> None:
     voyage_id = "voyage-unknown-capability"
     assert (
-        synchronize(client, voyage_id=voyage_id, secret=SECRET, device_id="skipper").status_code == 200
+        synchronize(client, voyage_id=voyage_id, secret=SECRET, device_id="skipper").status_code
+        == 200
     )
 
     response = _presence(
@@ -421,7 +442,8 @@ def test_unknown_capability_strings_are_ignored(client, synchronize) -> None:
 def test_presence_requires_at_least_one_presence_capability(client, synchronize) -> None:
     voyage_id = "voyage-no-capability"
     assert (
-        synchronize(client, voyage_id=voyage_id, secret=SECRET, device_id="skipper").status_code == 200
+        synchronize(client, voyage_id=voyage_id, secret=SECRET, device_id="skipper").status_code
+        == 200
     )
 
     response = _presence(client, voyage_id, "sailor-a", capabilities=["voyage-start-v1"])
@@ -433,7 +455,8 @@ def test_presence_requires_at_least_one_presence_capability(client, synchronize)
 def test_presence_rejects_a_client_below_the_minimum_protocol(client, synchronize) -> None:
     voyage_id = "voyage-presence-old-client"
     assert (
-        synchronize(client, voyage_id=voyage_id, secret=SECRET, device_id="skipper").status_code == 200
+        synchronize(client, voyage_id=voyage_id, secret=SECRET, device_id="skipper").status_code
+        == 200
     )
     client.app.state.settings.minimum_client_protocol = 2
 
@@ -446,7 +469,8 @@ def test_presence_rejects_a_client_below_the_minimum_protocol(client, synchroniz
 def test_presence_rejects_a_client_newer_than_the_service(client, synchronize) -> None:
     voyage_id = "voyage-presence-new-client"
     assert (
-        synchronize(client, voyage_id=voyage_id, secret=SECRET, device_id="skipper").status_code == 200
+        synchronize(client, voyage_id=voyage_id, secret=SECRET, device_id="skipper").status_code
+        == 200
     )
 
     response = client.post(
@@ -467,7 +491,8 @@ def test_presence_rejects_a_client_newer_than_the_service(client, synchronize) -
 def test_a_started_voyage_still_expires_a_position_by_ttl(client, synchronize) -> None:
     voyage_id = "voyage-started-ttl"
     assert (
-        synchronize(client, voyage_id=voyage_id, secret=SECRET, device_id="skipper").status_code == 200
+        synchronize(client, voyage_id=voyage_id, secret=SECRET, device_id="skipper").status_code
+        == 200
     )
     assert _presence(client, voyage_id, "sailor-a", position=_position(51.0)).status_code == 200
     assert _start(client, synchronize, voyage_id).status_code == 200
@@ -492,7 +517,8 @@ def test_a_started_voyage_still_expires_a_position_by_ttl(client, synchronize) -
 def test_members_are_withheld_from_a_legacy_reader(client, synchronize) -> None:
     voyage_id = "voyage-legacy-members"
     assert (
-        synchronize(client, voyage_id=voyage_id, secret=SECRET, device_id="skipper").status_code == 200
+        synchronize(client, voyage_id=voyage_id, secret=SECRET, device_id="skipper").status_code
+        == 200
     )
     assert (
         synchronize(
@@ -513,7 +539,8 @@ def test_members_are_withheld_from_a_legacy_reader(client, synchronize) -> None:
 def test_a_membership_event_without_a_usable_payload_is_skipped(client, synchronize) -> None:
     voyage_id = "voyage-bad-membership"
     assert (
-        synchronize(client, voyage_id=voyage_id, secret=SECRET, device_id="skipper").status_code == 200
+        synchronize(client, voyage_id=voyage_id, secret=SECRET, device_id="skipper").status_code
+        == 200
     )
     assert (
         synchronize(
@@ -543,7 +570,8 @@ def test_a_membership_event_without_a_usable_payload_is_skipped(client, synchron
 def test_a_repeated_publish_replaces_rather_than_duplicating(client, synchronize) -> None:
     voyage_id = "voyage-duplicate-publish"
     assert (
-        synchronize(client, voyage_id=voyage_id, secret=SECRET, device_id="skipper").status_code == 200
+        synchronize(client, voyage_id=voyage_id, secret=SECRET, device_id="skipper").status_code
+        == 200
     )
     body = _position(51.0)
 
@@ -566,7 +594,8 @@ def test_presence_reports_the_relay_clock_alongside_its_arrival_stamps(client, s
     """
     voyage_id = "voyage-server-time"
     assert (
-        synchronize(client, voyage_id=voyage_id, secret=SECRET, device_id="skipper").status_code == 200
+        synchronize(client, voyage_id=voyage_id, secret=SECRET, device_id="skipper").status_code
+        == 200
     )
     assert _presence(client, voyage_id, "sailor-a", position=_position(51.0)).status_code == 200
 
@@ -586,7 +615,8 @@ def test_presence_serves_a_position_whose_publisher_clock_is_behind(client, sync
     """A phone with a wrong clock still publishes, and is still served."""
     voyage_id = "voyage-skewed-publisher"
     assert (
-        synchronize(client, voyage_id=voyage_id, secret=SECRET, device_id="skipper").status_code == 200
+        synchronize(client, voyage_id=voyage_id, secret=SECRET, device_id="skipper").status_code
+        == 200
     )
     recorded_at = datetime.now(UTC) - timedelta(minutes=4)
 

--- a/apps/server/tests/test_observer_access.py
+++ b/apps/server/tests/test_observer_access.py
@@ -13,7 +13,7 @@ from tide_and_seek_server.models import ObserverGrant
 from tide_and_seek_server.observer import get_managed_observer_grant
 from tide_and_seek_server.service import RelayServiceError
 
-from .conftest import event, voyage_token, sync_request
+from .conftest import event, sync_request, voyage_token
 
 SECRET = "observer-test-secret-0123456789"
 
@@ -586,7 +586,9 @@ def test_concurrent_creation_cannot_exceed_the_voyage_cap(client) -> None:
         )
         assert (
             len(
-                session.scalars(select(ObserverGrant).where(ObserverGrant.voyage_id == voyage_id)).all()
+                session.scalars(
+                    select(ObserverGrant).where(ObserverGrant.voyage_id == voyage_id)
+                ).all()
             )
             == 1
         )

--- a/apps/server/tests/test_push.py
+++ b/apps/server/tests/test_push.py
@@ -5,7 +5,13 @@ from datetime import UTC, datetime, timedelta
 from sqlalchemy import delete, func, select
 
 from tide_and_seek_server.crypto import sha256
-from tide_and_seek_server.models import PushDelivery, PushRegistration, Voyage, VoyageMember, StoredEvent
+from tide_and_seek_server.models import (
+    PushDelivery,
+    PushRegistration,
+    StoredEvent,
+    Voyage,
+    VoyageMember,
+)
 from tide_and_seek_server.push import PushMessage, PushProviderResult
 
 from .conftest import voyage_token
@@ -246,7 +252,9 @@ def test_push_membership_projection_does_not_decrypt_large_event_history(
         payload={"message": "emergencyStop", "label": "Emergency stop"},
     )
 
-    assert synchronize(client, voyage_id=voyage_id, secret=SECRET, events=[alert]).status_code == 200
+    assert (
+        synchronize(client, voyage_id=voyage_id, secret=SECRET, events=[alert]).status_code == 200
+    )
 
     assert counter.event_decryptions == 0
     assert provider.tokens == ["fcm-token-lead-123456789"]
@@ -301,17 +309,23 @@ def test_existing_voyage_backfills_membership_projection_only_once(
         payload={"message": "emergencyStop"},
     )
 
-    assert synchronize(client, voyage_id=voyage_id, secret=SECRET, events=[first]).status_code == 200
+    assert (
+        synchronize(client, voyage_id=voyage_id, secret=SECRET, events=[first]).status_code == 200
+    )
     after_backfill = counter.event_decryptions
     assert after_backfill == 3
-    assert synchronize(client, voyage_id=voyage_id, secret=SECRET, events=[second]).status_code == 200
+    assert (
+        synchronize(client, voyage_id=voyage_id, secret=SECRET, events=[second]).status_code == 200
+    )
     assert counter.event_decryptions == after_backfill
     with client.app.state.session_factory() as session:
         voyage = session.get(Voyage, voyage_id)
         assert voyage is not None and voyage.membership_projection_ready
         assert (
             session.scalar(
-                select(func.count(VoyageMember.device_id)).where(VoyageMember.voyage_id == voyage_id)
+                select(func.count(VoyageMember.device_id)).where(
+                    VoyageMember.voyage_id == voyage_id
+                )
             )
             == 2
         )
@@ -369,7 +383,9 @@ def test_nested_off_course_alert_targets_coordinators_and_affected_sailor(
             }
         },
     )
-    assert synchronize(client, voyage_id=voyage_id, secret=SECRET, events=[alert]).status_code == 200
+    assert (
+        synchronize(client, voyage_id=voyage_id, secret=SECRET, events=[alert]).status_code == 200
+    )
 
     assert set(provider.tokens) == {
         "fcm-token-affected-123456789",

--- a/apps/server/tests/test_sync.py
+++ b/apps/server/tests/test_sync.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime, timedelta
 
 from sqlalchemy import func, select
 
-from tide_and_seek_server.models import IdempotencyReplay, Voyage, StoredEvent
+from tide_and_seek_server.models import IdempotencyReplay, StoredEvent, Voyage
 from tide_and_seek_server.service import purge_expired
 
 from .conftest import voyage_token
@@ -218,7 +218,9 @@ def test_idle_polling_does_not_accumulate_replay_records(client, synchronize) ->
     with factory() as session:
         assert (
             session.scalar(
-                select(func.count(IdempotencyReplay.id)).where(IdempotencyReplay.voyage_id == voyage_id)
+                select(func.count(IdempotencyReplay.id)).where(
+                    IdempotencyReplay.voyage_id == voyage_id
+                )
             )
             == 0
         )
@@ -227,7 +229,10 @@ def test_idle_polling_does_not_accumulate_replay_records(client, synchronize) ->
 def test_conflicting_event_identity_is_rejected_atomically(client, synchronize, make_event) -> None:
     voyage_id = "voyage-conflict"
     original = make_event(voyage_id, "event-1", payload={"value": 1})
-    assert synchronize(client, voyage_id=voyage_id, secret=SECRET, events=[original]).status_code == 200
+    assert (
+        synchronize(client, voyage_id=voyage_id, secret=SECRET, events=[original]).status_code
+        == 200
+    )
 
     conflict = make_event(voyage_id, "event-1", payload={"value": 2})
     response = synchronize(client, voyage_id=voyage_id, secret=SECRET, events=[conflict])

--- a/apps/server/tests/test_tec_role_and_rejoin_sharing.py
+++ b/apps/server/tests/test_tec_role_and_rejoin_sharing.py
@@ -15,7 +15,7 @@ from sqlalchemy import select
 from tide_and_seek_server.models import StoredEvent
 from tide_and_seek_server.service import RelayService
 
-from .conftest import event, voyage_token, sync_request
+from .conftest import event, sync_request, voyage_token
 
 SECRET = "0123456789abcdef0123456789abcdef"
 OBSERVER_SECRET = "observer-rejoin-secret-0123456789"
@@ -142,7 +142,9 @@ def test_new_event_retention_is_capped_tightly(client, synchronize, make_event) 
     with factory() as session:
         stored = {
             row.event_id: row.expires_at.replace(tzinfo=UTC)
-            for row in session.scalars(select(StoredEvent).where(StoredEvent.voyage_id == voyage_id))
+            for row in session.scalars(
+                select(StoredEvent).where(StoredEvent.voyage_id == voyage_id)
+            )
         }
 
     # A sailor's intended path is treated as perishably as where they actually
@@ -193,7 +195,9 @@ def test_a_shared_phone_number_is_accepted_and_capped(client, synchronize, make_
 
     factory = client.app.state.session_factory
     with factory() as session:
-        stored = session.scalars(select(StoredEvent).where(StoredEvent.voyage_id == voyage_id)).one()
+        stored = session.scalars(
+            select(StoredEvent).where(StoredEvent.voyage_id == voyage_id)
+        ).one()
 
     expires_at = stored.expires_at.replace(tzinfo=UTC)
     assert expires_at < before + timedelta(hours=3)


### PR DESCRIPTION
Closes #45.

`Server CI` has been failing on `main` since the rename, and it was lint the whole time — no relay code was broken.

```
uv run ruff format --check .   → 8 files would be reformatted
uv run ruff check .            → 49 errors: 42 × E501, 7 × I001
```

## Why the rename did it

`line-length = 100`, and `tide_and_seek_server` is six characters longer than what it replaced. It appears inside SQLAlchemy call chains that were already sitting near the margin:

```python
for row in session.scalars(select(VoyageMember).where(VoyageMember.voyage_id == voyage_id))
```

104 columns once indented. Forty-two lines crossed over the same way, and the import blocks lost their sort order in the same edit. A rename that touched no logic broke the build.

## Why it was worth stopping for

A permanently-red check is worse than no check. Every PR since #38 has shown a failure with nothing to do with it, so the tick stops being read — and the next real server regression lands underneath it unnoticed.

## The change

`ruff format .` and `ruff check --fix .`, nothing by hand. `git diff -w` shows import re-ordering and nothing else, so no behaviour has moved.

## Verification

The exact CI sequence, run locally:

- `uv run ruff format --check .` — 43 files already formatted
- `uv run ruff check .` — All checks passed
- `uv run ruff format --check ../../tools/discovery ../../tools/tester_notify` — 4 files already formatted
- `uv run ruff check ../../tools/discovery ../../tools/tester_notify` — All checks passed
- `uv run pytest --cov-fail-under=80` — **146 passed**, coverage **85.7%**

## One thing that is not in this PR, because it is not in the repo

`uv run pytest` failed locally with `pyenv: version '3.12' is not installed`, which is a red herring. The real cause was `apps/server/.venv`: its console scripts still had shebangs pointing at `/Users/osholt/Projects/Personal/knot-alone/apps/server/.venv/bin/python`, the directory name from before the rename. That path no longer exists, so the exec fails and the pyenv shim on `PATH` picks up the pieces and blames `.python-version`.

`rm -rf .venv && uv sync` fixes it. Nothing to commit — but anyone who renamed their checkout rather than re-cloning will hit the same misleading error, so it is written down here.