### PR TITLE
feat: let a sailor sail alone (#49)

### DIFF
--- a/apps/mobile/lib/controllers/sailor_profile_controller.dart
+++ b/apps/mobile/lib/controllers/sailor_profile_controller.dart
@@ -6,6 +6,18 @@ import '../domain/sailor_color.dart';
 import '../features/map/vessel_icon.dart';
 import '../services/sailor_contact_share.dart';
 
+/// The name a sailor appears under when they gave none.
+///
+/// A sailor name used to be mandatory before the app would open, and "Skip
+/// tour" did not skip it (#49) - so a solo sailor could not reach a solo-first
+/// app without first naming themselves for a crew they may never have.
+///
+/// The roster, the journal and every shared event do need *a* name, so one is
+/// supplied rather than the requirement being dropped. "Skipper" because that
+/// is what a single-handed sailor is, and because it is what a crew would call
+/// whoever set the voyage up.
+const defaultSailorName = 'Skipper';
+
 /// Remembers how a sailor last presented themselves - name, bike, colour -
 /// so the create/join voyage form starts pre-filled instead of blank every
 /// time. Deliberately separate from VoyageSession, which is scoped to one
@@ -157,7 +169,13 @@ class SailorProfileController extends ChangeNotifier {
     SailorSymbol? sailorSymbol,
     required SailorColor sailorColor,
     required bool educationSkipped,
-    required OnboardingVoyageChoice voyageChoice,
+
+    /// What to open on arrival, or null to land on the chart and sail alone.
+    ///
+    /// Nullable since #49. Onboarding used to end on "Create a voyage" or "Join
+    /// a voyage" with no third option, so a solo-first app made every new
+    /// sailor pick a crew activity before it would let them in.
+    required OnboardingVoyageChoice? voyageChoice,
   }) async {
     final normalizedName = displayName.trim();
     if (normalizedName.isEmpty) {

--- a/apps/mobile/lib/features/onboarding/onboarding_screen.dart
+++ b/apps/mobile/lib/features/onboarding/onboarding_screen.dart
@@ -27,7 +27,6 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
   int _step = 0;
   bool _educationSkipped = false;
   bool _permissionsDeferred = false;
-  String? _nameError;
   bool _saving = false;
 
   @override
@@ -107,14 +106,15 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
       ),
       const SizedBox(height: 28),
       Text(
-        'Keep the whole voyage together',
+        'Plan a passage, sail it, keep the log',
         style: Theme.of(context).textTheme.displaySmall,
       ),
       const SizedBox(height: 16),
       const Text(
-        'Tide and Seek coordinates a private crew with a shared '
-        'roster, route and safety alerts. Voyage events are kept on this device '
-        'first, then relayed by the internet or nearby devices when available.',
+        'Tide and Seek plans a passage as legs you can steer, and keeps the '
+        'voyage journal on this device. Sailing with others is optional: share '
+        'a six-digit code and the crew sees the same passage, the same roster '
+        'and the same alerts.',
         style: TextStyle(color: Color(0xFFBCC5D0), height: 1.5, fontSize: 17),
       ),
       const SizedBox(height: 24),
@@ -130,6 +130,15 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
         body:
             'Losing a relay does not erase the voyage journal on this device.',
       ),
+      const SizedBox(height: 12),
+      const _InfoCard(
+        icon: Icon(Icons.warning_amber_outlined),
+        title: 'Not a chart, and not for navigation',
+        body:
+            'Courses are direct lines between your marks, unchecked against '
+            'land, depth or traffic. Read the chart and plan the passage '
+            'yourself.',
+      ),
     ],
   );
 
@@ -137,12 +146,13 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
     crossAxisAlignment: CrossAxisAlignment.stretch,
     children: [
       Text(
-        'How the group sees you',
+        'How you appear on a shared voyage',
         style: Theme.of(context).textTheme.headlineMedium,
       ),
       const SizedBox(height: 10),
       const Text(
-        'Your saved name, symbol and colour are prefilled whenever you create or join a voyage.',
+        'Only used when you share a voyage. Your saved name, symbol and colour '
+        'are prefilled whenever you create or join one.',
         style: TextStyle(color: Color(0xFFABB5C1), height: 1.4),
       ),
       const SizedBox(height: 24),
@@ -151,12 +161,12 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
         controller: _nameController,
         maxLength: 24,
         textCapitalization: TextCapitalization.words,
-        onChanged: (_) => setState(() => _nameError = null),
         decoration: InputDecoration(
           labelText: 'Sailor name',
-          hintText: 'How the group will recognise you',
+          hintText: 'How a crew would recognise you',
+          helperText:
+              'Optional — leave it blank to sail as $defaultSailorName.',
           counterText: '',
-          errorText: _nameError,
         ),
       ),
       const SizedBox(height: 20),
@@ -386,17 +396,31 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
       ),
       const SizedBox(height: 12),
       Text(
-        '${_nameController.text.trim()}, choose how you want to begin. You can edit your profile or replay this guide from Settings.',
+        // Greets by name only when there is one. Interpolating a blank name
+        // opened this line with a comma (#49).
+        '$_greeting You can edit your profile or replay this guide from '
+        'Settings.',
         style: const TextStyle(color: Color(0xFFBCC5D0), height: 1.5),
       ),
       const SizedBox(height: 28),
+      // Sailing alone comes first, and is the primary button, because that is
+      // what this app is for. Onboarding used to offer only "Create a voyage"
+      // and "Join a voyage" - two crew activities - so a solo sailor had to
+      // pick one to get in (#49).
       FilledButton.icon(
+        key: const Key('onboarding-solo-voyage'),
+        onPressed: _saving ? null : () => _complete(null),
+        icon: const MarineGlyphIcon(MarineGlyph.sailor),
+        label: const Text('Sail on my own'),
+      ),
+      const SizedBox(height: 12),
+      OutlinedButton.icon(
         key: const Key('onboarding-create-voyage'),
         onPressed: _saving
             ? null
             : () => _complete(OnboardingVoyageChoice.create),
-        icon: const Icon(Icons.add_road),
-        label: const Text('Create a voyage'),
+        icon: const Icon(Icons.groups_outlined),
+        label: const Text('Create a voyage to share'),
       ),
       const SizedBox(height: 12),
       OutlinedButton.icon(
@@ -445,33 +469,37 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
     ),
   );
 
-  void _continue() {
-    if (_step == 1 && !_validateName()) return;
-    setState(() => _step += 1);
+  void _continue() => setState(() => _step += 1);
+
+  void _skipEducation() => setState(() {
+    _educationSkipped = true;
+    _step = _stepCount - 1;
+  });
+
+  /// The name to sail under when none was given.
+  ///
+  /// A name used to be mandatory, and "Skip tour" did not skip it (#49), so a
+  /// solo sailor could not reach a solo-first app without first naming
+  /// themselves for a crew they may never have. The roster and the journal do
+  /// need *a* name, so one is supplied rather than the requirement being
+  /// dropped - and it is stated on the field rather than appearing as a
+  /// surprise on the first shared voyage.
+  String get _displayName {
+    final typed = _nameController.text.trim();
+    return typed.isEmpty ? defaultSailorName : typed;
   }
 
-  void _skipEducation() {
-    if (!_validateName()) {
-      setState(() => _step = 1);
-      return;
-    }
-    setState(() {
-      _educationSkipped = true;
-      _step = _stepCount - 1;
-    });
+  String get _greeting {
+    final typed = _nameController.text.trim();
+    return typed.isEmpty
+        ? 'Choose how you want to begin.'
+        : '$typed, choose how you want to begin.';
   }
 
-  bool _validateName() {
-    if (_nameController.text.trim().isNotEmpty) return true;
-    setState(() => _nameError = 'Enter the name your group will recognise.');
-    return false;
-  }
-
-  Future<void> _complete(OnboardingVoyageChoice choice) async {
-    if (!_validateName()) return;
+  Future<void> _complete(OnboardingVoyageChoice? choice) async {
     setState(() => _saving = true);
     await widget.sailorProfile.completeOnboarding(
-      displayName: _nameController.text,
+      displayName: _displayName,
       vesselStyle: _vesselStyle,
       sailorSymbol: _sailorSymbol,
       sailorColor: _sailorColor,

--- a/apps/mobile/test/features/onboarding/onboarding_screen_test.dart
+++ b/apps/mobile/test/features/onboarding/onboarding_screen_test.dart
@@ -9,23 +9,15 @@ void main() {
 
   setUp(() => SharedPreferences.setMockInitialValues({}));
 
-  testWidgets('first run collects the required profile before skip', (
+  testWidgets('first run keeps the chosen profile through a skipped tour', (
     tester,
   ) async {
     final profile = await SailorProfileController.load();
     await tester.pumpWidget(_app(profile));
 
-    expect(find.text('Keep the whole voyage together'), findsOneWidget);
+    expect(find.text('Plan a passage, sail it, keep the log'), findsOneWidget);
     await tester.tap(find.byKey(const Key('onboarding-continue')));
     await tester.pumpAndSettle();
-    await tester.tap(find.byKey(const Key('skip-onboarding-tour')));
-    await tester.pump();
-
-    expect(
-      find.text('Enter the name your group will recognise.'),
-      findsOneWidget,
-    );
-    expect(profile.needsOnboarding, isTrue);
 
     await tester.enterText(
       find.byKey(const Key('onboarding-name-field')),
@@ -37,7 +29,7 @@ void main() {
     await tester.pumpAndSettle();
     await tester.enterText(
       find.byKey(const Key('sailor-custom-initials')),
-      'TEC',
+      'OJH',
     );
     await tester.pump();
     final purpleInk = find.byKey(
@@ -58,9 +50,48 @@ void main() {
     expect(profile.onboardingCompleted, isTrue);
     expect(profile.onboardingEducationSkipped, isTrue);
     expect(profile.displayName, 'Oliver');
-    expect(profile.sailorSymbol.storageValue, 'initials:v1:VEVD:purple');
+    expect(profile.sailorSymbol.storageValue, 'initials:v1:T0pI:purple');
     expect(profile.sailorColor.name, 'purple');
     expect(profile.takePendingVoyageChoice(), OnboardingVoyageChoice.join);
+  });
+
+  // #49. The name was mandatory and "Skip tour" did not skip it, so a solo
+  // sailor could not reach a solo-first app without first naming themselves for
+  // a crew they may never have.
+  testWidgets('a solo sailor can skip the tour without naming themselves', (
+    tester,
+  ) async {
+    final profile = await SailorProfileController.load();
+    await tester.pumpWidget(_app(profile));
+
+    await tester.tap(find.byKey(const Key('onboarding-continue')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('skip-onboarding-tour')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('You are ready to voyage'), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('onboarding-solo-voyage')));
+    await tester.pumpAndSettle();
+
+    expect(profile.onboardingCompleted, isTrue);
+    // The roster and the journal still need a name, so one is supplied rather
+    // than the requirement being dropped - and the field says so before the
+    // sailor gets there.
+    expect(profile.displayName, defaultSailorName);
+  });
+
+  testWidgets('the name field says what a blank one means', (tester) async {
+    final profile = await SailorProfileController.load();
+    await tester.pumpWidget(_app(profile));
+
+    await tester.tap(find.byKey(const Key('onboarding-continue')));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.textContaining('leave it blank to sail as $defaultSailorName'),
+      findsOneWidget,
+    );
   });
 
   testWidgets('permission deferral explains degradation and recovery', (
@@ -105,7 +136,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('Keep the whole voyage together'), findsOneWidget);
+    expect(find.text('Plan a passage, sail it, keep the log'), findsOneWidget);
     expect(find.byKey(const Key('onboarding-continue')), findsOneWidget);
     expect(tester.takeException(), isNull);
   });


### PR DESCRIPTION
Closes #49.

Onboarding demanded a crew-facing name before it would open the app, and **"Skip tour" did not skip it** — `_skipEducation` called `_validateName()` and sent you back to step 1. So a solo sailor could not reach a solo-first app without first naming themselves for a crew they may never have. It then finished on two buttons, *Create a voyage* and *Join a voyage*, both crew activities, with no third option.

## The name is optional

The roster, the journal and every shared event do need *a* name, so one is supplied rather than the requirement being dropped:

```dart
const defaultSailorName = 'Skipper';
```

And it is stated on the field — *"Optional — leave it blank to sail as Skipper"* — rather than arriving as a surprise on the first shared voyage. `_nameError` and `_validateName` are gone; nothing about the name gates anything now.

## The last step leads with sailing alone

**Sail on my own** is the primary button. It completes setup and lands on the chart with no sheet, which meant making `completeOnboarding`'s `voyageChoice` nullable — null being "land on the chart and get on with it". The two crew options stay, underneath, as the options they are.

## Screen one sells the right product

Before: *"Keep the whole voyage together — Tide and Seek coordinates a private crew with a shared roster, route and safety alerts."*

After: *"Plan a passage, sail it, keep the log — Tide and Seek plans a passage as legs you can steer, and keeps the voyage journal on this device. Sailing with others is optional: share a six-digit code and the crew sees the same passage, the same roster and the same alerts."*

It also gains a third card:

> **Not a chart, and not for navigation**
> Courses are direct lines between your marks, unchecked against land, depth or traffic. Read the chart and plan the passage yourself.

The first screen a TestFlight tester meets is a reasonable place to say that once, plainly.

## Two smaller things found on the way

- The finish screen interpolated the name straight into its greeting, so a blank one opened the line with a comma: *", choose how you want to begin."*
- *Create a voyage* wore `Icons.add_road`.

## Verification

- `flutter analyze` clean; `flutter test` — **1,707 pass**, 24 skipped
- 2 new widget tests: the tour skips with no name and completes as `Skipper`, and the field states what a blank one means. The old *"first run collects the required profile before skip"* test asserted the behaviour being removed and is rewritten to what it now guarantees.
- Run on an iPad Pro 11" simulator end to end: screen 1 reads correctly, Skip tour works with an empty name, the finish screen has no leading comma, and **Sail on my own** lands on the chart

## What that simulator run then found — #53

Landing on the chart as a solo sailor with no voyage shows a card reading *"Waiting for the skipper's route — This voyage has no group route yet. It will appear here when the skipper shares one."* There is no voyage, no crew and no skipper other than the person reading it.

Same inversion, one screen further on. Filed as #53 rather than folded in here, because it is the chart's empty state rather than onboarding and the crew-member version of that copy is correct and must survive.