### PR TITLE
fix: the skipper is called the skipper (#49)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -13,18 +13,27 @@ Initial users: UK coastal yacht sailors, primarily solo or small crews
 ## Where this actually is
 
 The requirements below describe the product. This section describes the build, so
-the two are not confused. Written 18 August 2026.
+the two are not confused. Written 18 August 2026, updated 19 August 2026.
 
 ### Working
 
 Inherited from Tail End Charlie and carried across intact: the live group map,
 six-digit voyage codes and QR join, roster and roles, SOS and quick messages, GPX
 import and export, offline tile caching, the local voyage journal, recap, and the
-simulator. Roughly 1,580 tests.
+simulator. Roughly 1,700 tests.
 
 Done since the rename: the road features stripped, the full domain rename, vessel
 icons and the marine glyph set, chart-provenance UI, size-driven layout for iPad,
 and passage legs that are no longer road routes.
+
+Done since: a passage leg table in nautical units, marks placed and named on the
+chart, navigation instruments that degrade with fix age, Open-Meteo wind and sea
+state, a Solent demo passage, and the chart sitting beside the detail on a tablet
+in landscape.
+
+**Build 22 (1.0.1) is on TestFlight**, internal testing only. That is the first
+time any of this has been on a device that is not a simulator, and it immediately
+found user-visible road vocabulary the earlier passes missed (#49).
 
 ### Not started
 
@@ -38,18 +47,28 @@ app's own name.
 |---|---|---|
 | Charts | A road basemap with an OpenSeaMap seamark overlay painted on. No depth, no soundings, no contours. | #17, #6 |
 | Depth shading | Blocked on whether UKHO's "not for use in the creation of navigational products" clause governs its free data | #29 |
-| Passage planning | Rhumb-line legs between waypoints. No land avoidance, no tidal gates, no waypoint editor on the chart | #8 |
+| Passage planning | Rhumb-line legs with a leg table; marks can be placed, named and removed on the chart. No land avoidance, no tidal gates, no drag-to-move, no leg reordering | #8, #32 |
 | Tides | Nothing | #11 |
-| Weather | Nothing | #12 |
+| Weather | Open-Meteo wind, gusts, pressure, visibility and open-water wave, labelled a forecast rather than an observation. No GRIB, no routing | #12 |
+| Instruments | COG, SOG, XTE, bearing and distance to the active mark, all dimming together once the fix is stale. Never verified against a real GNSS fix | #34 |
+| Onboarding | Sells crew coordination first on a solo-first app, and its crew-facing name field cannot be skipped | #49 |
 | Safety gates | No at-sea testing has happened at all | #10 |
 | Road leftovers | OSRM/Valhalla engines unreachable but present; road-only route preferences still in the UI | #31 |
 
 ### The honest summary
 
-This is a **crew-coordination app that speaks marine**, not a boating app. The
-coordination half is real and tested. The sailing half is a seamark overlay and a
-provenance sheet. Nothing here should be relied on at sea, and #10 exists because
-none of it has been near water.
+This is a **crew-coordination app that speaks marine**, and it has started to
+grow a boating app inside it. The coordination half is real and tested. The
+sailing half is now a passage you can plan, tabulate and steer to, with wind and
+sea state beside it - on top of a road basemap with a seamark overlay, and with
+no tide, no depth and no chart.
+
+Tide is the gap that matters most for UK coastal sailing, and it is the one
+gated on a licence question nobody has answered (#29). Until then a passage this
+app plans is a passage in still water.
+
+Nothing here should be relied on at sea. #10 exists because none of it has been
+near water, and being on TestFlight does not change that.
 
 ## Problem statement
 
@@ -343,11 +362,14 @@ The first phase that adds sailing capability rather than removing road
 assumptions. Tides before weather: for UK coastal sailing the tide decides
 whether the passage works at all, and the data is more tractable.
 
+- [x] Weather and wind from Open-Meteo, with forecast run time and age — #12
+- [x] Navigation instruments: COG, SOG, XTE, fix age — #34 *(never seen a real fix)*
 - [ ] Waypoint editing on the chart, with a leg table: course, distance, ETA — #32
+      *(leg table, mark placing, naming and removal done; drag-to-move, leg
+      reordering and tap-a-leg-to-centre remain)*
 - [ ] Tidal heights and curves from the UKHO Tidal API, with provenance — #11
-- [ ] Tidal windows and gates, built on the heights — #33
-- [ ] Weather and wind from Open-Meteo, with forecast run time and age — #12
-- [ ] Navigation instruments: COG, SOG, XTE, VMG, fix age — #34
+      *(parked: the licence question, #29)*
+- [ ] Tidal windows and gates, built on the heights — #33 *(parked behind #11)*
 
 ### Phase 4 — Trustworthy offline
 
@@ -356,6 +378,18 @@ Making the above survive losing signal, which is the normal condition at sea.
 - [ ] Offline passage packs: chart corridor, tides, forecast, verified — #13
 - [ ] Coastal depth, if the licence permits — #29
 - [ ] Crew sharing hardened: per-device authority, encrypted payloads — #14, #25
+
+### Phase 4a — What TestFlight found
+
+Not planned; discovered by putting build 22 on a device. Kept as its own group
+because "we shipped it and then looked at it" is a different kind of work from
+the phases around it, and there will be more of it after every build.
+
+- [ ] Crew roles and onboarding copy still speak road, and onboarding is
+      crew-first on a solo-first app — #49
+- [ ] Associated Domains points at a placeholder that can never resolve — #40
+- [ ] The iOS launch image is still the Flutter placeholder — #41
+- [ ] Release builds are hand-assembled and not reproducible — #42
 
 ### Phase 5 — Evidence before anyone sails with it
 

--- a/apps/mobile/integration_test/voyage_end_profile_test.dart
+++ b/apps/mobile/integration_test/voyage_end_profile_test.dart
@@ -53,7 +53,7 @@ void main() {
     joinToken: 'profile-token',
     localSailorId: 'sailor-0',
     displayName: 'Oliver',
-    role: VoyageRole.lead,
+    role: VoyageRole.skipper,
     joinedAt: DateTime.utc(2026, 7, 27, 9),
   );
 
@@ -257,7 +257,7 @@ List<VoyageEvent> _journal(
       deviceId: session.localSailorId,
       type: VoyageEventType.voyageCreated,
       createdAt: session.joinedAt,
-      payload: {'role': VoyageRole.lead.name, 'displayName': 'Oliver'},
+      payload: {'role': VoyageRole.skipper.name, 'displayName': 'Oliver'},
     ),
     for (var sailor = 1; sailor < _sailorsInGroup; sailor += 1)
       _signed(
@@ -299,7 +299,7 @@ List<VoyageEvent> _journal(
             'location': SailorLocation(
               sailorId: 'sailor-$sailor',
               displayName: sailor == 0 ? 'Oliver' : 'Sailor $sailor',
-              role: sailor == 0 ? VoyageRole.lead : VoyageRole.sailor,
+              role: sailor == 0 ? VoyageRole.skipper : VoyageRole.sailor,
               sample: LocationSample(
                 position: sample_geo.GeoPoint(
                   latitude: latitude,

--- a/apps/mobile/lib/controllers/pre_start_presence_controller.dart
+++ b/apps/mobile/lib/controllers/pre_start_presence_controller.dart
@@ -445,13 +445,10 @@ class PreStartPresenceController extends ChangeNotifier {
     return PresenceAvailability.serviceUnreachable;
   }
 
-  static VoyageRole _roleFor(String value) {
-    for (final role in VoyageRole.values) {
-      if (role.name == value) return role;
-    }
-    // An unknown future role must not drop the sailor from the roster.
-    return VoyageRole.sailor;
-  }
+  static VoyageRole _roleFor(String value) =>
+      // An unknown future role must not drop the sailor from the roster, and a
+      // role written by a pre-#49 build still reads as the skipper.
+      VoyageRoleWire.tryParse(value) ?? VoyageRole.sailor;
 
   static int _byJoinedAt(
     PresenceRosterMember left,

--- a/apps/mobile/lib/controllers/situational_awareness_controller.dart
+++ b/apps/mobile/lib/controllers/situational_awareness_controller.dart
@@ -384,7 +384,7 @@ class SituationalAwarenessController extends ChangeNotifier {
   };
 
   void _evaluateLocation(SailorLocation location) {
-    if (location.role == VoyageRole.lead) {
+    if (location.role == VoyageRole.skipper) {
       _recordSkipperTrailPoint(location.sample);
     }
     // Per-role, and re-applied on every fix so a hand-over mid-voyage moves both
@@ -522,7 +522,7 @@ class SituationalAwarenessController extends ChangeNotifier {
     // The skipper is always the end of their own trail, so exempting them says
     // nothing; leave their verdict to the geometry.
     final exempt =
-        location.role != VoyageRole.lead &&
+        location.role != VoyageRole.skipper &&
         SkipperTrackExemption.isFollowingSkipperTrack(
           position: location.sample.position,
           accuracyMeters: location.sample.accuracyMeters,

--- a/apps/mobile/lib/controllers/voyage_controller.dart
+++ b/apps/mobile/lib/controllers/voyage_controller.dart
@@ -209,7 +209,7 @@ class VoyageController extends ChangeNotifier {
 
   bool get voyageStarted => _lifecycle.started;
   DateTime? get voyageStartedAt => _lifecycle.startedAt;
-  bool get isLocalVoyageSkipper => _session?.role == VoyageRole.lead;
+  bool get isLocalVoyageSkipper => _session?.role == VoyageRole.skipper;
   VoyagePhase get voyagePhase => voyageEnded
       ? VoyagePhase.ended
       : voyageStarted
@@ -745,7 +745,7 @@ class VoyageController extends ChangeNotifier {
     final activeSession = _requireSession();
     if (activeSession.isSimulation ||
         activeSession.coordinationMode == VoyageCoordinationMode.solo ||
-        activeSession.role != VoyageRole.lead) {
+        activeSession.role != VoyageRole.skipper) {
       return;
     }
     var session = activeSession;
@@ -879,7 +879,7 @@ class VoyageController extends ChangeNotifier {
         type: VoyageEventType.sailorJoined,
         payload: {
           'displayName': session.displayName,
-          'role': session.role.name,
+          'role': session.role.wireName,
           'vesselStyle': session.sailorSymbol.wireValue(session.vesselStyle),
           'sailorColor': session.sailorColor.name,
         },
@@ -895,7 +895,7 @@ class VoyageController extends ChangeNotifier {
       await _sessionStore.save(updated);
       await _record(
         type: VoyageEventType.roleChanged,
-        payload: {'role': role.name},
+        payload: {'role': role.wireName},
       );
     });
   }
@@ -930,13 +930,13 @@ class VoyageController extends ChangeNotifier {
     return sweeperRoleAssignments.pendingFor(localSailorId);
   }
 
-  /// The sailor currently holding [VoyageRole.lead] in the reconciled roster.
+  /// The sailor currently holding [VoyageRole.skipper] in the reconciled roster.
   ///
   /// Used to address a skipper-only event. Null when the skipper has left or is
   /// not yet known, in which case the caller must not send rather than
   /// broadcasting to the group.
   String? get skipperSailorId => liveParticipants
-      .where((participant) => participant.role == VoyageRole.lead)
+      .where((participant) => participant.role == VoyageRole.skipper)
       .map((participant) => participant.sailorId)
       .firstOrNull;
 
@@ -1278,7 +1278,7 @@ class VoyageController extends ChangeNotifier {
     if (voyageStarted || voyageEnded) return;
     await _run(() async {
       final session = _requireSession();
-      if (session.role != VoyageRole.lead) {
+      if (session.role != VoyageRole.skipper) {
         throw const FormatException(
           'Only the voyage skipper can start the voyage.',
         );
@@ -1361,7 +1361,7 @@ class VoyageController extends ChangeNotifier {
       if (!voyageStarted) {
         throw const FormatException('Start the voyage before pausing it.');
       }
-      if (session.role != VoyageRole.lead) {
+      if (session.role != VoyageRole.skipper) {
         throw const FormatException(
           'Only the voyage skipper can pause the group.',
         );
@@ -1413,7 +1413,7 @@ class VoyageController extends ChangeNotifier {
     if (activeSession == null || !voyageEnded) {
       return VoyageReopenOutcome.notEnded;
     }
-    if (activeSession.role != VoyageRole.lead) {
+    if (activeSession.role != VoyageRole.skipper) {
       return VoyageReopenOutcome.notSkipper;
     }
     final endedAt = _voyageEndedAt;
@@ -1557,7 +1557,7 @@ class VoyageController extends ChangeNotifier {
       joinToken: _generateJoinToken(),
       localSailorId: _localSailorIdForVoyage(voyageId),
       displayName: normalisedDisplayName,
-      role: VoyageRole.lead,
+      role: VoyageRole.skipper,
       joinedAt: now,
       isSimulation: isSimulation,
       simulationSailorCount: simulationSailorCount,
@@ -1575,7 +1575,7 @@ class VoyageController extends ChangeNotifier {
       type: VoyageEventType.voyageCreated,
       payload: {
         'displayName': session.displayName,
-        'role': session.role.name,
+        'role': session.role.wireName,
         if (isSimulation) 'simulation': true,
         'vesselStyle': session.sailorSymbol.wireValue(session.vesselStyle),
         'sailorColor': session.sailorColor.name,

--- a/apps/mobile/lib/controllers/voyage_simulation_controller.dart
+++ b/apps/mobile/lib/controllers/voyage_simulation_controller.dart
@@ -282,9 +282,9 @@ class VoyageSimulationController extends ChangeNotifier {
         id: 'voyage-lab-maya',
         displayName: 'Maya',
         index: 1,
-        role: _selectedLocalRole == VoyageRole.lead
+        role: _selectedLocalRole == VoyageRole.skipper
             ? VoyageRole.sailor
-            : VoyageRole.lead,
+            : VoyageRole.skipper,
       ),
       sailor(
         id: offRouteSailorId,
@@ -330,7 +330,7 @@ class VoyageSimulationController extends ChangeNotifier {
   }
 
   List<GeoPoint> _displayTrailFor(_SimulatedAgent agent) {
-    if (agent.role != VoyageRole.lead) return agent.travelTrail;
+    if (agent.role != VoyageRole.skipper) return agent.travelTrail;
     final sweeper = _agent(sweeperSailorId);
     final routeTrail = _routeSampler.pointsBetween(
       math.min(sweeper.progressMeters, agent.progressMeters),
@@ -779,8 +779,8 @@ class VoyageSimulationController extends ChangeNotifier {
       agent.role = VoyageRole.sailor;
     }
     _agents.first.role = _selectedLocalRole;
-    if (_selectedLocalRole != VoyageRole.lead) {
-      _agent('voyage-lab-maya').role = VoyageRole.lead;
+    if (_selectedLocalRole != VoyageRole.skipper) {
+      _agent('voyage-lab-maya').role = VoyageRole.skipper;
     }
     if (_selectedLocalRole != VoyageRole.sweeper) {
       _agent(sweeperSailorId).role = VoyageRole.sweeper;
@@ -799,7 +799,7 @@ class VoyageSimulationController extends ChangeNotifier {
           (_activeMarkerSailorId == null && agent.isLocal));
 
   _SimulatedAgent _leadAgent() => _agents.firstWhere(
-    (agent) => agent.role == VoyageRole.lead,
+    (agent) => agent.role == VoyageRole.skipper,
     orElse: () => _agents.first,
   );
 
@@ -827,7 +827,7 @@ class VoyageSimulationController extends ChangeNotifier {
   String get _markerSailorPresentVerb => automaticMarkerIsLocal ? 'are' : 'is';
 
   String get _localPerspectiveName => switch (_selectedLocalRole) {
-    VoyageRole.lead => _session.displayName,
+    VoyageRole.skipper => _session.displayName,
     VoyageRole.sailor => 'You · Follower',
     VoyageRole.sweeper => 'You · TEC',
     VoyageRole.marker => 'You · Marker',

--- a/apps/mobile/lib/domain/completed_voyage.dart
+++ b/apps/mobile/lib/domain/completed_voyage.dart
@@ -117,7 +117,7 @@ class CompletedVoyage {
       voyageCode: json['voyageCode']! as String,
       voyageName: json['voyageName'] as String?,
       localDisplayName: json['localDisplayName']! as String,
-      localRole: VoyageRole.values.byName(json['localRole']! as String),
+      localRole: VoyageRoleWire.parse(json['localRole']! as String),
       startedAt: DateTime.parse(json['startedAt']! as String).toUtc(),
       endedAt: DateTime.parse(json['endedAt']! as String).toUtc(),
       archivedAt: DateTime.parse(json['archivedAt']! as String).toUtc(),

--- a/apps/mobile/lib/domain/sailor_location.dart
+++ b/apps/mobile/lib/domain/sailor_location.dart
@@ -73,7 +73,7 @@ class SailorLocation {
   Map<String, Object?> toJson() => {
     'sailorId': sailorId,
     'displayName': displayName,
-    'role': role.name,
+    'role': role.wireName,
     'sample': sample.toJson(),
     'receivedAt': receivedAt.toUtc().toIso8601String(),
     'vesselStyle': sailorSymbol.wireValue(vesselStyle),
@@ -83,7 +83,7 @@ class SailorLocation {
   factory SailorLocation.fromJson(Map<String, Object?> json) => SailorLocation(
     sailorId: json['sailorId']! as String,
     displayName: json['displayName']! as String,
-    role: VoyageRole.values.byName(json['role']! as String),
+    role: VoyageRoleWire.parse(json['role']! as String),
     sample: LocationSample.fromJson(
       Map<String, Object?>.from(json['sample']! as Map),
     ),

--- a/apps/mobile/lib/domain/voyage_role.dart
+++ b/apps/mobile/lib/domain/voyage_role.dart
@@ -1,10 +1,49 @@
-enum VoyageRole { lead, sailor, sweeper, marker }
+/// Who someone is on a passage.
+///
+/// [skipper] was `lead` until #49. "Lead" is the road group-riding role this app
+/// was scaffolded from; on a boat the word is skipper, and it is not a synonym -
+/// it names the person with responsibility for the vessel, which is exactly what
+/// this role carries. The marine glyph set drawn for #30 already said Skipper,
+/// so the icon and the role beside it disagreed on screen.
+enum VoyageRole { skipper, sailor, sweeper, marker }
 
 extension VoyageRoleLabel on VoyageRole {
   String get label => switch (this) {
-    VoyageRole.lead => 'Lead',
+    VoyageRole.skipper => 'Skipper',
     VoyageRole.sailor => 'Sailor',
     VoyageRole.sweeper => 'Sweeper',
     VoyageRole.marker => 'Marker',
   };
+}
+
+/// How a role crosses a wire or a restart.
+///
+/// Separate from `.name` on purpose. Roles are written into saved sessions,
+/// completed voyages, relay payloads and push registrations, and the old builds
+/// that wrote them spelled this role `lead`. `VoyageRole.values.byName('lead')`
+/// throws, and the place it throws is session restore - which surfaces as
+/// "Could not restore your saved voyage" and loses the passage.
+///
+/// So the wire name is stated rather than derived, and parsing accepts what
+/// earlier builds wrote. New payloads say `skipper`; anything that still says
+/// `lead` is read as one.
+extension VoyageRoleWire on VoyageRole {
+  /// The value written to storage and to the relay.
+  String get wireName => name;
+
+  /// Reads a stored or received role, tolerating the pre-#49 spelling.
+  ///
+  /// Returns null rather than throwing for anything unrecognised, so a payload
+  /// from a newer build with a role this one does not know degrades to "no role
+  /// stated" instead of taking the voyage down with it.
+  static VoyageRole? tryParse(String? value) => switch (value) {
+    null => null,
+    'lead' => VoyageRole.skipper,
+    _ => VoyageRole.values.where((role) => role.name == value).firstOrNull,
+  };
+
+  /// Reads a role that must be present, with the same tolerance as [tryParse].
+  static VoyageRole parse(String value) =>
+      tryParse(value) ??
+      (throw FormatException('Unknown voyage role: $value', value));
 }

--- a/apps/mobile/lib/domain/voyage_session.dart
+++ b/apps/mobile/lib/domain/voyage_session.dart
@@ -88,7 +88,7 @@ class VoyageSession {
     'joinToken': joinToken,
     'localSailorId': localSailorId,
     'displayName': displayName,
-    'role': role.name,
+    'role': role.wireName,
     'joinedAt': joinedAt.toUtc().toIso8601String(),
     if (isSimulation) 'isSimulation': true,
     if (isSimulation) 'simulationSailorCount': simulationSailorCount,
@@ -106,7 +106,7 @@ class VoyageSession {
     joinToken: _joinTokenOrFallback(json['joinToken']),
     localSailorId: json['localSailorId']! as String,
     displayName: json['displayName']! as String,
-    role: VoyageRole.values.byName(json['role']! as String),
+    role: VoyageRoleWire.parse(json['role']! as String),
     joinedAt: DateTime.parse(json['joinedAt']! as String).toLocal(),
     isSimulation: json['isSimulation'] as bool? ?? false,
     simulationSailorCount: _simulationSailorCount(

--- a/apps/mobile/lib/features/map/voyage_map_feature.dart
+++ b/apps/mobile/lib/features/map/voyage_map_feature.dart
@@ -5729,7 +5729,7 @@ class MapEmergencyContact {
   bool get hasPhoneNumber => (phoneNumber ?? '').isNotEmpty;
 
   String get shortRoleLabel => switch (role) {
-    VoyageRole.lead => 'the skipper',
+    VoyageRole.skipper => 'the skipper',
     VoyageRole.sweeper => 'the sweeper',
     _ => displayName,
   };
@@ -5737,7 +5737,7 @@ class MapEmergencyContact {
   /// "Oliver (skipper)". Used at the point of dialling, where the sailor needs to
   /// know both who and which role.
   String get roleQualifiedName => switch (role) {
-    VoyageRole.lead => '$displayName (skipper)',
+    VoyageRole.skipper => '$displayName (skipper)',
     VoyageRole.sweeper => '$displayName (sweeper)',
     _ => displayName,
   };

--- a/apps/mobile/lib/features/onboarding/onboarding_screen.dart
+++ b/apps/mobile/lib/features/onboarding/onboarding_screen.dart
@@ -113,7 +113,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
       const SizedBox(height: 16),
       const Text(
         'Tide and Seek coordinates a private crew with a shared '
-        'roster, route and safety alerts. Voyage events are kept on your phone '
+        'roster, route and safety alerts. Voyage events are kept on this device '
         'first, then relayed by the internet or nearby devices when available.',
         style: TextStyle(color: Color(0xFFBCC5D0), height: 1.5, fontSize: 17),
       ),
@@ -127,7 +127,8 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
       const _InfoCard(
         icon: Icon(Icons.cloud_off_outlined),
         title: 'Designed for patchy coverage',
-        body: 'Losing a relay does not erase the voyage journal on your phone.',
+        body:
+            'Losing a relay does not erase the voyage journal on this device.',
       ),
     ],
   );
@@ -258,7 +259,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
       const SizedBox(height: 14),
       const _InfoCard(
         icon: MarineGlyphIcon(MarineGlyph.skipper),
-        title: 'Lead',
+        title: 'Skipper',
         body:
             'Creates the private code, publishes the group route, starts, pauses and ends the voyage.',
       ),

--- a/apps/mobile/lib/features/simulation/voyage_simulation_screen.dart
+++ b/apps/mobile/lib/features/simulation/voyage_simulation_screen.dart
@@ -181,7 +181,7 @@ class _SimulationControls extends StatelessWidget {
               showSelectedIcon: false,
               segments: const [
                 ButtonSegment(
-                  value: VoyageRole.lead,
+                  value: VoyageRole.skipper,
                   icon: MarineGlyphIcon(MarineGlyph.skipper),
                   label: Text('Skipper'),
                 ),

--- a/apps/mobile/lib/features/voyage/active_voyage_shell.dart
+++ b/apps/mobile/lib/features/voyage/active_voyage_shell.dart
@@ -200,7 +200,7 @@ ObserverPublishedSnapshot buildGroupObserverSnapshot({
             .toUpperCase();
         return ObserverPublishedGroupParticipant(
           displayName: _boundedObserverText(participant.displayName, 80),
-          role: participant.role.name,
+          role: participant.role.wireName,
           color: '#$color',
           position: sample == null
               ? null
@@ -1358,7 +1358,7 @@ class _ActiveVoyageShellState extends State<ActiveVoyageShell>
             } else {
               await _voyageRouteStore!.saveActiveRoute(route);
             }
-          } else if (session.role != VoyageRole.lead) {
+          } else if (session.role != VoyageRole.skipper) {
             route = null;
             await _voyageRouteStore!.clearActiveRoute();
           } else {
@@ -1415,7 +1415,7 @@ class _ActiveVoyageShellState extends State<ActiveVoyageShell>
     if (widget.enableNativeServices && !_isSimulation) {
       final session = widget.voyageController.session;
       final groupVoyage = widget.voyageController.coordinationMode.isGroup;
-      if (groupVoyage && session?.role == VoyageRole.lead) {
+      if (groupVoyage && session?.role == VoyageRole.skipper) {
         try {
           await widget.voyageController.publishVoyageCode();
         } on VoyageCodeDirectoryException catch (error) {
@@ -2055,7 +2055,7 @@ class _ActiveVoyageShellState extends State<ActiveVoyageShell>
             final isSweeper = _effectiveSweeperSailorIds.contains(
               location.sailorId,
             );
-            final isLead = location.role == VoyageRole.lead;
+            final isLead = location.role == VoyageRole.skipper;
             // A position past its freshness threshold is demoted explicitly in
             // the label. The identity fill remains stable across surfaces.
             final freshness =
@@ -2079,7 +2079,7 @@ class _ActiveVoyageShellState extends State<ActiveVoyageShell>
                 : isSweeper
                 ? 'Sweeper'
                 : isLead
-                ? 'Lead'
+                ? 'Skipper'
                 : null;
             final label = [
               location.displayName,
@@ -2220,7 +2220,7 @@ class _ActiveVoyageShellState extends State<ActiveVoyageShell>
     // group locally, so completion must work from its skipper, follower and TEC
     // perspectives alike.
     if (session == null ||
-        (!_isSimulation && session.role != VoyageRole.lead)) {
+        (!_isSimulation && session.role != VoyageRole.skipper)) {
       return;
     }
     final route = _activeRoute;
@@ -2320,7 +2320,7 @@ class _ActiveVoyageShellState extends State<ActiveVoyageShell>
         sailorId: sailor.id,
         displayName: sailor.displayName,
         kind: SailorTrailRecorder.kindFor(
-          isSkipper: sailor.role == VoyageRole.lead,
+          isSkipper: sailor.role == VoyageRole.skipper,
           isOffRoute: sailor.isOffRoute,
         ),
         // Voyage Lab maintains its own ephemeral history; the same per-sailor
@@ -2357,7 +2357,7 @@ class _ActiveVoyageShellState extends State<ActiveVoyageShell>
               longitude: location.sample.position.longitude,
               recordedAt: location.sample.recordedAt,
             ),
-            isSkipper: location.role == VoyageRole.lead,
+            isSkipper: location.role == VoyageRole.skipper,
             isOffRoute: _isOffRouteState(
               alerts[location.sailorId]?.assessment.state,
             ),
@@ -2366,7 +2366,7 @@ class _ActiveVoyageShellState extends State<ActiveVoyageShell>
                     .participantFor(location.sailorId)
                     ?.isEligibleForLivePosition ==
                 true,
-            journalTrail: location.role == VoyageRole.lead
+            journalTrail: location.role == VoyageRole.skipper
                 ? [
                     for (final sample in awareness.skipperTrailSamples)
                       route_domain.GeoPoint(
@@ -2864,7 +2864,7 @@ class _ActiveVoyageShellState extends State<ActiveVoyageShell>
                 // record in the voyage roster instead (#144).
                 participants: widget.voyageController.liveParticipants,
                 coordinationMode: widget.voyageController.coordinationMode,
-                isSkipper: session.role == VoyageRole.lead,
+                isSkipper: session.role == VoyageRole.skipper,
                 busy: widget.voyageController.busy || _loading,
                 routeName: _activeRoute?.name,
                 onStartVoyage: _confirmStartVoyage,
@@ -3290,7 +3290,7 @@ class _ActiveVoyageShellState extends State<ActiveVoyageShell>
     final sharedNumbers = widget.voyageController.receivedSailorContacts;
     final session = widget.voyageController.session;
     if (session != null &&
-        (session.role == VoyageRole.lead ||
+        (session.role == VoyageRole.skipper ||
             session.role == VoyageRole.sweeper)) {
       contacts[session.localSailorId] = MapEmergencyContact(
         sailorId: session.localSailorId,
@@ -3299,7 +3299,8 @@ class _ActiveVoyageShellState extends State<ActiveVoyageShell>
       );
     }
     for (final sailor in _awarenessController?.sailorLocations ?? const []) {
-      if (sailor.role != VoyageRole.lead && sailor.role != VoyageRole.sweeper) {
+      if (sailor.role != VoyageRole.skipper &&
+          sailor.role != VoyageRole.sweeper) {
         continue;
       }
       final shared = sharedNumbers[sailor.sailorId];
@@ -3529,9 +3530,9 @@ class _ActiveVoyageShellState extends State<ActiveVoyageShell>
 
   String? get _currentSkipperSailorId {
     final session = widget.voyageController.session;
-    if (session?.role == VoyageRole.lead) return session!.localSailorId;
+    if (session?.role == VoyageRole.skipper) return session!.localSailorId;
     for (final sailor in _awarenessController?.sailorLocations ?? const []) {
-      if (sailor.role == VoyageRole.lead) return sailor.sailorId;
+      if (sailor.role == VoyageRole.skipper) return sailor.sailorId;
     }
     return null;
   }
@@ -3553,7 +3554,7 @@ class _ActiveVoyageShellState extends State<ActiveVoyageShell>
     final controller = widget.voyageController;
     _diagnostics?.recordNote(
       'start voyage tapped on the phone: '
-      'role=${controller.session?.role.name ?? 'none'} '
+      'role=${controller.session?.role.wireName ?? 'none'} '
       'started=${controller.voyageStarted} '
       'busy=${controller.busy} '
       'route=${_activeRoute == null ? 'none' : 'selected'}',
@@ -3566,7 +3567,7 @@ class _ActiveVoyageShellState extends State<ActiveVoyageShell>
     }
     _voyageStartFlowInProgress = true;
     try {
-      if (controller.session?.role != VoyageRole.lead ||
+      if (controller.session?.role != VoyageRole.skipper ||
           controller.voyageStarted) {
         _diagnostics?.recordNote(
           'start voyage refused before the dialog: not the skipper, or already '
@@ -3775,7 +3776,7 @@ class _ActiveVoyageShellState extends State<ActiveVoyageShell>
     canToggleVoyagePause:
         !_isSimulation &&
         widget.voyageController.voyageStarted &&
-        widget.voyageController.session?.role == VoyageRole.lead,
+        widget.voyageController.session?.role == VoyageRole.skipper,
     onToggleVoyagePause: _toggleVoyagePause,
     onLeaveOrEndVoyage: _confirmLeaveVoyageFromMap,
   );
@@ -4192,7 +4193,7 @@ class _ActiveVoyageShellState extends State<ActiveVoyageShell>
     if (session == null) return;
     final sailors = <String>[];
     String labelFor(String name, VoyageRole role) => switch (role) {
-      VoyageRole.lead => '$name (Lead)',
+      VoyageRole.skipper => '$name (Lead)',
       VoyageRole.sweeper => '$name (Sweeper)',
       _ => name,
     };
@@ -4395,7 +4396,7 @@ class _ActiveVoyageShellState extends State<ActiveVoyageShell>
         controller.voyageStarted ||
         controller.busy ||
         controller.coordinationMode != VoyageCoordinationMode.solo ||
-        controller.session?.role != VoyageRole.lead) {
+        controller.session?.role != VoyageRole.skipper) {
       return;
     }
     await _leaveVoyage();

--- a/apps/mobile/lib/features/voyage/end_voyage_confirmation.dart
+++ b/apps/mobile/lib/features/voyage/end_voyage_confirmation.dart
@@ -24,7 +24,7 @@ import '../../controllers/voyage_controller.dart';
 /// three separate expressions of it and two were wrong. `VoyageController.endVoyage`
 /// accepts `isLocalVoyageSkipper`, and the voyage menu offers the action on the same
 /// — but the shell's end-voyage guard and the map's exit dialog both read
-/// `session?.role == VoyageRole.lead`, which is **false while the skipper is acting
+/// `session?.role == VoyageRole.skipper`, which is **false while the skipper is acting
 /// as the marker**. So a skipper marking a junction was refused an action the
 /// controller would have accepted: End voyage did nothing at all, and LEAVE showed
 /// the follower's dialog with no "End for everyone" (#306).

--- a/apps/mobile/lib/features/voyage/observer_access_sheet.dart
+++ b/apps/mobile/lib/features/voyage/observer_access_sheet.dart
@@ -144,7 +144,7 @@ class _ObserverAccessSheetState extends State<ObserverAccessSheet> {
                           'sailor’s last-known position and freshness, and the '
                           'planned route outline. Tell the whole group before '
                           'creating this link.'
-                    : 'This follows only your phone. Other sailors and the '
+                    : 'This follows only this device. Other sailors and the '
                           'planned route stay private.',
                 style: const TextStyle(color: Color(0xFFA9B4C2)),
               ),

--- a/apps/mobile/lib/features/voyage/voyage_dashboard.dart
+++ b/apps/mobile/lib/features/voyage/voyage_dashboard.dart
@@ -435,7 +435,7 @@ class _VoyageCodeCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final session = controller.session!;
-    if (session.role != VoyageRole.lead) {
+    if (session.role != VoyageRole.skipper) {
       return const SizedBox.shrink();
     }
     return Card(

--- a/apps/mobile/lib/features/voyage/voyage_roster_sheet.dart
+++ b/apps/mobile/lib/features/voyage/voyage_roster_sheet.dart
@@ -126,7 +126,7 @@ class _VoyageRosterSheetState extends State<VoyageRosterSheet> {
             if (widget.controller.voyageHasNoSkipper)
               _MissingSkipperNotice(
                 onTakeLead: () async {
-                  await widget.controller.setRole(VoyageRole.lead);
+                  await widget.controller.setRole(VoyageRole.skipper);
                   if (context.mounted) Navigator.pop(context);
                 },
               ),
@@ -601,12 +601,10 @@ class _ParticipantTile extends StatelessWidget {
     );
   }
 
-  static String _roleLabel(VoyageRole role) => switch (role) {
-    VoyageRole.lead => 'Lead',
-    VoyageRole.sweeper => 'Sweeper',
-    VoyageRole.marker => 'Marker',
-    VoyageRole.sailor => 'Sailor',
-  };
+  // Deferred to `VoyageRoleLabel` rather than restated. This copy is how the
+  // roster came to say "Lead" while the glyph beside it said Skipper (#49):
+  // two switches over the same enum, only one of them updated.
+  static String _roleLabel(VoyageRole role) => role.label;
 
   static String _lastSeenLabel(DateTime value, DateTime now) {
     final age = now.difference(value);

--- a/apps/mobile/lib/internet/internet_relay_client.dart
+++ b/apps/mobile/lib/internet/internet_relay_client.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 
+import '../domain/voyage_role.dart';
+
 import 'package:crypto/crypto.dart';
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
@@ -1089,7 +1091,7 @@ class HttpPreStartPresenceClient implements PreStartPresenceApi {
             ? null
             : {
                 'displayName': position.displayName,
-                'role': position.role.name,
+                'role': position.role.wireName,
                 'vesselStyle': position.sailorSymbol.wireValue(
                   position.vesselStyle,
                 ),

--- a/apps/mobile/lib/internet/push_registration_client.dart
+++ b/apps/mobile/lib/internet/push_registration_client.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 import 'dart:convert';
 
+import '../domain/voyage_role.dart';
+
 import 'package:crypto/crypto.dart';
 import 'package:http/http.dart' as http;
 
@@ -73,7 +75,7 @@ class HttpPushRegistrationClient implements PushRegistrationApi {
       'platform': token.platform,
       'provider': token.provider.name,
       'token': token.value,
-      'role': session.role.name,
+      'role': session.role.wireName,
       'preferences': preferences.toJson(),
     });
     final response = await _send(

--- a/apps/mobile/lib/services/sailor_contact_share.dart
+++ b/apps/mobile/lib/services/sailor_contact_share.dart
@@ -190,7 +190,7 @@ class SailorContactRecipients {
     required String? skipperSailorId,
     required Iterable<String> sweeperSailorIds,
   }) {
-    if (localRole == VoyageRole.lead || localRole == VoyageRole.sweeper) {
+    if (localRole == VoyageRole.skipper || localRole == VoyageRole.sweeper) {
       return const SailorContactRecipients.voyageGroup();
     }
     return SailorContactRecipients.addressed([

--- a/apps/mobile/lib/services/skipper_voyage_status.dart
+++ b/apps/mobile/lib/services/skipper_voyage_status.dart
@@ -181,7 +181,7 @@ class SkipperVoyageStatusCalculator {
     String? assignedSweeperSailorId,
     DateTime? now,
   }) {
-    if (localRole != VoyageRole.lead) return null;
+    if (localRole != VoyageRole.skipper) return null;
     final evaluatedAt = now ?? DateTime.now();
     final currentSailorIds = sailorLocations
         .map((location) => location.sailorId)

--- a/apps/mobile/lib/services/sweeper_role_assignment.dart
+++ b/apps/mobile/lib/services/sweeper_role_assignment.dart
@@ -50,7 +50,7 @@ class SweeperRoleAssignment {
 
   final String requestId;
 
-  /// The sailor who issued it, verified to have held [VoyageRole.lead] at the
+  /// The sailor who issued it, verified to have held [VoyageRole.skipper] at the
   /// moment the event was created.
   final String skipperSailorId;
 
@@ -161,7 +161,7 @@ class SweeperRoleAssignmentState {
 /// harmless:
 ///
 /// * A request is admissible only from a device whose latest signed role **at
-///   that point in the journal** is [VoyageRole.lead], and only when the payload
+///   that point in the journal** is [VoyageRole.skipper], and only when the payload
 ///   names its own author as the skipper. This is exactly how
 ///   [VoyageLifecycleReducer] admits `voyageStarted`, and how #99 rejects a forged
 ///   departure.
@@ -331,7 +331,7 @@ class SweeperRoleAssignmentReducer {
     // Only the current skipper may initiate, and the event must name its own
     // author as that skipper. A request forged or replayed by another device
     // fails one of these and is dropped whole.
-    if (roles[event.deviceId] != VoyageRole.lead) return null;
+    if (roles[event.deviceId] != VoyageRole.skipper) return null;
     if (event.payload['skipperSailorId'] != event.deviceId) return null;
     final requestId = _identifier(event.payload['requestId']);
     final targetSailorId = _identifier(event.payload['targetSailorId']);
@@ -360,10 +360,6 @@ class SweeperRoleAssignmentReducer {
 
   static VoyageRole? _role(Object? value) {
     if (value is! String) return null;
-    try {
-      return VoyageRole.values.byName(value);
-    } on ArgumentError {
-      return null;
-    }
+    return VoyageRoleWire.tryParse(value);
   }
 }

--- a/apps/mobile/lib/services/test_control_snapshot.dart
+++ b/apps/mobile/lib/services/test_control_snapshot.dart
@@ -1,4 +1,5 @@
 import '../controllers/voyage_controller.dart';
+import '../domain/voyage_role.dart';
 import '../controllers/situational_awareness_controller.dart';
 import '../relay/live_presence.dart';
 import 'voyage_membership.dart';
@@ -54,7 +55,7 @@ class TestControlSnapshot {
               'voyageCode': session.voyageCode,
               'localSailorId': session.localSailorId,
               'displayName': session.displayName,
-              'role': session.role.name,
+              'role': session.role.wireName,
               // No inviteSecret, no joinToken - see the class comment.
             },
       'roster': [
@@ -72,7 +73,7 @@ class TestControlSnapshot {
   ) => {
     'sailorId': participant.sailorId,
     'displayName': participant.displayName,
-    'role': participant.role.name,
+    'role': participant.role.wireName,
     'state': participant.state.name,
     'isLocal': participant.isLocal,
     'hasLastKnownLocation': participant.lastKnownLocation != null,
@@ -86,7 +87,7 @@ class TestControlSnapshot {
   ) => {
     'sailorId': sailor.sailorId,
     'displayName': sailor.displayName,
-    'role': sailor.role.name,
+    'role': sailor.role.wireName,
     'freshness': sailor.freshness.name,
     'isLocal': sailor.isLocal,
     'hasPosition': sailor.location != null,

--- a/apps/mobile/lib/services/voyage_lifecycle.dart
+++ b/apps/mobile/lib/services/voyage_lifecycle.dart
@@ -47,7 +47,7 @@ class VoyageLifecycleReducer {
           if (role != null) roles[event.deviceId] = role;
           break;
         case VoyageEventType.voyageStarted:
-          if (roles[event.deviceId] == VoyageRole.lead &&
+          if (roles[event.deviceId] == VoyageRole.skipper &&
               event.payload['skipperSailorId'] == event.deviceId) {
             return VoyageLifecycle(startEvent: event);
           }
@@ -87,10 +87,6 @@ class VoyageLifecycleReducer {
 
   static VoyageRole? _roleFromPayload(Object? value) {
     if (value is! String) return null;
-    try {
-      return VoyageRole.values.byName(value);
-    } on ArgumentError {
-      return null;
-    }
+    return VoyageRoleWire.tryParse(value);
   }
 }

--- a/apps/mobile/lib/services/voyage_membership.dart
+++ b/apps/mobile/lib/services/voyage_membership.dart
@@ -449,7 +449,7 @@ class VoyageMembershipReducer {
         if (displayName == null || role == null) continue;
         final isLocal = event.deviceId == localSailorId;
         final joiningRole = isLocal ? localRole : role;
-        if (joiningRole == VoyageRole.lead) {
+        if (joiningRole == VoyageRole.skipper) {
           leadClaimedAt[event.deviceId] = event.createdAt;
         }
         participants[event.deviceId] = VoyageParticipant(
@@ -537,7 +537,7 @@ class VoyageMembershipReducer {
       if (event.type == VoyageEventType.roleChanged) {
         final role = _role(event.payload['role']);
         if (role == null) continue;
-        if (role == VoyageRole.lead) {
+        if (role == VoyageRole.skipper) {
           leadClaimedAt[event.deviceId] = event.createdAt;
         }
         participants[event.deviceId] = existing.copyWith(
@@ -736,7 +736,7 @@ class VoyageMembershipReducer {
     return List.unmodifiable(_withOneSkipper(result, leadClaimedAt));
   }
 
-  /// Leaves exactly one sailor holding [VoyageRole.lead].
+  /// Leaves exactly one sailor holding [VoyageRole.skipper].
   ///
   /// A tester found that two sailors could hold lead at the same time, and that
   /// either could then end the voyage for everyone (#284). #241 restricted that
@@ -761,7 +761,7 @@ class VoyageMembershipReducer {
     Map<String, DateTime> leadClaimedAt,
   ) {
     final skippers = participants
-        .where((participant) => participant.role == VoyageRole.lead)
+        .where((participant) => participant.role == VoyageRole.skipper)
         .toList(growable: false);
     if (skippers.length < 2) return participants;
 
@@ -787,7 +787,7 @@ class VoyageMembershipReducer {
 
     return [
       for (final participant in participants)
-        participant.role == VoyageRole.lead &&
+        participant.role == VoyageRole.skipper &&
                 participant.sailorId != winner!.sailorId
             // Demoted to sailor rather than dropped: they are still in the voyage,
             // they just do not lead it, and saying so is what stops their phone
@@ -878,11 +878,7 @@ class VoyageMembershipReducer {
 
   static VoyageRole? _role(Object? value) {
     if (value is! String) return null;
-    try {
-      return VoyageRole.values.byName(value);
-    } on ArgumentError {
-      return null;
-    }
+    return VoyageRoleWire.tryParse(value);
   }
 
   static String? _nonEmptyString(Object? value) {

--- a/apps/mobile/lib/services/voyage_route_reducer.dart
+++ b/apps/mobile/lib/services/voyage_route_reducer.dart
@@ -230,16 +230,12 @@ class VoyageRouteReducer {
     VoyageEvent event,
     Map<String, VoyageRole> roles,
   ) =>
-      roles[event.deviceId] == VoyageRole.lead &&
+      roles[event.deviceId] == VoyageRole.skipper &&
       event.payload['skipperSailorId'] == event.deviceId;
 
   static VoyageRole? _role(Object? value) {
     if (value is! String) return null;
-    try {
-      return VoyageRole.values.byName(value);
-    } on ArgumentError {
-      return null;
-    }
+    return VoyageRoleWire.tryParse(value);
   }
 
   static String? _string(Object? value) =>

--- a/apps/mobile/test/controllers/live_presence_clock_skew_test.dart
+++ b/apps/mobile/test/controllers/live_presence_clock_skew_test.dart
@@ -39,7 +39,7 @@ void main() {
   test(
     "a peer whose clock is behind stays live, and is named rather than aged out",
     () async {
-      final skipper = device('skipper', 'Lead', role: VoyageRole.lead);
+      final skipper = device('skipper', 'Lead', role: VoyageRole.skipper);
       final follower = device(
         'follower',
         'Alex',
@@ -80,7 +80,7 @@ void main() {
   test(
     'a peer whose clock is ahead is judged on the relay clock too',
     () async {
-      final skipper = device('skipper', 'Lead', role: VoyageRole.lead);
+      final skipper = device('skipper', 'Lead', role: VoyageRole.skipper);
       final follower = device(
         'follower',
         'Alex',
@@ -120,7 +120,7 @@ void main() {
       final skipper = device(
         'skipper',
         'Lead',
-        role: VoyageRole.lead,
+        role: VoyageRole.skipper,
         clockOffset: const Duration(seconds: 90),
       );
       final follower = device('follower', 'Alex');
@@ -143,7 +143,7 @@ void main() {
   );
 
   test('one unreadable position does not hide the others', () async {
-    final skipper = device('skipper', 'Lead', role: VoyageRole.lead);
+    final skipper = device('skipper', 'Lead', role: VoyageRole.skipper);
     final follower = device('follower', 'Alex');
     relay.join('follower', 'Alex', 'sailor');
     await follower.start();
@@ -164,7 +164,7 @@ void main() {
     final skipper = device(
       'skipper',
       'Lead',
-      role: VoyageRole.lead,
+      role: VoyageRole.skipper,
       clockOffset: const Duration(seconds: -45),
     );
     await skipper.start();
@@ -176,7 +176,7 @@ void main() {
   test(
     'a position stops being retained on the relay clock, not the peer\'s',
     () async {
-      final skipper = device('skipper', 'Lead', role: VoyageRole.lead);
+      final skipper = device('skipper', 'Lead', role: VoyageRole.skipper);
       final follower = device(
         'follower',
         'Alex',

--- a/apps/mobile/test/controllers/live_presence_two_device_test.dart
+++ b/apps/mobile/test/controllers/live_presence_two_device_test.dart
@@ -40,7 +40,7 @@ void main() {
   }
 
   test('a sailor visible before the start stays visible across it', () async {
-    final skipper = device('skipper', 'Lead', role: VoyageRole.lead);
+    final skipper = device('skipper', 'Lead', role: VoyageRole.skipper);
     final follower = device('follower', 'Alex');
     relay.join('skipper', 'Lead', 'lead');
     relay.join('follower', 'Alex', 'sailor');
@@ -70,7 +70,7 @@ void main() {
   test(
     'the skipper sees a sailor who joins an already-started voyage',
     () async {
-      final skipper = device('skipper', 'Lead', role: VoyageRole.lead);
+      final skipper = device('skipper', 'Lead', role: VoyageRole.skipper);
       relay.join('skipper', 'Lead', 'lead');
       await skipper.start();
       relay.startVoyage();
@@ -96,7 +96,7 @@ void main() {
   test(
     'the joiner sees the skipper advancing, not one frozen position',
     () async {
-      final skipper = device('skipper', 'Lead', role: VoyageRole.lead);
+      final skipper = device('skipper', 'Lead', role: VoyageRole.skipper);
       relay.join('skipper', 'Lead', 'lead');
       await skipper.start();
       relay.startVoyage();
@@ -118,7 +118,7 @@ void main() {
   );
 
   test('a sailor who restarts the app rejoins without re-opting in', () async {
-    final skipper = device('skipper', 'Lead', role: VoyageRole.lead);
+    final skipper = device('skipper', 'Lead', role: VoyageRole.skipper);
     relay.join('skipper', 'Lead', 'lead');
     relay.join('follower', 'Alex', 'sailor');
     await skipper.start();
@@ -144,7 +144,7 @@ void main() {
   });
 
   test('presence resumes by itself after a network loss', () async {
-    final skipper = device('skipper', 'Lead', role: VoyageRole.lead);
+    final skipper = device('skipper', 'Lead', role: VoyageRole.skipper);
     final follower = device('follower', 'Alex');
     relay.join('skipper', 'Lead', 'lead');
     relay.join('follower', 'Alex', 'sailor');
@@ -183,7 +183,7 @@ void main() {
   test(
     'a position that stops updating ages, goes stale, then disappears',
     () async {
-      final skipper = device('skipper', 'Lead', role: VoyageRole.lead);
+      final skipper = device('skipper', 'Lead', role: VoyageRole.skipper);
       final follower = device('follower', 'Alex');
       relay.join('skipper', 'Lead', 'lead');
       await skipper.start();
@@ -358,7 +358,7 @@ void main() {
   test(
     'stopping clears this device from the relay and its peer demotes it',
     () async {
-      final skipper = device('skipper', 'Lead', role: VoyageRole.lead);
+      final skipper = device('skipper', 'Lead', role: VoyageRole.skipper);
       final follower = device('follower', 'Alex');
       await skipper.start();
       await follower.start();
@@ -383,7 +383,7 @@ void main() {
   );
 
   test('an explicit departure removes a sailor immediately', () async {
-    final skipper = device('skipper', 'Lead', role: VoyageRole.lead);
+    final skipper = device('skipper', 'Lead', role: VoyageRole.skipper);
     final follower = device('follower', 'Alex');
     relay.join('skipper', 'Lead', 'lead');
     relay.join('follower', 'Alex', 'sailor');

--- a/apps/mobile/test/controllers/personal_voyage_heatmap_controller_test.dart
+++ b/apps/mobile/test/controllers/personal_voyage_heatmap_controller_test.dart
@@ -176,7 +176,7 @@ CompletedVoyage _voyage(
   voyageCode: id.padLeft(6, '0'),
   voyageName: null,
   localDisplayName: 'Oliver',
-  localRole: VoyageRole.lead,
+  localRole: VoyageRole.skipper,
   startedAt: DateTime.utc(2026, 8, 12, 9),
   endedAt: DateTime.utc(2026, 8, 12, 10),
   archivedAt: DateTime.utc(2026, 8, 12, 10, 1),

--- a/apps/mobile/test/controllers/pre_start_presence_controller_test.dart
+++ b/apps/mobile/test/controllers/pre_start_presence_controller_test.dart
@@ -18,7 +18,7 @@ void main() {
     joinToken: 'test-join-token-0123456789',
     localSailorId: 'local',
     displayName: 'Oliver',
-    role: VoyageRole.lead,
+    role: VoyageRole.skipper,
     joinedAt: DateTime.utc(2026, 7, 23, 10),
   );
 
@@ -154,7 +154,7 @@ SailorLocation _location({
 }) => SailorLocation(
   sailorId: sailorId,
   displayName: displayName,
-  role: sailorId == 'local' ? VoyageRole.lead : VoyageRole.sailor,
+  role: sailorId == 'local' ? VoyageRole.skipper : VoyageRole.sailor,
   sample: LocationSample(
     position: GeoPoint(latitude: latitude, longitude: -2.4),
     recordedAt: receivedAt,

--- a/apps/mobile/test/controllers/voyage_controller_no_skipper_test.dart
+++ b/apps/mobile/test/controllers/voyage_controller_no_skipper_test.dart
@@ -132,7 +132,7 @@ void main() {
     await controller.setRole(VoyageRole.sailor);
     expect(controller.voyageHasNoSkipper, isTrue);
 
-    await controller.setRole(VoyageRole.lead);
+    await controller.setRole(VoyageRole.skipper);
 
     expect(controller.voyageHasNoSkipper, isFalse);
     expect(controller.skipperSailorId, controller.session!.localSailorId);
@@ -145,7 +145,7 @@ void main() {
     expect(controller.voyageHasNoSkipper, isTrue);
 
     // endVoyage requires the lead role, so take it back to end the voyage.
-    await controller.setRole(VoyageRole.lead);
+    await controller.setRole(VoyageRole.skipper);
     await controller.endVoyage();
 
     expect(
@@ -172,7 +172,7 @@ void main() {
       type: VoyageEventType.roleChanged,
       priority: EventPriority.important,
       createdAt: now,
-      payload: {'role': VoyageRole.lead.name},
+      payload: {'role': VoyageRole.skipper.name},
       // Signed with the wrong secret: a device outside the voyage.
       signature: VoyageEventAuthenticator.sign(
         VoyageEvent(
@@ -182,7 +182,7 @@ void main() {
           type: VoyageEventType.roleChanged,
           priority: EventPriority.important,
           createdAt: now,
-          payload: {'role': VoyageRole.lead.name},
+          payload: {'role': VoyageRole.skipper.name},
           signature: '',
         ),
         'not-this-voyages-secret',

--- a/apps/mobile/test/controllers/voyage_controller_test.dart
+++ b/apps/mobile/test/controllers/voyage_controller_test.dart
@@ -55,7 +55,7 @@ void main() {
   test('new voyage is persisted with lead role and a signed event', () async {
     await controller.createVoyage('Oliver');
 
-    expect(controller.session?.role, VoyageRole.lead);
+    expect(controller.session?.role, VoyageRole.skipper);
     expect(controller.session?.displayName, 'Oliver');
     expect(controller.session?.voyageCode, matches(RegExp(r'^\d{6}$')));
     expect(controller.events, hasLength(1));
@@ -338,7 +338,7 @@ void main() {
         controller.participants
             .singleWhere((participant) => participant.sailorId == 'follower')
             .role,
-        VoyageRole.lead,
+        VoyageRole.skipper,
       );
     },
   );
@@ -605,7 +605,7 @@ void main() {
 
     final archived = (await completedVoyageStore.list()).single;
     expect(archived.title, 'Peak District');
-    expect(archived.localRole, VoyageRole.lead);
+    expect(archived.localRole, VoyageRole.skipper);
     expect(archived.endedAt, DateTime.utc(2026, 7, 16, 12));
     expect(archived.toJson().toString(), isNot(contains(inviteSecret)));
     expect(archived.toJson().toString(), isNot(contains(joinToken)));
@@ -1250,7 +1250,7 @@ void main() {
             'sailorId': sailorId,
             'displayName': sailorId,
             'phone': phone,
-            'sharedByRole': VoyageRole.lead.name,
+            'sharedByRole': VoyageRole.skipper.name,
           },
           'recipientSailorIds': ?recipientSailorIds,
         },

--- a/apps/mobile/test/controllers/voyage_simulation_controller_test.dart
+++ b/apps/mobile/test/controllers/voyage_simulation_controller_test.dart
@@ -22,7 +22,7 @@ void main() {
       joinToken: 'test-join-token-0123456789',
       localSailorId: 'lead',
       displayName: 'Demo Lead',
-      role: VoyageRole.lead,
+      role: VoyageRole.skipper,
       joinedAt: DateTime.utc(2026, 7, 17),
       isSimulation: true,
     );
@@ -78,7 +78,7 @@ void main() {
       joinToken: 'test-join-token-0123456789',
       localSailorId: 'lead',
       displayName: 'Demo Lead',
-      role: VoyageRole.lead,
+      role: VoyageRole.skipper,
       joinedAt: DateTime.utc(2026, 7, 17),
       isSimulation: true,
     );
@@ -140,7 +140,7 @@ void main() {
         joinToken: 'test-join-token-0123456789',
         localSailorId: 'lead',
         displayName: 'Demo Lead',
-        role: VoyageRole.lead,
+        role: VoyageRole.skipper,
         joinedAt: DateTime.utc(2026, 7, 17),
         isSimulation: true,
       ),
@@ -165,7 +165,7 @@ void main() {
         joinToken: 'test-join-token-0123456789',
         localSailorId: 'lead',
         displayName: 'Demo Lead',
-        role: VoyageRole.lead,
+        role: VoyageRole.skipper,
         joinedAt: DateTime.utc(2026, 7, 17),
         isSimulation: true,
         simulationSailorCount: 30,
@@ -205,7 +205,7 @@ void main() {
 
   test('retains a recent trail for the simulated skipper', () async {
     final initialSkipper = simulation.sailors.singleWhere(
-      (sailor) => sailor.role == VoyageRole.lead,
+      (sailor) => sailor.role == VoyageRole.skipper,
     );
     final sweeper = simulation.sailors.singleWhere(
       (sailor) => sailor.role == VoyageRole.sweeper,
@@ -223,7 +223,7 @@ void main() {
     await simulation.advance(const Duration(seconds: 1));
 
     final movingSkipper = simulation.sailors.singleWhere(
-      (sailor) => sailor.role == VoyageRole.lead,
+      (sailor) => sailor.role == VoyageRole.skipper,
     );
     expect(movingSkipper.travelTrail.length, greaterThan(1));
   });
@@ -237,7 +237,7 @@ void main() {
     );
     expect(follower.displayName, 'You · Follower');
     expect(follower.progress, lessThan(skipper.progress));
-    expect(skipper.role, VoyageRole.lead);
+    expect(skipper.role, VoyageRole.skipper);
 
     simulation.setLocalRole(VoyageRole.sweeper);
     expect(simulation.localRole, VoyageRole.sweeper);
@@ -262,7 +262,7 @@ void main() {
       (sailor) => sailor.displayName == 'Maya',
     );
     expect(follower.role, VoyageRole.sailor);
-    expect(skipper.role, VoyageRole.lead);
+    expect(skipper.role, VoyageRole.skipper);
     expect(follower.progress, lessThan(skipper.progress));
   });
 
@@ -304,7 +304,7 @@ void main() {
           joinToken: 'test-join-token-0123456789',
           localSailorId: 'lead',
           displayName: 'Demo Lead',
-          role: VoyageRole.lead,
+          role: VoyageRole.skipper,
           joinedAt: DateTime.utc(2026, 7, 17),
           isSimulation: true,
         ),
@@ -372,7 +372,7 @@ void main() {
           joinToken: 'test-join-token-0123456789',
           localSailorId: 'lead',
           displayName: 'Demo Lead',
-          role: VoyageRole.lead,
+          role: VoyageRole.skipper,
           joinedAt: DateTime.utc(2026, 7, 17),
           isSimulation: true,
         ),
@@ -397,7 +397,7 @@ void main() {
       final maya = markerSimulation.sailors.singleWhere(
         (sailor) => sailor.id == 'voyage-lab-maya',
       );
-      expect(markerSimulation.localRole, VoyageRole.lead);
+      expect(markerSimulation.localRole, VoyageRole.skipper);
       expect(markerSimulation.automaticMarkerActive, isTrue);
       expect(markerSimulation.automaticMarkerIsLocal, isFalse);
       expect(markerSimulation.automaticMarkerSailorName, 'Maya');

--- a/apps/mobile/test/data/shared_preferences_session_store_test.dart
+++ b/apps/mobile/test/data/shared_preferences_session_store_test.dart
@@ -95,7 +95,7 @@ VoyageSession _session() => VoyageSession(
   joinToken: 'test-join-token-0123456789',
   localSailorId: 'sailor-1',
   displayName: 'Oliver',
-  role: VoyageRole.lead,
+  role: VoyageRole.skipper,
   joinedAt: DateTime.utc(2026, 7, 16, 12),
 );
 

--- a/apps/mobile/test/domain/voyage_role_test.dart
+++ b/apps/mobile/test/domain/voyage_role_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tide_and_seek/domain/voyage_role.dart';
+import 'package:tide_and_seek/domain/voyage_session.dart';
+
+/// #49. `lead` is the road group-riding role this app was scaffolded from; on a
+/// boat it is the skipper, and the marine glyph set already said so, which left
+/// the icon and the role beside it disagreeing on screen.
+///
+/// Renaming an enum whose `.name` is written into saved sessions, completed
+/// voyages, relay payloads and push registrations is the part that can lose a
+/// sailor's passage, so most of this file is about what happens to what earlier
+/// builds already wrote.
+void main() {
+  group('what a person reads', () {
+    test('the skipper is called the skipper', () {
+      expect(VoyageRole.skipper.label, 'Skipper');
+    });
+
+    test('no role is still labelled for a road group', () {
+      expect(
+        VoyageRole.values.map((role) => role.label),
+        isNot(contains('Lead')),
+      );
+    });
+  });
+
+  group('reading what earlier builds wrote', () {
+    test('a stored "lead" reads as the skipper', () {
+      expect(VoyageRoleWire.tryParse('lead'), VoyageRole.skipper);
+      expect(VoyageRoleWire.parse('lead'), VoyageRole.skipper);
+    });
+
+    test('every current role round-trips through its wire name', () {
+      for (final role in VoyageRole.values) {
+        expect(
+          VoyageRoleWire.tryParse(role.wireName),
+          role,
+          reason: '${role.name} should survive a write and a read',
+        );
+      }
+    });
+
+    test('an unknown role is absent rather than fatal', () {
+      // A payload from a newer build must degrade to "no role stated" instead
+      // of taking the voyage down with it.
+      expect(VoyageRoleWire.tryParse('navigator'), isNull);
+      expect(VoyageRoleWire.tryParse(''), isNull);
+      expect(VoyageRoleWire.tryParse(null), isNull);
+    });
+
+    test('parse refuses an unknown role rather than guessing one', () {
+      expect(
+        () => VoyageRoleWire.parse('navigator'),
+        throwsA(isA<FormatException>()),
+      );
+    });
+  });
+
+  group('a session saved before the rename still restores', () {
+    // The failure this guards against is not abstract: `values.byName('lead')`
+    // throws, restore catches it, and the sailor is shown "Could not restore
+    // your saved voyage" with the passage gone.
+    test('a stored session carrying "lead" comes back as the skipper', () {
+      final session = VoyageSession.fromJson({
+        ..._session().toJson(),
+        'role': 'lead',
+      });
+
+      expect(session.role, VoyageRole.skipper);
+    });
+
+    test('a session written now says skipper on the wire', () {
+      expect(_session().toJson()['role'], 'skipper');
+    });
+  });
+}
+
+VoyageSession _session() => VoyageSession(
+  voyageId: 'v1',
+  voyageCode: '123456',
+  inviteSecret: 'secret',
+  joinToken: 'token',
+  localSailorId: 's1',
+  displayName: 'Oliver',
+  role: VoyageRole.skipper,
+  joinedAt: DateTime.utc(2026, 8, 19),
+);

--- a/apps/mobile/test/domain/voyage_session_test.dart
+++ b/apps/mobile/test/domain/voyage_session_test.dart
@@ -12,7 +12,7 @@ void main() {
     joinToken: 'aTokenWithPlentyOfEntropy',
     localSailorId: 'lead',
     displayName: 'Demo Lead',
-    role: VoyageRole.lead,
+    role: VoyageRole.skipper,
     joinedAt: DateTime.utc(2026, 7, 17),
     isSimulation: true,
   );
@@ -31,7 +31,7 @@ void main() {
         joinToken: 'aTokenWithPlentyOfEntropy',
         localSailorId: 'lead',
         displayName: 'Demo Lead',
-        role: VoyageRole.lead,
+        role: VoyageRole.skipper,
         joinedAt: DateTime.utc(2026, 7, 17),
         isSimulation: true,
         simulationSailorCount: 30,
@@ -64,7 +64,7 @@ void main() {
         joinToken: 'aTokenWithPlentyOfEntropy',
         localSailorId: 'lead',
         displayName: 'Demo Lead',
-        role: VoyageRole.lead,
+        role: VoyageRole.skipper,
         joinedAt: DateTime.utc(2026, 7, 17),
         coordinationMode: VoyageCoordinationMode.solo,
       );
@@ -91,7 +91,7 @@ void main() {
         joinToken: 'aTokenWithPlentyOfEntropy',
         localSailorId: 'lead',
         displayName: 'Demo Lead',
-        role: VoyageRole.lead,
+        role: VoyageRole.skipper,
         joinedAt: DateTime.utc(2026, 7, 17),
         sailorSymbol: const SailorSymbol.initials(),
       );

--- a/apps/mobile/test/features/map/emergency_sheet_landscape_test.dart
+++ b/apps/mobile/test/features/map/emergency_sheet_landscape_test.dart
@@ -50,7 +50,7 @@ void main() {
             MapEmergencyContact(
               sailorId: 'lead',
               displayName: 'Oliver',
-              role: VoyageRole.lead,
+              role: VoyageRole.skipper,
             ),
             MapEmergencyContact(
               sailorId: 'sweeper',

--- a/apps/mobile/test/features/map/stored_route_source_test.dart
+++ b/apps/mobile/test/features/map/stored_route_source_test.dart
@@ -334,7 +334,7 @@ CompletedVoyage _completedVoyage({
   voyageCode: voyageCode,
   voyageName: 'Sunday run',
   localDisplayName: 'Alex',
-  localRole: VoyageRole.lead,
+  localRole: VoyageRole.skipper,
   startedAt: DateTime.utc(2026, 7, 26, 9),
   endedAt: DateTime.utc(2026, 7, 26, 12),
   archivedAt: DateTime.utc(2026, 7, 26, 12, 5),

--- a/apps/mobile/test/features/map/voyage_map_feature_test.dart
+++ b/apps/mobile/test/features/map/voyage_map_feature_test.dart
@@ -2253,7 +2253,7 @@ void main() {
             MapEmergencyContact(
               sailorId: 'lead',
               displayName: 'Oliver',
-              role: VoyageRole.lead,
+              role: VoyageRole.skipper,
             ),
             MapEmergencyContact(
               sailorId: 'sweeper',
@@ -2322,7 +2322,7 @@ void main() {
             MapEmergencyContact(
               sailorId: 'lead',
               displayName: 'Oliver',
-              role: VoyageRole.lead,
+              role: VoyageRole.skipper,
               phoneNumber: '+44 7700 900321',
               contactShareEventId: 'lead-share',
             ),
@@ -2420,7 +2420,7 @@ void main() {
             MapEmergencyContact(
               sailorId: 'lead',
               displayName: 'Oliver',
-              role: VoyageRole.lead,
+              role: VoyageRole.skipper,
             ),
           ],
           onEmergencyAlert: () async {},
@@ -4388,7 +4388,7 @@ CompletedVoyage _completedHeatmapVoyage(ImportedRoute traveledRoute) =>
       voyageCode: '392725',
       voyageName: 'Previous voyage',
       localDisplayName: 'Oliver',
-      localRole: VoyageRole.lead,
+      localRole: VoyageRole.skipper,
       startedAt: DateTime.utc(2026, 8, 12, 9),
       endedAt: DateTime.utc(2026, 8, 12, 10),
       archivedAt: DateTime.utc(2026, 8, 12, 10, 1),

--- a/apps/mobile/test/features/voyage/active_voyage_shell_route_test.dart
+++ b/apps/mobile/test/features/voyage/active_voyage_shell_route_test.dart
@@ -91,7 +91,7 @@ void main() {
         registeredSweeperSailorIds(
           simulatedSailors: null,
           liveParticipants: [
-            participant(sailorId: 'lead', role: VoyageRole.lead),
+            participant(sailorId: 'lead', role: VoyageRole.skipper),
             participant(sailorId: 'charlie', role: VoyageRole.sweeper),
           ],
         ),
@@ -104,7 +104,7 @@ void main() {
         registeredSweeperSailorIds(
           simulatedSailors: null,
           liveParticipants: [
-            participant(sailorId: 'lead', role: VoyageRole.lead),
+            participant(sailorId: 'lead', role: VoyageRole.skipper),
             participant(sailorId: 'alex', role: VoyageRole.sailor),
           ],
         ),
@@ -117,7 +117,7 @@ void main() {
         registeredSweeperSailorIds(
           simulatedSailors: null,
           liveParticipants: [
-            participant(sailorId: 'lead', role: VoyageRole.lead),
+            participant(sailorId: 'lead', role: VoyageRole.skipper),
             participant(
               sailorId: 'charlie',
               role: VoyageRole.sweeper,
@@ -133,7 +133,7 @@ void main() {
       expect(
         registeredSweeperSailorIds(
           simulatedSailors: [
-            _simulated(id: 'voyage-lab-maya', role: VoyageRole.lead),
+            _simulated(id: 'voyage-lab-maya', role: VoyageRole.skipper),
             _simulated(id: 'voyage-lab-charlie', role: VoyageRole.sweeper),
           ],
           liveParticipants: const [],

--- a/apps/mobile/test/features/voyage/end_voyage_confirmation_test.dart
+++ b/apps/mobile/test/features/voyage/end_voyage_confirmation_test.dart
@@ -68,7 +68,7 @@ void main() {
     // Three surfaces offered this and expressed the condition three ways, two
     // of them wrong. `VoyageController.endVoyage` accepts `isLocalVoyageSkipper`; the
     // shell's end-voyage guard and the map's exit dialog both read
-    // `session?.role == VoyageRole.lead`, which is a different thing.
+    // `session?.role == VoyageRole.skipper`, which is a different thing.
     Future<VoyageController> controllerFor() async {
       var id = 0;
       final controller = VoyageController(
@@ -90,7 +90,7 @@ void main() {
       final controller = await controllerFor();
       addTearDown(controller.dispose);
 
-      expect(controller.session?.role, VoyageRole.lead);
+      expect(controller.session?.role, VoyageRole.skipper);
       expect(canEndVoyageForEveryone(controller), isTrue);
     });
 

--- a/apps/mobile/test/features/voyage/observer_snapshot_privacy_test.dart
+++ b/apps/mobile/test/features/voyage/observer_snapshot_privacy_test.dart
@@ -102,7 +102,7 @@ void main() {
       joinToken: 'private-join-token',
       localSailorId: 'local-sailor',
       displayName: 'Local sailor',
-      role: VoyageRole.lead,
+      role: VoyageRole.skipper,
       joinedAt: now,
     );
     const sharedNumber = '+44 7700 900321';
@@ -151,7 +151,7 @@ void main() {
       joinToken: 'private-join-token',
       localSailorId: 'skipper-private-id',
       displayName: 'Oliver',
-      role: VoyageRole.lead,
+      role: VoyageRole.skipper,
       joinedAt: now,
       voyageName: 'Sunday voyage',
     );
@@ -159,7 +159,7 @@ void main() {
       VoyageParticipant(
         sailorId: 'skipper-private-id',
         displayName: 'Oliver',
-        role: VoyageRole.lead,
+        role: VoyageRole.skipper,
         joinedAt: now,
         lastSeenAt: now,
         state: VoyageMembershipState.active,

--- a/apps/mobile/test/features/voyage/voyage_roster_no_skipper_test.dart
+++ b/apps/mobile/test/features/voyage/voyage_roster_no_skipper_test.dart
@@ -102,7 +102,7 @@ void main() {
     await tester.tap(find.byKey(const Key('roster-take-the-lead-button')));
     await tester.pumpAndSettle();
 
-    expect(controller.session?.role, VoyageRole.lead);
+    expect(controller.session?.role, VoyageRole.skipper);
     expect(controller.voyageHasNoSkipper, isFalse);
     expect(controller.skipperSailorId, controller.session!.localSailorId);
     // Recorded as this sailor's own role change, which is what makes it

--- a/apps/mobile/test/features/voyage_simulation_screen_test.dart
+++ b/apps/mobile/test/features/voyage_simulation_screen_test.dart
@@ -19,7 +19,7 @@ void main() {
         joinToken: 'test-join-token-0123456789',
         localSailorId: 'lead',
         displayName: 'Demo Lead',
-        role: VoyageRole.lead,
+        role: VoyageRole.skipper,
         joinedAt: DateTime.utc(2026, 7, 17),
         isSimulation: true,
       );
@@ -87,7 +87,7 @@ void main() {
       joinToken: 'test-join-token-0123456789',
       localSailorId: 'lead',
       displayName: 'Demo Lead',
-      role: VoyageRole.lead,
+      role: VoyageRole.skipper,
       joinedAt: DateTime.utc(2026, 7, 17),
       isSimulation: true,
     );
@@ -167,7 +167,7 @@ void main() {
       joinToken: 'test-join-token-0123456789',
       localSailorId: 'lead',
       displayName: 'Demo Lead',
-      role: VoyageRole.lead,
+      role: VoyageRole.skipper,
       joinedAt: DateTime.utc(2026, 7, 17),
       isSimulation: true,
     );

--- a/apps/mobile/test/internet/pre_start_presence_client_test.dart
+++ b/apps/mobile/test/internet/pre_start_presence_client_test.dart
@@ -76,13 +76,13 @@ void main() {
         joinToken: 'test-join-token-0123456789',
         localSailorId: 'local',
         displayName: 'Oliver',
-        role: VoyageRole.lead,
+        role: VoyageRole.skipper,
         joinedAt: now,
       );
       final position = SailorLocation(
         sailorId: 'local',
         displayName: 'Oliver',
-        role: VoyageRole.lead,
+        role: VoyageRole.skipper,
         sample: LocationSample(
           position: const GeoPoint(latitude: 51.2, longitude: -2.4),
           recordedAt: now,
@@ -144,7 +144,7 @@ void main() {
         joinToken: 'test-join-token-0123456789',
         localSailorId: 'local',
         displayName: 'Oliver',
-        role: VoyageRole.lead,
+        role: VoyageRole.skipper,
         joinedAt: DateTime.utc(2026, 7, 23),
       );
 

--- a/apps/mobile/test/internet/two_device_relay_sync_test.dart
+++ b/apps/mobile/test/internet/two_device_relay_sync_test.dart
@@ -52,7 +52,7 @@ void main() {
   test(
     'an idle device with an empty outbound queue still receives a peer',
     () async {
-      final skipper = device('skipper', role: VoyageRole.lead);
+      final skipper = device('skipper', role: VoyageRole.skipper);
       final follower = device('follower');
 
       // The skipper is parked on a desk: it uploads its own creation event once
@@ -82,7 +82,7 @@ void main() {
   );
 
   test('the same holds with the roles the other way round', () async {
-    final skipper = device('skipper', role: VoyageRole.lead);
+    final skipper = device('skipper', role: VoyageRole.skipper);
     final follower = device('follower');
     await follower.enqueue('follower-joined', VoyageEventType.sailorJoined);
     await follower.start();
@@ -104,7 +104,7 @@ void main() {
   test(
     'positions keep arriving in both directions while one device is idle',
     () async {
-      final skipper = device('skipper', role: VoyageRole.lead);
+      final skipper = device('skipper', role: VoyageRole.skipper);
       final follower = device('follower');
       await skipper.start();
       await follower.start();
@@ -127,7 +127,7 @@ void main() {
   test(
     'a repeated upload after a lost acknowledgement still delivers the peer',
     () async {
-      final skipper = device('skipper', role: VoyageRole.lead);
+      final skipper = device('skipper', role: VoyageRole.skipper);
       final follower = device('follower');
       await skipper.enqueue(
         'skipper-position-1',
@@ -156,7 +156,7 @@ void main() {
   );
 
   test('device clocks that disagree do not stop journal delivery', () async {
-    final skipper = device('skipper', role: VoyageRole.lead);
+    final skipper = device('skipper', role: VoyageRole.skipper);
     final follower = device('follower');
     await skipper.start();
     await follower.start();

--- a/apps/mobile/test/relay/live_presence_test.dart
+++ b/apps/mobile/test/relay/live_presence_test.dart
@@ -192,7 +192,12 @@ void main() {
       now: now,
       localSailorId: 'local',
       internetPresence: [
-        _location('bill', 'Impostor', recordedAt: now, role: VoyageRole.skipper),
+        _location(
+          'bill',
+          'Impostor',
+          recordedAt: now,
+          role: VoyageRole.skipper,
+        ),
       ],
       roster: [
         PresenceRosterMember(

--- a/apps/mobile/test/relay/live_presence_test.dart
+++ b/apps/mobile/test/relay/live_presence_test.dart
@@ -192,7 +192,7 @@ void main() {
       now: now,
       localSailorId: 'local',
       internetPresence: [
-        _location('bill', 'Impostor', recordedAt: now, role: VoyageRole.lead),
+        _location('bill', 'Impostor', recordedAt: now, role: VoyageRole.skipper),
       ],
       roster: [
         PresenceRosterMember(

--- a/apps/mobile/test/services/sailor_contact_share_test.dart
+++ b/apps/mobile/test/services/sailor_contact_share_test.dart
@@ -108,13 +108,13 @@ void main() {
           deviceId: 'skipper',
           sailorId: 'skipper',
           displayName: 'Oliver',
-          role: VoyageRole.lead,
+          role: VoyageRole.skipper,
           recipientSailorIds: null,
         ),
       ], localSailorId: 'ordinary-sailor');
 
       expect(result['skipper']!.toVoyageGroup, isTrue);
-      expect(result['skipper']!.sharedByRole, VoyageRole.lead);
+      expect(result['skipper']!.sharedByRole, VoyageRole.skipper);
     });
 
     test('a malformed recipient list fails closed rather than reading as '
@@ -259,7 +259,7 @@ void main() {
       expect(recipients.isEmpty, isTrue);
     });
 
-    for (final role in [VoyageRole.lead, VoyageRole.sweeper]) {
+    for (final role in [VoyageRole.skipper, VoyageRole.sweeper]) {
       test('a ${role.name} offers theirs to the voyage', () {
         final recipients = SailorContactRecipients.resolve(
           localRole: role,

--- a/apps/mobile/test/services/skipper_voyage_status_test.dart
+++ b/apps/mobile/test/services/skipper_voyage_status_test.dart
@@ -10,12 +10,12 @@ void main() {
 
   test('skipper receives along-route TEC distance and estimated time gap', () {
     final status = const SkipperVoyageStatusCalculator().calculate(
-      localRole: VoyageRole.lead,
+      localRole: VoyageRole.skipper,
       localSailorId: 'lead',
       localLocation: _location(
         id: 'lead',
         name: 'Lead',
-        role: VoyageRole.lead,
+        role: VoyageRole.skipper,
         longitude: 0.015,
         speed: 10,
         at: now,
@@ -54,12 +54,12 @@ void main() {
       List<SailorLocation> sailorLocations = const [],
       Iterable<String> registeredSweeperSailorIds = const [],
     }) => const SkipperVoyageStatusCalculator().calculate(
-      localRole: VoyageRole.lead,
+      localRole: VoyageRole.skipper,
       localSailorId: 'lead',
       localLocation: _location(
         id: 'lead',
         name: 'Lead',
-        role: VoyageRole.lead,
+        role: VoyageRole.skipper,
         longitude: 0.015,
         speed: 10,
         at: now,
@@ -186,7 +186,7 @@ void main() {
 
   test('a fresh TEC without a skipper fix keeps the age but not the gap', () {
     final status = const SkipperVoyageStatusCalculator().calculate(
-      localRole: VoyageRole.lead,
+      localRole: VoyageRole.skipper,
       localSailorId: 'lead',
       localLocation: null,
       sailorLocations: [
@@ -213,12 +213,12 @@ void main() {
 
   test('closed loop uses the short gap across its start and finish', () {
     final status = const SkipperVoyageStatusCalculator().calculate(
-      localRole: VoyageRole.lead,
+      localRole: VoyageRole.skipper,
       localSailorId: 'lead',
       localLocation: _location(
         id: 'lead',
         name: 'Lead',
-        role: VoyageRole.lead,
+        role: VoyageRole.skipper,
         longitude: 0,
         speed: 10,
         at: now,
@@ -253,7 +253,7 @@ void main() {
 
   test('skipper receives simple unacknowledged off-course alerts', () {
     final status = const SkipperVoyageStatusCalculator().calculate(
-      localRole: VoyageRole.lead,
+      localRole: VoyageRole.skipper,
       localSailorId: 'lead',
       localLocation: null,
       sailorLocations: [
@@ -312,7 +312,7 @@ void main() {
       );
 
       final status = const SkipperVoyageStatusCalculator().calculate(
-        localRole: VoyageRole.lead,
+        localRole: VoyageRole.skipper,
         localSailorId: 'lead',
         localLocation: null,
         sailorLocations: [
@@ -386,7 +386,7 @@ void main() {
     // raised by another device. Only the one who is not on the skipper's actual
     // track should reach the skipper's count.
     final status = const SkipperVoyageStatusCalculator().calculate(
-      localRole: VoyageRole.lead,
+      localRole: VoyageRole.skipper,
       localSailorId: 'lead',
       localLocation: null,
       sailorLocations: [
@@ -564,12 +564,12 @@ void main() {
         ),
       ]) {
         final status = calculator.calculate(
-          localRole: VoyageRole.lead,
+          localRole: VoyageRole.skipper,
           localSailorId: 'lead',
           localLocation: _location(
             id: 'lead',
             name: 'Lead',
-            role: VoyageRole.lead,
+            role: VoyageRole.skipper,
             longitude: 0,
             speed: 10,
             at: now,

--- a/apps/mobile/test/services/stored_route_library_test.dart
+++ b/apps/mobile/test/services/stored_route_library_test.dart
@@ -324,7 +324,7 @@ CompletedVoyage _completedVoyage({
   voyageCode: voyageCode,
   voyageName: 'Sunday run',
   localDisplayName: 'Alex',
-  localRole: VoyageRole.lead,
+  localRole: VoyageRole.skipper,
   startedAt: DateTime.utc(2026, 7, 26, 9),
   endedAt: DateTime.utc(2026, 7, 26, 12),
   archivedAt: DateTime.utc(2026, 7, 26, 12, 5),

--- a/apps/mobile/test/services/sweeper_role_assignment_test.dart
+++ b/apps/mobile/test/services/sweeper_role_assignment_test.dart
@@ -429,7 +429,7 @@ void main() {
         roleChanged(
           id: 'f-handover-to',
           deviceId: 'dave',
-          role: VoyageRole.lead,
+          role: VoyageRole.skipper,
           after: const Duration(seconds: 41),
         ),
         response(
@@ -455,7 +455,7 @@ void main() {
         roleChanged(
           id: 'e-handover-to',
           deviceId: 'dave',
-          role: VoyageRole.lead,
+          role: VoyageRole.skipper,
           after: const Duration(seconds: 31),
         ),
         request(

--- a/apps/mobile/test/services/voyage_completion_detector_test.dart
+++ b/apps/mobile/test/services/voyage_completion_detector_test.dart
@@ -13,7 +13,7 @@ void main() {
 
   test('ends only when every known sailor is near the destination', () {
     final arrived = [
-      _location('lead', VoyageRole.lead, destination, now),
+      _location('lead', VoyageRole.skipper, destination, now),
       _location(
         'sweeper',
         VoyageRole.sweeper,
@@ -57,7 +57,7 @@ void main() {
       sailorLocations: [
         _location(
           'lead',
-          VoyageRole.lead,
+          VoyageRole.skipper,
           const GeoPoint(latitude: 51.5001, longitude: -2.5001),
           now,
         ),
@@ -85,7 +85,7 @@ void main() {
       detector.everyoneReachedDestination(
         destination: destination,
         sailorLocations: [
-          _location('lead', VoyageRole.lead, destination, now),
+          _location('lead', VoyageRole.skipper, destination, now),
           _location(
             'sweeper',
             VoyageRole.sweeper,
@@ -102,7 +102,7 @@ void main() {
 
   test('keeps a voyage open while the route is still ahead of the group', () {
     final atDestination = [
-      _location('lead', VoyageRole.lead, destination, now),
+      _location('lead', VoyageRole.skipper, destination, now),
     ];
 
     for (final fraction in [0.0, 0.02, 0.5, 0.89]) {
@@ -125,7 +125,7 @@ void main() {
         detector.everyoneReachedDestination(
           destination: destination,
           sailorLocations: [
-            _location('lead', VoyageRole.lead, destination, now),
+            _location('lead', VoyageRole.skipper, destination, now),
           ],
           now: now,
           routeProgressFraction: fraction,
@@ -157,7 +157,7 @@ void main() {
       }
       return detector.everyoneReachedDestination(
         destination: finish,
-        sailorLocations: [_location('lead', VoyageRole.lead, finish, now)],
+        sailorLocations: [_location('lead', VoyageRole.skipper, finish, now)],
         now: now,
         routeProgressFraction: geometry.totalMeters <= 0
             ? 0

--- a/apps/mobile/test/services/voyage_end_cost_test.dart
+++ b/apps/mobile/test/services/voyage_end_cost_test.dart
@@ -36,7 +36,7 @@ void main() {
     joinToken: 'cost-token',
     localSailorId: 'sailor-0',
     displayName: 'Oliver',
-    role: VoyageRole.lead,
+    role: VoyageRole.skipper,
     joinedAt: DateTime.utc(2026, 7, 27, 9),
   );
 
@@ -225,7 +225,7 @@ List<VoyageEvent> _journal(
     deviceId: session.localSailorId,
     type: VoyageEventType.voyageCreated,
     createdAt: session.joinedAt,
-    payload: {'role': VoyageRole.lead.name, 'displayName': 'Oliver'},
+    payload: {'role': VoyageRole.skipper.name, 'displayName': 'Oliver'},
   ),
   _signed(
     session,
@@ -265,7 +265,7 @@ VoyageEvent _locationEvent(
       'location': SailorLocation(
         sailorId: 'sailor-$sailor',
         displayName: sailor == 0 ? 'Oliver' : 'Sailor $sailor',
-        role: sailor == 0 ? VoyageRole.lead : VoyageRole.sailor,
+        role: sailor == 0 ? VoyageRole.skipper : VoyageRole.sailor,
         sample: LocationSample(
           position: GeoPoint(
             latitude: 51.46 + index * 0.00006,

--- a/apps/mobile/test/services/voyage_live_view_test.dart
+++ b/apps/mobile/test/services/voyage_live_view_test.dart
@@ -20,7 +20,7 @@ void main() {
   test('every counted sailor is either rendered or stated, never neither', () {
     final view = VoyageLiveView.reconcile(
       participants: [
-        _participant('skipper', 'Lead', role: VoyageRole.lead),
+        _participant('skipper', 'Lead', role: VoyageRole.skipper),
         _participant('follower', 'Alex'),
         _participant('sam', 'Sam'),
       ],
@@ -58,7 +58,7 @@ void main() {
     // is allowed only while the reason is on the roster row.
     final view = VoyageLiveView.reconcile(
       participants: [
-        _participant('skipper', 'Lead', role: VoyageRole.lead),
+        _participant('skipper', 'Lead', role: VoyageRole.skipper),
         _participant('follower', 'Alex', state: VoyageMembershipState.inactive),
       ],
       presence: [
@@ -84,7 +84,7 @@ void main() {
     () {
       final view = VoyageLiveView.reconcile(
         participants: [
-          _participant('skipper', 'Lead', role: VoyageRole.lead),
+          _participant('skipper', 'Lead', role: VoyageRole.skipper),
           _participant('follower', 'Alex'),
         ],
         presence: const [],
@@ -107,7 +107,7 @@ void main() {
   test('a sailor who has left is neither counted nor rendered', () {
     final view = VoyageLiveView.reconcile(
       participants: [
-        _participant('skipper', 'Lead', role: VoyageRole.lead),
+        _participant('skipper', 'Lead', role: VoyageRole.skipper),
         _participant('gone', 'Gone', state: VoyageMembershipState.left),
       ],
       presence: [
@@ -132,7 +132,7 @@ void main() {
     // is readable and it is not a marker: the sailor is not there.
     final view = VoyageLiveView.reconcile(
       participants: [
-        _participant('skipper', 'Lead', role: VoyageRole.lead),
+        _participant('skipper', 'Lead', role: VoyageRole.skipper),
         _participant(
           'gone',
           'Gone',
@@ -170,7 +170,7 @@ void main() {
   test('a stale position is still rendered, and still counted', () {
     final view = VoyageLiveView.reconcile(
       participants: [
-        _participant('skipper', 'Lead', role: VoyageRole.lead),
+        _participant('skipper', 'Lead', role: VoyageRole.skipper),
         _participant('follower', 'Alex', state: VoyageMembershipState.inactive),
       ],
       presence: [

--- a/apps/mobile/test/services/voyage_membership_departure_retention_test.dart
+++ b/apps/mobile/test/services/voyage_membership_departure_retention_test.dart
@@ -36,7 +36,7 @@ void main() {
     now: now,
     localSailorId: 'skipper',
     localDisplayName: 'Oliver',
-    localRole: VoyageRole.lead,
+    localRole: VoyageRole.skipper,
     localJoinedAt: startedAt,
     localVesselStyle: vesselIconStyleDefault,
     localSailorColor: sailorColorDefault,

--- a/apps/mobile/test/services/voyage_membership_keep_alive_test.dart
+++ b/apps/mobile/test/services/voyage_membership_keep_alive_test.dart
@@ -36,7 +36,7 @@ void main() {
     now: now,
     localSailorId: 'skipper',
     localDisplayName: 'Lead',
-    localRole: VoyageRole.lead,
+    localRole: VoyageRole.skipper,
     localJoinedAt: startedAt,
     localVesselStyle: vesselIconStyleDefault,
     localSailorColor: sailorColorDefault,

--- a/apps/mobile/test/services/voyage_membership_live_presence_test.dart
+++ b/apps/mobile/test/services/voyage_membership_live_presence_test.dart
@@ -29,7 +29,7 @@ void main() {
     now: now,
     localSailorId: 'local',
     localDisplayName: 'Oliver',
-    localRole: VoyageRole.lead,
+    localRole: VoyageRole.skipper,
     localJoinedAt: startedAt,
     localVesselStyle: vesselIconStyleDefault,
     localSailorColor: sailorColorDefault,

--- a/apps/mobile/test/services/voyage_membership_test.dart
+++ b/apps/mobile/test/services/voyage_membership_test.dart
@@ -46,7 +46,7 @@ void main() {
                 now: now,
                 localSailorId: 'skipper',
                 localDisplayName: 'Lead',
-                localRole: VoyageRole.lead,
+                localRole: VoyageRole.skipper,
                 localJoinedAt: joinedAt,
                 localVesselStyle: vesselIconStyleDefault,
                 localSailorColor: sailorColorDefault,
@@ -107,7 +107,7 @@ void main() {
       now: joinedAt.add(const Duration(minutes: 2, seconds: 30)),
       localSailorId: 'skipper',
       localDisplayName: 'Lead',
-      localRole: VoyageRole.lead,
+      localRole: VoyageRole.skipper,
       localJoinedAt: joinedAt,
       localVesselStyle: vesselIconStyleDefault,
       localSailorColor: sailorColorDefault,
@@ -193,7 +193,7 @@ void main() {
     ]) {
       final participants = reduce(ordering);
       final skippers = participants
-          .where((participant) => participant.role == VoyageRole.lead)
+          .where((participant) => participant.role == VoyageRole.skipper)
           .toList();
 
       expect(
@@ -242,7 +242,7 @@ void main() {
           now: joinedAt.add(const Duration(minutes: 1)),
           localSailorId: 'skipper',
           localDisplayName: 'Lead',
-          localRole: VoyageRole.lead,
+          localRole: VoyageRole.skipper,
           localJoinedAt: joinedAt,
           localVesselStyle: vesselIconStyleDefault,
           localSailorColor: sailorColorDefault,

--- a/apps/mobile/test/services/voyage_summary_exporter_test.dart
+++ b/apps/mobile/test/services/voyage_summary_exporter_test.dart
@@ -16,7 +16,7 @@ void main() {
       joinToken: 'test-join-token-0123456789',
       localSailorId: 'device-a',
       displayName: 'Oliver',
-      role: VoyageRole.lead,
+      role: VoyageRole.skipper,
       joinedAt: DateTime.utc(2026, 7, 16, 9, 55),
     );
     final events = [
@@ -75,7 +75,7 @@ void main() {
       joinToken: 'test-join-token-0123456789',
       localSailorId: 'device-a',
       displayName: 'Oliver',
-      role: VoyageRole.lead,
+      role: VoyageRole.skipper,
       joinedAt: DateTime.utc(2026, 7, 16, 9, 55),
     );
     final events = [
@@ -133,7 +133,7 @@ void main() {
       joinToken: 'test-join-token-0123456789',
       localSailorId: 'device-a',
       displayName: 'Oliver',
-      role: VoyageRole.lead,
+      role: VoyageRole.skipper,
       joinedAt: DateTime.utc(2026, 7, 16, 9, 55),
     );
     final events = [
@@ -177,7 +177,7 @@ void main() {
       joinToken: 'test-join-token-0123456789',
       localSailorId: 'device-a',
       displayName: 'Oliver',
-      role: VoyageRole.lead,
+      role: VoyageRole.skipper,
       joinedAt: DateTime.utc(2026, 7, 16, 9, 55),
     );
     final events = [
@@ -245,7 +245,7 @@ void main() {
       joinToken: 'test-join-token-0123456789',
       localSailorId: 'device-a',
       displayName: 'Oliver',
-      role: VoyageRole.lead,
+      role: VoyageRole.skipper,
       joinedAt: DateTime.utc(2026, 7, 16, 9, 55),
     );
     final events = [
@@ -320,7 +320,7 @@ void main() {
       joinToken: 'test-join-token-0123456789',
       localSailorId: 'device-a',
       displayName: 'Oliver',
-      role: VoyageRole.lead,
+      role: VoyageRole.skipper,
       joinedAt: DateTime.utc(2026, 7, 16, 9, 55),
     );
     const exporter = VoyageSummaryExporter();
@@ -342,7 +342,7 @@ void main() {
       joinToken: 'test-join-token-0123456789',
       localSailorId: 'device-a',
       displayName: 'Oliver',
-      role: VoyageRole.lead,
+      role: VoyageRole.skipper,
       joinedAt: DateTime.utc(2026, 7, 16, 9, 55),
     );
     final events = [
@@ -396,7 +396,7 @@ void main() {
       localSailorId: 'device-a',
       displayName: 'Oliver',
       // Solo: the sailor creates the voyage, so they lead it.
-      role: VoyageRole.lead,
+      role: VoyageRole.skipper,
       joinedAt: DateTime.utc(2026, 7, 16, 9, 55),
     );
 

--- a/apps/server/src/tide_and_seek_server/membership.py
+++ b/apps/server/src/tide_and_seek_server/membership.py
@@ -67,8 +67,16 @@ def project_membership_events(
             member.state = "left"
 
 
+# `lead` is the pre-#49 spelling of `skipper`; both are accepted so a roster
+# rebuilt from stored events keeps the skipper it had.
+KNOWN_ROLES = frozenset({"skipper", "lead", "sailor", "sweeper", "marker"})
+
+# The roles that coordinate a voyage, under either spelling.
+COORDINATOR_ROLES = frozenset({"skipper", "lead", "sweeper"})
+
+
 def safe_role(value: object) -> str:
-    if value in {"lead", "sailor", "sweeper", "marker"}:
+    if value in KNOWN_ROLES:
         return str(value)
     return "sailor"
 

--- a/apps/server/src/tide_and_seek_server/push.py
+++ b/apps/server/src/tide_and_seek_server/push.py
@@ -19,7 +19,7 @@ from sqlalchemy.orm import Session
 
 from .config import Settings
 from .crypto import DataCipher, base64url, sha256, token_hash
-from .membership import MembershipEvent, project_membership_events
+from .membership import COORDINATOR_ROLES, MembershipEvent, project_membership_events
 from .models import PushDelivery, PushRegistration, StoredEvent, Voyage, VoyageMember
 from .schemas import PushRegistrationRequest
 from .service import RelayServiceError
@@ -445,7 +445,7 @@ def classify_push_event(
     if not isinstance(event_id, str) or not isinstance(payload, dict):
         return None
     recipients = _recipient_ids(payload)
-    coordinator_roles = frozenset({"lead", "sweeper"})
+    coordinator_roles = COORDINATOR_ROLES
 
     if event_type == "statusMessage":
         message_type = payload.get("message")
@@ -480,7 +480,7 @@ def classify_push_event(
                 body="Open Tide and Seek for the latest group status.",
                 critical=False,
                 recipient_ids=recipients,
-                recipient_roles=frozenset({"lead", "sweeper", "marker"}),
+                recipient_roles=COORDINATOR_ROLES | {"marker"},
             )
         return None
 

--- a/apps/server/src/tide_and_seek_server/schemas.py
+++ b/apps/server/src/tide_and_seek_server/schemas.py
@@ -12,6 +12,15 @@ from pydantic import (
     model_validator,
 )
 
+VoyageRoleName = Literal["skipper", "lead", "sailor", "sweeper", "marker"]
+"""Roles the relay accepts on the wire.
+
+`lead` is the pre-#49 spelling of `skipper` and is still accepted, because a
+`Literal` that dropped it would 422 every payload from an app that has not
+updated - which on a boat means crew sharing silently stops working mid-passage.
+The app reads either and writes `skipper`.
+"""
+
 
 class SyncRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
@@ -52,7 +61,7 @@ class PresencePositionRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     displayName: str = Field(min_length=1, max_length=80)
-    role: Literal["lead", "sailor", "sweeper", "marker"]
+    role: VoyageRoleName
     motorcycleStyle: str = Field(min_length=1, max_length=40)
     sailorColor: str = Field(min_length=1, max_length=40)
     sample: PresenceLocationSample
@@ -137,7 +146,7 @@ class PushRegistrationRequest(BaseModel):
     platform: Literal["ios", "android"]
     provider: Literal["apns", "fcm"]
     token: str = Field(min_length=16, max_length=4096)
-    role: Literal["lead", "sailor", "sweeper", "marker"]
+    role: VoyageRoleName
     preferences: PushPreferences = Field(default_factory=PushPreferences)
 
     @model_validator(mode="after")
@@ -155,7 +164,7 @@ class PushRegistrationResponse(BaseModel):
     installationId: str
     platform: Literal["ios", "android"]
     provider: Literal["apns", "fcm"]
-    role: Literal["lead", "sailor", "sweeper", "marker"]
+    role: VoyageRoleName
     preferences: PushPreferences
     registeredAt: datetime
     updatedAt: datetime
@@ -411,7 +420,7 @@ class PublishObserverGroupParticipant(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     displayName: str = Field(min_length=1, max_length=80)
-    role: Literal["lead", "sweeper", "marker", "sailor"]
+    role: VoyageRoleName
     color: str = Field(pattern=r"^#[0-9A-Fa-f]{6}$")
     position: ObserverPosition | None
 

--- a/apps/server/tests/test_voyage_role_names.py
+++ b/apps/server/tests/test_voyage_role_names.py
@@ -1,0 +1,80 @@
+"""#49. The app renamed its `lead` role to `skipper`.
+
+`lead` is the road group-riding role the app was scaffolded from; on a boat the
+word is skipper. The rename matters here because the relay pinned the old name
+in `Literal` types, so an app sending `skipper` would have been rejected with a
+422 on every presence position, every roster projection and every push
+registration - crew sharing failing silently, mid-passage, with no error a
+sailor would understand.
+
+Both spellings are therefore accepted. These tests hold that open in both
+directions: a current app must work, and an app that has not updated must not
+be cut off.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from tide_and_seek_server.membership import COORDINATOR_ROLES, KNOWN_ROLES, safe_role
+from tide_and_seek_server.schemas import (
+    PresencePositionRequest,
+    PushRegistrationRequest,
+)
+
+
+def _position(role: str) -> dict:
+    return {
+        "displayName": "Alex",
+        "role": role,
+        "motorcycleStyle": "adventure",
+        "sailorColor": "blue",
+        "sample": {
+            "position": {"latitude": 50.75, "longitude": -1.52},
+            "recordedAt": "2026-08-19T00:00:00Z",
+            "accuracyMeters": 4,
+        },
+    }
+
+
+@pytest.mark.parametrize("role", ["skipper", "lead", "sailor", "sweeper", "marker"])
+def test_a_presence_position_is_accepted_under_either_spelling(role: str) -> None:
+    assert PresencePositionRequest.model_validate(_position(role)).role == role
+
+
+def test_a_presence_position_still_refuses_an_invented_role() -> None:
+    with pytest.raises(ValidationError):
+        PresencePositionRequest.model_validate(_position("harbourmaster"))
+
+
+@pytest.mark.parametrize("role", ["skipper", "lead"])
+def test_push_registration_accepts_either_spelling(role: str) -> None:
+    request = PushRegistrationRequest.model_validate(
+        {
+            "platform": "ios",
+            "provider": "apns",
+            "token": "0123456789abcdef0123456789abcdef",
+            "role": role,
+        }
+    )
+    assert request.role == role
+
+
+@pytest.mark.parametrize("role", sorted(KNOWN_ROLES))
+def test_a_projected_roster_keeps_every_known_role(role: str) -> None:
+    assert safe_role(role) == role
+
+
+def test_an_unknown_role_falls_back_to_sailor_rather_than_failing() -> None:
+    # A roster rebuilt from stored events must not lose a member because a
+    # newer app sent a role this relay has never heard of.
+    assert safe_role("harbourmaster") == "sailor"
+    assert safe_role(None) == "sailor"
+
+
+def test_both_spellings_of_the_skipper_coordinate_a_voyage() -> None:
+    # Push routing asks "is this a coordinator". A skipper on a current app and
+    # a skipper on an older one are the same person, and both must be told.
+    assert {"skipper", "lead"} <= COORDINATOR_ROLES
+    assert "sailor" not in COORDINATOR_ROLES


### PR DESCRIPTION
Part of #49. Found by running build 22 on an iPad simulator.

## The disagreement on screen

`VoyageRole` still labelled its roles for a road group, so the onboarding card rendered the marine **Skipper** glyph drawn for #30 with the word **Lead** underneath it. It is not a synonym problem: on a boat the skipper is the person with responsibility for the vessel, which is precisely what the role carries.

`VoyageRole.lead` is now `skipper`, across 170 sites. `voyage_roster_sheet.dart` kept its own private copy of the label switch — that copy is deleted rather than corrected, because two switches over one enum is how it drifted in the first place.

## Why a rename here is not free

`.name` is written into saved sessions, completed voyages, relay payloads and push registrations, and `VoyageRole.values.byName('lead')` throws. The place it throws is session restore, which surfaces as *"Could not restore your saved voyage"* — the exact banner this simulator run opened on.

So the wire name is now stated rather than derived:

```dart
extension VoyageRoleWire on VoyageRole {
  String get wireName => name;

  static VoyageRole? tryParse(String? value) => switch (value) {
    null => null,
    'lead' => VoyageRole.skipper,
    _ => VoyageRole.values.where((role) => role.name == value).firstOrNull,
  };
}
```

New payloads say `skipper`; anything that still says `lead` reads as one. The four `_role()` helpers that wrapped `byName` in `try/catch (ArgumentError)` now call `tryParse`, which says "null on unknown" directly — and an unrecognised role from a *newer* build now degrades to "no role stated" instead of taking the voyage down.

## The relay would have been the worse failure

`apps/server` pinned the old set in `Literal["lead", "sailor", "sweeper", "marker"]` in four schemas. An app sending `skipper` would have been refused with a **422 on every presence position, roster projection and push registration** — crew sharing failing mid-passage, with nothing a sailor could act on.

One `VoyageRoleName` alias now covers both spellings, and `COORDINATOR_ROLES` in `membership.py` replaces the two hand-written `frozenset({"lead", "sweeper"})` literals in push routing, so the next rename cannot miss a copy.

## Also

Onboarding told an iPad owner their iPad was a phone, twice, on an app whose primary surface is a mounted tablet (#28). `observer_access_sheet.dart` said it a third time. "This device" is true everywhere. (`live_presence.dart` still says "your phone number" — that one is an actual telephone number and stays.)

## Verification

- `flutter analyze` clean; `flutter test` — **1,701 pass**, 24 skipped
- `ruff format --check`, `ruff check` clean; `pytest --cov-fail-under=80` — **161 pass**, coverage **85.8%**
- 8 new Dart tests: the label, the legacy `lead` read, a round-trip of every role through its wire name, unknown-role tolerance, and a stored session carrying `lead` restoring as the skipper
- 15 new relay tests: both spellings accepted on presence and push, an invented role still refused, roster fallback, and both spellings counting as coordinators for push routing

## Deliberately left on #49

- **`Marker`** is the road role where a rider stops at a junction to show the way. #3 removed junction markers entirely, so the role outlived its feature — it is already unselectable in the picker and inescapable once held. That needs deciding, not renaming, and it touches the simulation controller.
- **The onboarding sells the wrong product.** Screen 1 leads with crew coordination and screen 2 requires a crew-facing name that "Skip tour" does not skip — so a solo sailor cannot reach a solo-first app without naming themselves for a crew they may never have. That is a product change, not a vocabulary one.