### PR TITLE
feat: chart beside the detail on a tablet in landscape (#47)

### DIFF
--- a/apps/mobile/lib/features/map/route_review_screen.dart
+++ b/apps/mobile/lib/features/map/route_review_screen.dart
@@ -14,6 +14,7 @@ import '../../services/route_reshape_planner.dart';
 import '../../services/route_waypoint_editor.dart';
 import 'maneuver_list_screen.dart';
 import 'resolved_route_map_preview.dart';
+import 'voyage_layout.dart';
 import '../../services/passage_legs.dart';
 import 'passage_leg_table.dart';
 
@@ -565,6 +566,7 @@ class _RouteReviewScreenState extends State<RouteReviewScreen> {
       ?materialWarning,
     ];
     final formatter = MeasurementFormatter(distanceUnit);
+    final layout = VoyageLayout.of(context);
     final maneuverCount = const NavigationGuidancePlanner()
         .instructions(route)
         .length;
@@ -598,11 +600,24 @@ class _RouteReviewScreenState extends State<RouteReviewScreen> {
         ],
       ),
       body: SafeArea(
-        child: Column(
+        // Chart above detail on a phone; chart beside detail on a tablet in
+        // landscape. Both panes are already flexible, so the only thing that
+        // changes is which way the box runs.
+        //
+        // The condition is `canHostSidePanel` rather than `isLandscape`: a
+        // phone on its side is the case with the *least* vertical room, and
+        // splitting it into two columns would leave the leg table four rows
+        // tall. A tablet in portrait is left alone too - it is tall, not wide.
+        child: Flex(
+          direction: layout.canHostSidePanel ? Axis.horizontal : Axis.vertical,
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             Expanded(
-              flex: 5,
+              // Stacked, the detail gets the larger share because it holds the
+              // legs, the marks and the confirm button. Side by side, the chart
+              // takes it back: a wide text column is harder to read, not
+              // easier, and the chart is what the decision is made on.
+              flex: layout.canHostSidePanel ? 6 : 5,
               child: ColoredBox(
                 color: const Color(0xFF111720),
                 child: allPoints.isEmpty
@@ -799,7 +814,7 @@ class _RouteReviewScreenState extends State<RouteReviewScreen> {
               ),
             ),
             Expanded(
-              flex: 6,
+              flex: layout.canHostSidePanel ? 5 : 6,
               child: ListView(
                 // Keyed so tests can scroll *this* list rather than picking a
                 // Scrollable by position. The map and the leg table bring their

--- a/apps/mobile/test/features/map/route_review_screen_test.dart
+++ b/apps/mobile/test/features/map/route_review_screen_test.dart
@@ -718,6 +718,97 @@ void main() {
     expect(find.byKey(const Key('maneuver-list')), findsOneWidget);
     expect(find.text('2nd exit, straight on'), findsOneWidget);
   });
+
+  group('side by side on a tablet (#47)', () {
+    // Real device point sizes, so a breakpoint that drifts onto one of them
+    // fails here rather than on a boat.
+    const iPadLandscape = Size(1366, 1024);
+    const iPadPortrait = Size(1024, 1366);
+    const phonePortrait = Size(390, 844);
+    const phoneLandscape = Size(844, 390);
+
+    Future<void> pumpAt(WidgetTester tester, Size size) async {
+      tester.view.physicalSize = size;
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: RouteReviewScreen(
+            route: _passage(),
+            distanceUnit: DistanceUnit.nauticalMiles,
+            basemapConfiguration: const BasemapConfiguration(),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    /// The chart pane and the detail list, as laid out.
+    (Rect chart, Rect detail) panes(WidgetTester tester) => (
+      tester.getRect(find.byKey(const Key('route-review-map'))),
+      tester.getRect(find.byKey(const Key('route-review-detail'))),
+    );
+
+    testWidgets('an iPad in landscape puts the chart beside the detail', (
+      tester,
+    ) async {
+      await pumpAt(tester, iPadLandscape);
+      final (chart, detail) = panes(tester);
+
+      expect(
+        chart.right,
+        lessThanOrEqualTo(detail.left),
+        reason: 'the chart should be left of the detail, not above it',
+      );
+      // Both full height, which is the whole point: neither pane is squeezed
+      // into half a screen when the screen is 1024pt tall.
+      expect(chart.height, greaterThan(900));
+      expect(detail.height, greaterThan(900));
+      expect(
+        chart.width,
+        greaterThan(detail.width),
+        reason: 'the chart is what the decision is made on',
+      );
+    });
+
+    testWidgets('an iPad in portrait keeps the chart above the detail', (
+      tester,
+    ) async {
+      await pumpAt(tester, iPadPortrait);
+      final (chart, detail) = panes(tester);
+      expect(chart.bottom, lessThanOrEqualTo(detail.top));
+    });
+
+    testWidgets('a phone stacks in both orientations', (tester) async {
+      await pumpAt(tester, phonePortrait);
+      var (chart, detail) = panes(tester);
+      expect(chart.bottom, lessThanOrEqualTo(detail.top));
+
+      // Landscape on a phone is the case with the least vertical room of all.
+      // Splitting it into two columns would leave the leg table a few rows
+      // tall, so it stacks like everything else.
+      await pumpAt(tester, phoneLandscape);
+      (chart, detail) = panes(tester);
+      expect(chart.bottom, lessThanOrEqualTo(detail.top));
+    });
+
+    testWidgets('the legs and the marks are both reachable on a tablet', (
+      tester,
+    ) async {
+      await pumpAt(tester, iPadLandscape);
+      expect(
+        find.byKey(const Key('route-review-legs-section')),
+        findsOneWidget,
+      );
+      // 1024pt of detail column is enough for the summary, the legs and the
+      // marks without the chart scrolling away, which is what stacking cost.
+      expect(
+        find.byKey(const Key('route-review-points-section')),
+        findsOneWidget,
+      );
+    });
+  });
 }
 
 ImportedRoute _route(double longitudeDelta) => ImportedRoute(


### PR DESCRIPTION
Closes #47. Part of #28 and #32.

## The change

`RouteReviewScreen` was a `Column`: chart on top, scrolling detail below, on every device. On a 1366×1024 iPad that produced a 1366-wide chart 465pt tall above a 1366-wide text column — the one screen with room to spare, used as if it were a phone.

Both panes were already `Expanded`, so this is a `Column` becoming a direction-aware `Flex`. #32 asked for exactly this and named the helper; `VoyageLayout.canHostSidePanel` already existed and nothing here called it.

## Why `canHostSidePanel` and not `isLandscape`

A phone on its side is landscape, and it is the orientation with the *least* vertical room of any. Splitting it into two columns would leave the leg table about four rows tall. That confusion — treating "landscape" as "has room" — is the exact mistake `VoyageLayout` was written to stop, so this uses the predicate that means what it says. A tablet in portrait is left alone as well: it is tall, not wide.

## The flex ratio flips

Stacked, the detail pane gets the larger share — it carries the summary, the legs, the marks and the confirm button. Side by side the chart takes it back. A very wide text column is harder to read rather than easier, and the chart is the thing the confirm decision is actually made on.

## Why this is more than tidying

Since the leg table landed (#36) it sits between the summary and the marks list, far enough down the lazily built detail list that the marks are not constructed at all until scrolled to — the #43 widget tests had to scroll to reach them.

That order is correct: a passage is reviewed on its courses before its names. But the consequence was that a sailor comparing *"what course is leg 3"* against *"which mark is that"* could not see both at once on any device, including the one where both fit with room over. On a tablet they now do.

## Verification

- `flutter analyze` clean
- `flutter test` — **1,697 pass**, 24 skipped
- 4 new widget tests, at real device point sizes rather than round numbers, so a breakpoint drifting onto a real device fails here rather than on a boat:
  - 1366×1024 — chart left of detail, both over 900pt tall, chart wider
  - 1024×1366 — still stacked
  - 390×844 and 844×390 — still stacked in both orientations
  - legs and marks sections both present on the tablet

## Still open on #32

Dragging a mark to move it, reordering legs, and tapping a leg row to centre the chart on it.

The drag is not a one-liner and is worth saying why: the MapLibre pins are native annotations rather than Flutter widgets, so a per-pin gesture detector is not available, and the existing full-screen gesture surface would have to claim the pan — which is how you find where to put the next mark. Two taps (select a mark, tap where it goes) may well be the better gesture on a wet moving boat anyway. That deserves its own ticket and its own decision rather than being smuggled in here.