### PR TITLE
fix: stop shipping links and entitlements that cannot work (#40, #51)

### DIFF
--- a/apps/mobile/ios/Runner/DebugProfile.entitlements
+++ b/apps/mobile/ios/Runner/DebugProfile.entitlements
@@ -4,10 +4,6 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
-	<key>com.apple.developer.associated-domains</key>
-	<array>
-		<string>applinks:tideandseek.invalid</string>
-	</array>
 	<key>keychain-access-groups</key>
 	<array/>
 </dict>

--- a/apps/mobile/ios/Runner/Release.entitlements
+++ b/apps/mobile/ios/Runner/Release.entitlements
@@ -4,10 +4,6 @@
 <dict>
 	<key>aps-environment</key>
 	<string>production</string>
-	<key>com.apple.developer.associated-domains</key>
-	<array>
-		<string>applinks:tideandseek.invalid</string>
-	</array>
 	<key>keychain-access-groups</key>
 	<array/>
 </dict>

--- a/apps/mobile/lib/controllers/voyage_controller.dart
+++ b/apps/mobile/lib/controllers/voyage_controller.dart
@@ -27,7 +27,6 @@ import '../services/nearby_bridge.dart';
 import '../services/completed_voyage_archiver.dart';
 import '../services/voyage_event_authenticator.dart';
 import '../services/voyage_lifecycle.dart';
-import '../services/voyage_invitation_link.dart';
 import '../services/voyage_membership.dart';
 import '../services/received_quick_message.dart';
 import '../services/voyage_route_reducer.dart';
@@ -565,6 +564,19 @@ class VoyageController extends ChangeNotifier {
     toWholeGroup: event.payload['recipientSailorIds'] == null,
   );
 
+  /// The message sent to invite someone onto a voyage.
+  ///
+  /// Deliberately carries **no URL** (#51). It used to lead with
+  /// `voyageInvitationUrl`, which builds an `https://tideandseek.invalid/...`
+  /// address - a reserved TLD (RFC 2606) that can never resolve, on a build
+  /// with no Associated Domain to claim it and no custom URL scheme either. So
+  /// every invitation opened with the one thing in it that fails when tapped,
+  /// and offered the six digits that work underneath.
+  ///
+  /// The code comes first now because it is what the recipient will actually
+  /// type. The link returns the day there is a real domain serving an
+  /// `apple-app-site-association` file - that is #40, and one domain answers
+  /// both.
   String get voyageCodeShareText {
     final activeSession = _requireSession();
     final name = activeSession.voyageName;
@@ -573,13 +585,9 @@ class VoyageController extends ChangeNotifier {
       activeSession.voyageCode,
       activeSession.joinToken,
     );
-    final link = voyageInvitationUrl(
-      activeSession.voyageCode,
-      activeSession.joinToken,
-    );
-    return 'Join $group in Tide and Seek: $link\n\n'
-        'Enter voyage code ${activeSession.voyageCode} in the app, or paste this '
-        'private invite: $invite.';
+    return 'Join $group in Tide and Seek.\n\n'
+        'Voyage code: ${activeSession.voyageCode}\n\n'
+        'Or paste this private invite into the app: $invite';
   }
 
   Future<void> initialize() async {

--- a/apps/mobile/lib/services/voyage_invitation_link.dart
+++ b/apps/mobile/lib/services/voyage_invitation_link.dart
@@ -47,7 +47,18 @@ class VoyageInvitationLinkChannel
   }
 }
 
-/// Builds the only invitation URL format the app shares.
+/// Builds the invitation URL format the app will share once it has a domain.
+///
+/// Nothing in `lib/` calls this today (#51). The share message leads with the
+/// voyage code instead, because `tideandseek.invalid` is a reserved TLD that
+/// can never resolve and the build carries no Associated Domain and no custom
+/// URL scheme - so the link was the one part of an invitation that failed when
+/// tapped.
+///
+/// It is kept rather than deleted because the receiving half is real:
+/// `VoyageInvitationLinkController` parses links that arrive from anywhere, and
+/// it needs a builder to be tested against. The day #40 gets a real domain, the
+/// host constant changes here and the share message gets its link back.
 ///
 /// [Uri.replace] percent-encodes the `#` inside `code#token`; it remains inside
 /// the outer URL fragment and is decoded again by [Uri.fragment].

--- a/apps/mobile/test/controllers/voyage_controller_test.dart
+++ b/apps/mobile/test/controllers/voyage_controller_test.dart
@@ -463,11 +463,40 @@ void main() {
 
       expect(
         controller.voyageCodeShareText,
-        contains('voyage code ${skipperSession.voyageCode} in the'),
+        contains('Voyage code: ${skipperSession.voyageCode}'),
       );
       expect(
         controller.voyageCodeShareText,
         contains('${skipperSession.voyageCode}#${skipperSession.joinToken}'),
+      );
+    },
+  );
+
+  // #51. The message used to open with an `https://tideandseek.invalid/...`
+  // address: a reserved TLD that cannot resolve, on a build with no Associated
+  // Domain and no custom URL scheme. Every invitation therefore led with the
+  // one thing in it that failed when tapped.
+  test(
+    'voyage code share text contains nothing that fails when tapped',
+    () async {
+      await controller.createVoyage('Lead');
+
+      expect(controller.voyageCodeShareText, isNot(contains('http')));
+      expect(controller.voyageCodeShareText, isNot(contains('.invalid')));
+    },
+  );
+
+  test(
+    'the voyage code is the first actionable thing in the share text',
+    () async {
+      await controller.createVoyage('Lead');
+      final text = controller.voyageCodeShareText;
+      final activeSession = controller.session!;
+
+      expect(
+        text.indexOf('Voyage code: ${activeSession.voyageCode}'),
+        lessThan(text.indexOf(activeSession.joinToken)),
+        reason: 'the six digits are what a recipient will actually type',
       );
     },
   );


### PR DESCRIPTION
Closes #51. Closes #40.

## Every invitation led with a link that failed when tapped

```
Join "Solent weekend" in Tide and Seek: https://tideandseek.invalid/join#123456%23token

Enter voyage code 123456 in the app, or paste this private invite: 123456#token.
```

`.invalid` is an RFC 2606 reserved TLD guaranteed never to resolve. The build carries no Associated Domain that could claim it, and `Info.plist` has no `CFBundleURLTypes` at all — so there was no mechanism by which that link could open anything, in a browser or in the app. The six digits that *do* work were offered second, underneath the thing that fails.

This is in build 22, on TestFlight now.

The message now leads with what the recipient will actually type:

```
Join "Solent weekend" in Tide and Seek.

Voyage code: 123456

Or paste this private invite into the app: 123456#token
```

## The entitlement goes with it

`applinks:tideandseek.invalid` in both entitlements files was inherited scaffolding claiming a capability the app cannot use. #40 asked for a decision between "get a real domain" and "remove it"; removal is the smaller change, loses nothing today, and reverses in one line the moment a domain exists.

It is also the reason the first `flutter build ipa` failed. Before:

> `exportArchive "Runner.app" requires a provisioning profile with the Associated Domains and Push Notifications features.`

After:

> `exportArchive "Runner.app" requires a provisioning profile with the Push Notifications feature.`

Push Notifications is a capability the app genuinely uses, so that half is correct and is #42's problem (the Bundle ID has no profiles).

## What survives, and why

`voyageInvitationUrl` now has no caller in `lib/`. Kept rather than deleted, with a doc comment saying so: the *receiving* half is real — `VoyageInvitationLinkController` parses links arriving from anywhere, including ones sent by an older build — and it needs a builder to be tested against. When #40 gets a real domain, the host constant changes in one place and the share message gets its link back.

The fragment discipline is untouched: `code#token` stays in the URL fragment, which is not sent to servers. #51 flagged that as a choice worth not undoing.

## Verification

- `flutter analyze` clean; `flutter test` — **1,707 pass**, 24 skipped
- 2 new tests: the share text contains no `http` and no `.invalid`, and the voyage code appears before the token
- Built end to end: `xcodebuild -exportArchive -allowProvisioningUpdates` → **EXPORT SUCCEEDED**, and `codesign -d --entitlements` on the resulting app shows `aps-environment` and nothing else

## Deliberately not done

The Bundle ID `34RUABFBY4` still has the Associated Domains capability enabled in the developer account. Turning it off is an account-level change that forces every provisioning profile to be regenerated, for no gain — an enabled-but-unclaimed capability is inert. Worth revisiting only if App Review asks.