### PR TITLE
fix: stop telling a solo sailor to wait for a skipper (#53)

### DIFF
--- a/apps/mobile/lib/features/home/home_map_backdrop.dart
+++ b/apps/mobile/lib/features/home/home_map_backdrop.dart
@@ -140,8 +140,12 @@ class _HomeMapBackdropState extends State<HomeMapBackdrop> {
             distanceUnit: widget.distanceUnit,
             onMapStyleResolved: widget.onMapStyleResolved,
             // No voyage yet, so nothing may edit a voyage's route from here and no
-            // voyage surface has anything to say.
+            // voyage surface has anything to say - including the prompt that
+            // asks where the route is. There is no route because there is no
+            // voyage, and the bottom bar already offers both ways to start one
+            // (#53).
             canEditRoute: false,
+            inVoyage: false,
             markerFeaturesEnabled: false,
           )
         else

--- a/apps/mobile/lib/features/map/voyage_map_feature.dart
+++ b/apps/mobile/lib/features/map/voyage_map_feature.dart
@@ -212,6 +212,7 @@ class VoyageMapFeature extends StatefulWidget {
     this.navigationExportCoordinator,
     this.routeStore,
     this.canEditRoute = true,
+    this.inVoyage = true,
     this.offlineTileCache,
     this.mapLibreOfflineManager,
     this.mapStyleString,
@@ -274,6 +275,7 @@ class VoyageMapFeature extends StatefulWidget {
     CompletedVoyageStore? completedVoyageStore,
     PersonalVoyageHeatmapController? personalVoyageHeatmap,
     bool canEditRoute = true,
+    bool inVoyage = true,
     DistanceUnit distanceUnit = DistanceUnit.nauticalMiles,
     bool showRouteProgress = true,
     bool darkMapStyle = false,
@@ -329,6 +331,7 @@ class VoyageMapFeature extends StatefulWidget {
     completedVoyageStore: completedVoyageStore,
     personalVoyageHeatmap: personalVoyageHeatmap,
     canEditRoute: canEditRoute,
+    inVoyage: inVoyage,
     distanceUnit: distanceUnit,
     showRouteProgress: showRouteProgress,
     basemapConfiguration: BasemapConfiguration.fromEnvironment().forBrightness(
@@ -420,6 +423,18 @@ class VoyageMapFeature extends StatefulWidget {
   final NavigationExportCoordinator? navigationExportCoordinator;
   final RouteStore? routeStore;
   final bool canEditRoute;
+
+  /// Whether this map is showing a voyage at all.
+  ///
+  /// Distinct from [canEditRoute], which answers a different question and had
+  /// been carrying both. The home screen's backdrop sets `canEditRoute: false`
+  /// because there is no voyage route to edit - and the route prompt read that
+  /// as "somebody else owns the route", so a solo sailor who had just chosen
+  /// "Sail on my own" was told to wait for a skipper who did not exist (#53).
+  ///
+  /// Three states, not two: plan one yourself, wait for the skipper, or there
+  /// is no voyage and the question does not arise.
+  final bool inVoyage;
   final OfflineTileCache? offlineTileCache;
   final MapLibreOfflineManager? mapLibreOfflineManager;
   final String? mapStyleString;
@@ -572,6 +587,7 @@ class _VoyageMapFeatureState extends State<VoyageMapFeature> {
         onLeaveVoyage: widget.onLeaveVoyage,
         onOpenVoyageMenu: widget.onOpenVoyageMenu,
         canEditRoute: widget.canEditRoute,
+        inVoyage: widget.inVoyage,
         onRouteChanged: widget.onRouteChanged,
         onRouteCommitted: widget.onRouteCommitted,
         onNavigationGuidanceChanged: widget.onNavigationGuidanceChanged,
@@ -656,6 +672,7 @@ class VoyageMapScreen extends StatefulWidget {
     this.onLeaveVoyage,
     this.onOpenVoyageMenu,
     this.canEditRoute = true,
+    this.inVoyage = true,
     this.onRouteChanged,
     this.onRouteCommitted,
     this.onNavigationGuidanceChanged,
@@ -757,6 +774,7 @@ class VoyageMapScreen extends StatefulWidget {
   final Future<void> Function()? onLeaveVoyage;
   final Future<void> Function()? onOpenVoyageMenu;
   final bool canEditRoute;
+  final bool inVoyage;
   final ValueChanged<ImportedRoute?>? onRouteChanged;
   final ValueChanged<ImportedRoute?>? onRouteCommitted;
   final ValueChanged<NavigationGuidance?>? onNavigationGuidanceChanged;
@@ -1599,7 +1617,14 @@ class _VoyageMapScreenState extends State<VoyageMapScreen> {
                 // it gives way. Route entry stays reachable from the voyage
                 // menu's "Change route" and from the app bar whenever this card
                 // is showing.
+                // `inVoyage` because "there is no route" has three causes,
+                // not two: plan one yourself, wait for the skipper, or there is
+                // no voyage and the question does not arise. The home screen's
+                // backdrop is the third, and it used to fall through to the
+                // second - telling a solo sailor to wait for a skipper who did
+                // not exist (#53).
                 if (_route == null &&
+                    widget.inVoyage &&
                     !hideChrome &&
                     !widget.voyageStarted &&
                     !_waitingRoutePromptDismissed)
@@ -1618,6 +1643,9 @@ class _VoyageMapScreenState extends State<VoyageMapScreen> {
                             onLoadDemo: _loadDemoRoute,
                             onDismiss: _continueWithoutRoute,
                           )
+                        // Only a crew member is waiting on anybody. With no
+                        // voyage at all this branch is unreachable, because the
+                        // whole prompt is gated on `inVoyage` above (#53).
                         : _WaitingForSkipperRoutePrompt(
                             onDismiss: _continueWithoutRoute,
                           ),

--- a/apps/mobile/test/features/map/voyage_map_feature_test.dart
+++ b/apps/mobile/test/features/map/voyage_map_feature_test.dart
@@ -649,6 +649,75 @@ void main() {
     expect(find.text('Choose a route'), findsNothing);
   });
 
+  // #53. The home screen's backdrop passes `canEditRoute: false` because there
+  // is no voyage route to edit. The prompt read that as "somebody else owns the
+  // route", so a solo sailor who had just chosen "Sail on my own" landed on the
+  // chart and was told to wait for a skipper who did not exist.
+  testWidgets('a map with no voyage asks nobody for a route', (tester) async {
+    final directory = Directory.systemTemp.createTempSync(
+      'map-no-voyage-no-prompt-test',
+    );
+    addTearDown(() => directory.deleteSync(recursive: true));
+    final cache = OfflineTileCache(
+      rootDirectory: directory,
+      configuration: const BasemapConfiguration(),
+      httpClient: MockClient((_) async => http.Response('', 404)),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData.dark(useMaterial3: true),
+        home: VoyageMapScreen(
+          routeStore: InMemoryRouteStore(),
+          routeImporter: RouteImporter(source: const _NoFileSource()),
+          offlineTileCache: cache,
+          // What the home backdrop passes: no voyage, so no route to edit.
+          canEditRoute: false,
+          inVoyage: false,
+          voyageStarted: false,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Waiting for the skipper’s route'), findsNothing);
+    expect(find.text('Choose a route'), findsNothing);
+    expect(find.byKey(const Key('dismiss-waiting-route-prompt')), findsNothing);
+  });
+
+  // The crew-member case must survive: someone who has joined a voyage with no
+  // shared route genuinely is waiting on the skipper, and that copy is right.
+  testWidgets('a crew member in a voyage is still told what they wait for', (
+    tester,
+  ) async {
+    final directory = Directory.systemTemp.createTempSync(
+      'map-crew-still-waits-test',
+    );
+    addTearDown(() => directory.deleteSync(recursive: true));
+    final cache = OfflineTileCache(
+      rootDirectory: directory,
+      configuration: const BasemapConfiguration(),
+      httpClient: MockClient((_) async => http.Response('', 404)),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData.dark(useMaterial3: true),
+        home: VoyageMapScreen(
+          routeStore: InMemoryRouteStore(),
+          routeImporter: RouteImporter(source: const _NoFileSource()),
+          offlineTileCache: cache,
+          canEditRoute: false,
+          inVoyage: true,
+          voyageStarted: false,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Waiting for the skipper’s route'), findsOneWidget);
+  });
+
   testWidgets('skipper can dismiss the route chooser and use the live map', (
     tester,
   ) async {


### PR DESCRIPTION
Part of #53. Found immediately after #54, by taking the new "Sail on my own" path on an iPad.

## What happened

Choose **Sail on my own**, land on the chart, and this sits over the middle of it:

> **Waiting for the skipper's route**
>
> This voyage has no group route yet. It will appear here when the skipper shares one. The skipper can also start without a route.
>
> [ Continue without a route ]

There is no voyage, no crew, and no skipper other than the person reading it. The bottom bar is simultaneously offering **New voyage** and **Join a voyage** — the app correctly saying nothing has started — while the card above describes a shared voyage waiting on somebody else.

## One flag, two questions

`home_map_backdrop.dart` passes `canEditRoute: false` for an honest reason:

```dart
// No voyage yet, so nothing may edit a voyage's route from here…
canEditRoute: false,
```

The prompt then branches on that same flag, and its `else` assumes the only other way `canEditRoute` is false: you are a crew member and the skipper owns the route.

*"There is no route"* has **three** causes, not two — plan one yourself, wait for the skipper, or there is no voyage and the question does not arise. The third is now stated rather than inferred, via `inVoyage`, and the whole prompt is gated on it.

## The crew case is untouched

Someone who has joined a voyage with no shared route genuinely is waiting on the skipper, and that copy is right for them. `inVoyage` defaults to `true`, so every existing caller keeps its behaviour, and there is a test holding it open next to the new one rather than trusting the default.

## Verification

- `flutter analyze` clean; `flutter test` — **1,709 pass**, 24 skipped
- 2 new widget tests: a map with `inVoyage: false` shows neither prompt nor its dismiss button; a map with `inVoyage: true` and `canEditRoute: false` still shows the waiting copy

## Not in scope

#53 also asked what the *right* empty state is for a solo sailor with no voyage — an invitation to import a GPX, open the demo passage, or tap the chart to place a first mark. This PR removes the wrong answer; it does not yet write the right one. The bottom bar's two buttons are what a sailor has today, and the issue stays open for the rest.