### PR TITLE
chore: 1.0.2+23 for TestFlight

### DIFF
--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.1+22
+version: 1.0.2+23
 
 environment:
   sdk: ^3.12.2


### PR DESCRIPTION
Version bump only. **Build 23 is already uploaded, processed and attached to the Internal Testing group** — this lands the bump that produced it so the repo and App Store Connect agree on what 23 was.

## What is in build 23 that was not in 22

| | |
|---|---|
| #51 | Every invitation led with a `tideandseek.invalid` link that could not open |
| #40 | The Associated Domains entitlement claimed a capability the app cannot use |
| #49 | The Skipper glyph was captioned "Lead"; the relay would have 422'd the fix |
| #49 | A crew-facing name was mandatory and "Skip tour" did not skip it |
| #49 | Onboarding sold crew coordination first on a solo-first app |
| #53 | A solo sailor with no voyage was told to wait for the skipper's route |
| #41 | The launch screen was a transparent pixel on white |
| #47 | iPad landscape stacked the chart above the detail |
| #43 | A mark on an imported passage could not be removed, and none could be named |

Six of those nine came from putting build 22 on a device.

## The release path, again by hand

Same sequence as build 22, and still not checked in — that is #42:

- `flutter build ipa` archives, then fails the export needing a provisioning profile with Push Notifications
- `xcodebuild -exportArchive -allowProvisioningUpdates` against Xcode's signed-in account succeeds
- `altool --validate-app` then `--upload-app` with the App Manager API key
- build appears in `/v1/builds` about 2½ minutes after `UPLOAD SUCCEEDED`
- attach to the beta group, then **PATCH** the auto-created `betaBuildLocalizations` rather than POST a new one — App Store Connect creates an empty en-GB record itself and a POST 409s on the duplicate locale

That last one is new since build 22 and belongs in #42's script.

## Verified

- `flutter build ipa` no longer warns about the launch image
- `EXPORT SUCCEEDED`; `VERIFY SUCCEEDED with no errors`; `UPLOAD SUCCEEDED with no errors`
- Build 23 reached `processingState: VALID`
- Group now lists builds 23 and 22; `osholt@me.com` remains `INVITED`