### PR TITLE
feat: a release path that is checked in, not in a shell history (#42)

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -37,10 +37,16 @@ jobs:
         run: uv run pip-audit --skip-editable
       - run: uv run ruff format --check .
       - run: uv run ruff check .
-      - run: uv run ruff format --check ../../tools/discovery ../../tools/tester_notify
-      - run: uv run ruff check ../../tools/discovery ../../tools/tester_notify
+      # tools/release and tools/testflight talk to App Store Connect and were
+      # neither linted nor tested here, which is how a release path grew that
+      # only one shell history knew (#42).
+      - run: uv run ruff format --check ../../tools/discovery ../../tools/tester_notify ../../tools/release ../../tools/testflight
+      - run: uv run ruff check ../../tools/discovery ../../tools/tester_notify ../../tools/release ../../tools/testflight
       - run: cd ../.. && python3 -m unittest discover -s tools/discovery/tests -v
       - run: cd ../.. && python3 -m unittest discover -s tools/tester_notify/tests -v
+      - run: cd ../.. && python3 -m unittest discover -s tools/release/tests -v
+      - run: cd ../.. && python3 -m unittest discover -s tools/testflight -p 'test_*.py' -v
+      - run: cd ../.. && bash -n tools/release/release.sh
       - run: uv run pytest --cov=tide_and_seek_server --cov-report=term-missing --cov-fail-under=80
 
   postgres-migration:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,18 @@
+Build 23. Seven fixes since build 22, most of them found by running build 22 on an iPad — which is the argument for shipping early.
+
+Fixed since build 22:
+- Every invitation used to lead with a link that could not open. It pointed at tideandseek.invalid, a reserved domain guaranteed never to resolve, with no Associated Domain and no URL scheme behind it. Invitations now lead with the six-digit code, which is what you actually type.
+- The onboarding card showed the Skipper glyph captioned "Lead" — the road group-riding role this app was scaffolded from. Skipper everywhere now. The relay was pinning the old spelling and would have rejected every crew payload once the app changed, so both sides accept both.
+- A sailor name was mandatory before the app would open, and "Skip tour" did not skip it. So a solo-first app made you name yourself for a crew you may never have. Optional now: leave it blank and you sail as Skipper.
+- Onboarding used to end on "Create a voyage" or "Join a voyage", both crew activities. "Sail on my own" is now the first option, and screen one says what the app does alone — plus a card stating plainly that this is not a chart and the courses are unchecked.
+- Choosing to sail alone then showed "Waiting for the skipper's route", to a sailor with no voyage and no crew. Gone.
+- The launch screen was Flutter's placeholder: a transparent pixel on white, so a dark app flashed white on every launch. It is the yacht from the app icon now, on the app's own background.
+- A mark added to an imported passage could not be removed — the delete button was gated on a flag that is false for exactly those passages. Marks can now be named too, and a name survives GPX.
+
+Worth trying on this build:
+- On the iPad in landscape, open a passage for review: the chart now sits beside the leg table instead of above it, both full height. This is the layout I could verify in tests but not on a running device — please tell me if it reads wrong.
+- Setup with no name at all, then "Sail on my own".
+- The demo passage (Lymington to Cowes, 5 marks, 4 legs, 8.6 NM), its leg table, and adding then naming then removing a mark.
+- Navigation instruments under way. Still the thing that most needs a real GNSS fix — the simulator has none, so nothing in it has been seen with live values.
+
+Still deliberately absent: tides, tidal streams, charted depth, wrecks and obstructions. The free UKHO data may carry a field-of-use restriction that blocks a navigation app and that question is unanswered. With no tide, a passage this plans is a passage in still water. Not a substitute for an official chart.

--- a/docs/source-baseline.md
+++ b/docs/source-baseline.md
@@ -113,3 +113,37 @@ Each carries its own `v1`. Change one only as a deliberate, versioned migration.
 Deployment-facing names *were* renamed and need config updated in step: the
 `TIDE_AND_SEEK_*` environment variables, the `tide_and_seek_*` Prometheus metric
 names, and the default database URL. `deploy/` was updated in the same commit.
+
+## Releasing to TestFlight
+
+`tools/release/release.sh` is the whole path: analyse, test, archive, export,
+validate, upload, wait for processing, attach to the internal group and set the
+tester notes from `RELEASE_NOTES.md`.
+
+Written after builds 22 and 23 were both assembled by hand and each one
+rediscovered the same traps (#42). The ones worth knowing without reading the
+script:
+
+- `flutter build ipa` archives correctly and then **fails its own export**. The
+  App Store profile must carry Push Notifications, and the Bundle ID has the
+  capability with no provisioning profile behind it. The archive is good; the
+  script exports it with `xcodebuild` instead.
+- That export needs `-allowProvisioningUpdates` **against Xcode's signed-in
+  account**. Passing the App Store Connect API key gives "Cloud signing
+  permission error" — an App Manager key can upload but cannot cloud-sign.
+- The API key must be App Manager or better. A Developer-role key can do
+  neither.
+- A build is not in `/v1/builds` when `altool` reports success. Build 23 took
+  about two and a half minutes to appear, so "not found" is a state to wait
+  through rather than an error.
+- App Store Connect creates an **empty** `betaBuildLocalizations` record for the
+  app's primary locale by itself. POSTing one 409s with "There is an entity with
+  same 'locale'", so notes are written with PATCH when a record already exists.
+
+Set `ASC_ISSUER_ID` and `ASC_KEY_ID`; the key file is read from
+`~/.appstoreconnect/private_keys/AuthKey_$ASC_KEY_ID.p8` unless
+`ASC_PRIVATE_KEY` says otherwise. No secret is checked in.
+
+Tester notes live in `RELEASE_NOTES.md` so they are reviewed in a pull request
+rather than typed into a web form, and the script refuses to publish without
+them.

--- a/tools/release/ExportOptions.plist
+++ b/tools/release/ExportOptions.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>method</key><string>app-store-connect</string>
+  <key>teamID</key><string>UY4624PH6X</string>
+  <key>signingStyle</key><string>automatic</string>
+  <key>uploadSymbols</key><true/>
+  <key>destination</key><string>export</string>
+</dict>
+</plist>

--- a/tools/release/publish_internal.py
+++ b/tools/release/publish_internal.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""Put an uploaded build in front of the internal testers.
+
+The half of a release that talks to App Store Connect: wait for processing,
+attach the build to an internal beta group, and set the "What to Test" notes
+from a file in the repository so they are reviewed in a pull request rather
+than typed into a web form.
+
+Separate from `tools/testflight/submit_external.py`, which handles external
+groups and beta review. Internal testing needs neither, and conflating them
+would put a review submission one flag away from an internal build.
+
+Two behaviours here exist because both were learned the hard way:
+
+* A build is not visible in `/v1/builds` the moment `altool` reports success.
+  It took about 2.5 minutes to appear for build 23, so "not found" is a state
+  to wait through rather than an error.
+* App Store Connect creates an empty `betaBuildLocalizations` record for the
+  app's primary locale by itself. POSTing one 409s with "There is an entity
+  with same 'locale'", so notes are written with PATCH when a record exists.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+API_ROOT = "https://api.appstoreconnect.apple.com/v1"
+TERMINAL_PROCESSING_FAILURES = {"FAILED", "INVALID"}
+
+# App Store Connect rejects longer notes outright.
+MAX_WHATS_NEW = 4_000
+
+
+class AppStoreConnectError(RuntimeError):
+    """An App Store Connect request or release precondition failed."""
+
+
+class AppStoreConnectClient:
+    def __init__(self, *, issuer_id: str, key_id: str, private_key_path: Path):
+        import jwt
+
+        now = int(time.time())
+        self._token = jwt.encode(
+            {
+                "iss": issuer_id,
+                "iat": now,
+                "exp": now + 1_200,
+                "aud": "appstoreconnect-v1",
+            },
+            private_key_path.read_text(encoding="utf-8"),
+            algorithm="ES256",
+            headers={"kid": key_id, "typ": "JWT"},
+        )
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        query: dict[str, str] | None = None,
+        body: dict[str, Any] | None = None,
+        expected: tuple[int, ...] = (200,),
+    ) -> dict[str, Any]:
+        url = f"{API_ROOT}{path}"
+        if query:
+            url = f"{url}?{urllib.parse.urlencode(query)}"
+        request = urllib.request.Request(  # noqa: S310 - see below
+            url,
+            data=None if body is None else json.dumps(body).encode(),
+            method=method,
+            headers={
+                "Authorization": f"Bearer {self._token}",
+                "Content-Type": "application/json",
+            },
+        )
+        try:
+            # S310 guards against attacker-chosen schemes. Every URL here is
+            # API_ROOT, a literal https:// constant, plus a path this module
+            # writes - there is no scheme to choose.
+            with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310
+                payload = response.read()
+                if response.status not in expected:
+                    raise AppStoreConnectError(f"{method} {path} returned HTTP {response.status}")
+                return {} if not payload else json.loads(payload)
+        except urllib.error.HTTPError as error:
+            body_text = error.read().decode(errors="replace")
+            try:
+                errors = json.loads(body_text).get("errors", [])
+                detail = "; ".join(
+                    item.get("detail") or item.get("title") or "unknown error" for item in errors
+                )
+            except json.JSONDecodeError:
+                detail = body_text[:500]
+            raise AppStoreConnectError(
+                f"{method} {path} returned HTTP {error.code}: {detail}"
+            ) from error
+
+
+def _single(items: list[dict[str, Any]], description: str) -> dict[str, Any]:
+    if len(items) != 1:
+        raise AppStoreConnectError(
+            f"Expected one {description}, App Store Connect returned {len(items)}"
+        )
+    return items[0]
+
+
+def find_app(client: Any, bundle_id: str) -> dict[str, Any]:
+    payload = client.request("GET", "/apps", query={"filter[bundleId]": bundle_id, "limit": "2"})
+    return _single(payload.get("data", []), f"app for {bundle_id}")
+
+
+def wait_for_build(
+    client: Any,
+    *,
+    app_id: str,
+    build_number: str,
+    timeout_seconds: int,
+    poll_seconds: int,
+    sleep: Any = time.sleep,
+    now: Any = time.monotonic,
+) -> dict[str, Any]:
+    """Poll until the build processes, treating "not yet visible" as normal."""
+    deadline = now() + timeout_seconds
+    last_state = "not uploaded yet"
+    while True:
+        payload = client.request(
+            "GET",
+            "/builds",
+            query={
+                "filter[app]": app_id,
+                "filter[version]": build_number,
+                "sort": "-uploadedDate",
+                "limit": "1",
+            },
+        )
+        builds = payload.get("data", [])
+        if builds:
+            build = builds[0]
+            last_state = build.get("attributes", {}).get("processingState", "unknown")
+            if last_state == "VALID":
+                return build
+            if last_state in TERMINAL_PROCESSING_FAILURES:
+                raise AppStoreConnectError(f"Build {build_number} processing ended in {last_state}")
+        if now() >= deadline:
+            raise AppStoreConnectError(
+                f"Build {build_number} did not become VALID within "
+                f"{timeout_seconds}s (last state: {last_state})"
+            )
+        print(f"Build {build_number}: {last_state}; waiting for App Store Connect")
+        sleep(poll_seconds)
+
+
+def find_internal_group(client: Any, *, app_id: str, group_name: str) -> dict[str, Any]:
+    """The named internal group.
+
+    Internal-only on purpose. Attaching a build to an external group is a
+    different act with different consequences - it needs beta review - and this
+    script must not be able to do it by being pointed at the wrong name.
+    """
+    payload = client.request("GET", "/betaGroups", query={"filter[app]": app_id, "limit": "200"})
+    matches = [
+        group
+        for group in payload.get("data", [])
+        if group.get("attributes", {}).get("name") == group_name
+        and group.get("attributes", {}).get("isInternalGroup", False)
+    ]
+    return _single(matches, f'internal beta group named "{group_name}"')
+
+
+def ensure_group_access(
+    client: Any, *, build_id: str, group: dict[str, Any], dry_run: bool
+) -> bool:
+    """Attach the build to the group. Returns whether anything changed."""
+    payload = client.request(
+        "GET", "/betaGroups", query={"filter[builds]": build_id, "limit": "200"}
+    )
+    if any(item.get("id") == group["id"] for item in payload.get("data", [])):
+        return False
+    if not dry_run:
+        client.request(
+            "POST",
+            f"/builds/{build_id}/relationships/betaGroups",
+            body={"data": [{"type": "betaGroups", "id": group["id"]}]},
+            expected=(204,),
+        )
+    return True
+
+
+def set_whats_new(client: Any, *, build_id: str, locale: str, notes: str, dry_run: bool) -> str:
+    """Write the tester-facing notes, creating or updating as required.
+
+    App Store Connect creates an empty localisation for the app's primary
+    locale by itself, and POSTing over it 409s on the duplicate locale. So the
+    existing record is looked for first.
+    """
+    notes = notes.strip()
+    if not notes:
+        raise AppStoreConnectError("Release notes are empty; refusing to publish")
+    if len(notes) > MAX_WHATS_NEW:
+        raise AppStoreConnectError(
+            f"Release notes are {len(notes)} characters; the limit is {MAX_WHATS_NEW}"
+        )
+
+    payload = client.request(
+        "GET", f"/builds/{build_id}/betaBuildLocalizations", query={"limit": "200"}
+    )
+    existing = [
+        item
+        for item in payload.get("data", [])
+        if item.get("attributes", {}).get("locale") == locale
+    ]
+    if dry_run:
+        return "updated" if existing else "created"
+    if existing:
+        localization_id = existing[0]["id"]
+        client.request(
+            "PATCH",
+            f"/betaBuildLocalizations/{localization_id}",
+            body={
+                "data": {
+                    "type": "betaBuildLocalizations",
+                    "id": localization_id,
+                    "attributes": {"whatsNew": notes},
+                }
+            },
+        )
+        return "updated"
+    client.request(
+        "POST",
+        "/betaBuildLocalizations",
+        body={
+            "data": {
+                "type": "betaBuildLocalizations",
+                "attributes": {"locale": locale, "whatsNew": notes},
+                "relationships": {"build": {"data": {"type": "builds", "id": build_id}}},
+            }
+        },
+        expected=(201,),
+    )
+    return "created"
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bundle-id", required=True)
+    parser.add_argument("--build-number", required=True)
+    parser.add_argument("--group", default="Internal Testing")
+    parser.add_argument("--locale", default="en-GB")
+    parser.add_argument("--notes", required=True, type=Path)
+    parser.add_argument("--issuer-id", required=True)
+    parser.add_argument("--key-id", required=True)
+    parser.add_argument("--private-key", required=True, type=Path)
+    parser.add_argument("--timeout-seconds", type=int, default=1_800)
+    parser.add_argument("--poll-seconds", type=int, default=30)
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        notes = args.notes.read_text(encoding="utf-8")
+    except OSError as error:
+        print(f"Cannot read release notes: {error}", file=sys.stderr)
+        return 1
+
+    try:
+        client = AppStoreConnectClient(
+            issuer_id=args.issuer_id,
+            key_id=args.key_id,
+            private_key_path=args.private_key,
+        )
+        app = find_app(client, args.bundle_id)
+        app_id = app["id"]
+        build = wait_for_build(
+            client,
+            app_id=app_id,
+            build_number=args.build_number,
+            timeout_seconds=args.timeout_seconds,
+            poll_seconds=args.poll_seconds,
+        )
+        group = find_internal_group(client, app_id=app_id, group_name=args.group)
+        attached = ensure_group_access(
+            client, build_id=build["id"], group=group, dry_run=args.dry_run
+        )
+        outcome = set_whats_new(
+            client,
+            build_id=build["id"],
+            locale=args.locale,
+            notes=notes,
+            dry_run=args.dry_run,
+        )
+    except AppStoreConnectError as error:
+        print(f"Release failed: {error}", file=sys.stderr)
+        return 1
+
+    prefix = "Would have" if args.dry_run else ""
+    print(
+        f"{prefix or 'Build'} {args.build_number} is VALID; "
+        f'{"attached to" if attached else "already in"} "{args.group}"; '
+        f"notes {outcome} for {args.locale}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/release/release.sh
+++ b/tools/release/release.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Build, sign, upload and publish an iOS build to the internal testers.
+#
+# Written because builds 22 and 23 were both assembled by hand from one
+# session's shell history, and each one rediscovered the same traps. Every
+# non-obvious step below is non-obvious for a reason recorded next to it.
+#
+#   tools/release/release.sh
+#   tools/release/release.sh --dry-run     # everything up to the upload
+#
+# Requires: Xcode signed in to the Apple Developer account, and an App Store
+# Connect API key of App Manager or better. A Developer-role key can neither
+# upload nor do cloud signing.
+set -euo pipefail
+
+BUNDLE_ID="${TIDE_AND_SEEK_BUNDLE_ID:-dev.osholt.tideandseek}"
+GROUP="${TIDE_AND_SEEK_BETA_GROUP:-Internal Testing}"
+LOCALE="${TIDE_AND_SEEK_BETA_LOCALE:-en-GB}"
+ISSUER_ID="${ASC_ISSUER_ID:-}"
+KEY_ID="${ASC_KEY_ID:-}"
+KEY_PATH="${ASC_PRIVATE_KEY:-$HOME/.appstoreconnect/private_keys/AuthKey_${KEY_ID}.p8}"
+
+DRY_RUN=0
+case "${1:-}" in
+  --dry-run) DRY_RUN=1 ;;
+  -h|--help)
+    sed -n '2,13p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    exit 0
+    ;;
+  "") ;;
+  *) echo "release: unknown option $1 (try --dry-run or --help)" >&2; exit 2 ;;
+esac
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+mobile="$repo_root/apps/mobile"
+notes="$repo_root/RELEASE_NOTES.md"
+export_options="$repo_root/tools/release/ExportOptions.plist"
+export_dir="$mobile/build/ios/release-upload"
+
+die() { printf '\nrelease: %s\n' "$1" >&2; exit 1; }
+step() { printf '\n==> %s\n' "$1"; }
+
+[[ -f "$notes" ]] || die "RELEASE_NOTES.md is missing. Tester-facing notes live in the repo so they are reviewed in a pull request."
+
+# The build number is the only source of truth for which build this is, and it
+# is what App Store Connect keys on. Read it rather than passing it in, so the
+# uploaded build and the committed pubspec cannot disagree.
+version_line="$(grep -m1 '^version:' "$mobile/pubspec.yaml")"
+marketing_version="${version_line#version: }"
+build_number="${marketing_version##*+}"
+marketing_version="${marketing_version%%+*}"
+[[ -n "$build_number" && "$build_number" != "$marketing_version" ]] \
+  || die "Cannot read a build number from pubspec.yaml ($version_line)"
+
+printf 'Releasing %s (%s) of %s to "%s"\n' \
+  "$marketing_version" "$build_number" "$BUNDLE_ID" "$GROUP"
+
+step "Tests and analysis"
+( cd "$mobile" && flutter analyze && flutter test )
+
+step "Archive"
+# `flutter build ipa` archives correctly and then fails its own export step:
+# the App Store profile must carry Push Notifications, and the Bundle ID has
+# the capability with no provisioning profile behind it. The archive it leaves
+# behind is good, so the failure is expected and swallowed here - the export
+# below is the step that must succeed.
+( cd "$mobile" && flutter build ipa --release ) || \
+  echo 'release: flutter build ipa failed at export as expected; exporting with xcodebuild'
+
+archive="$mobile/build/ios/archive/Runner.xcarchive"
+[[ -d "$archive" ]] || die "No archive at $archive; the build failed before export"
+
+step "Export a signed App Store build"
+rm -rf "$export_dir"
+# -allowProvisioningUpdates against **Xcode's signed-in account**, not the API
+# key. Passing the API key here fails with "Cloud signing permission error":
+# an App Manager key cannot do cloud signing, only upload.
+xcodebuild -exportArchive \
+  -archivePath "$archive" \
+  -exportOptionsPlist "$export_options" \
+  -exportPath "$export_dir" \
+  -allowProvisioningUpdates
+
+ipa="$(find "$export_dir" -name '*.ipa' -maxdepth 1 | head -1)"
+[[ -n "$ipa" ]] || die "Export produced no .ipa in $export_dir"
+printf 'Exported %s (%s)\n' "$(basename "$ipa")" "$(du -h "$ipa" | cut -f1)"
+
+[[ -n "$ISSUER_ID" && -n "$KEY_ID" ]] || \
+  die "Set ASC_ISSUER_ID and ASC_KEY_ID. The key must be App Manager or better; a Developer key cannot upload."
+[[ -f "$KEY_PATH" ]] || die "No API key at $KEY_PATH"
+
+step "Validate"
+xcrun altool --validate-app -f "$ipa" -t ios \
+  --apiKey "$KEY_ID" --apiIssuer "$ISSUER_ID"
+
+if (( DRY_RUN )); then
+  printf '\nrelease: --dry-run, stopping before upload. Validated %s\n' "$(basename "$ipa")"
+  exit 0
+fi
+
+step "Upload"
+xcrun altool --upload-app -f "$ipa" -t ios \
+  --apiKey "$KEY_ID" --apiIssuer "$ISSUER_ID"
+
+step "Publish to $GROUP"
+# Processing, attaching and the notes are one Python step so its behaviour is
+# testable - see tools/release/tests. In particular the notes are PATCHed when
+# App Store Connect has already made an empty localisation, which it does for
+# the app's primary locale without being asked.
+python3 "$repo_root/tools/release/publish_internal.py" \
+  --bundle-id "$BUNDLE_ID" \
+  --build-number "$build_number" \
+  --group "$GROUP" \
+  --locale "$LOCALE" \
+  --notes "$notes" \
+  --issuer-id "$ISSUER_ID" \
+  --key-id "$KEY_ID" \
+  --private-key "$KEY_PATH"
+
+printf '\nrelease: %s (%s) is live for "%s"\n' \
+  "$marketing_version" "$build_number" "$GROUP"

--- a/tools/release/tests/test_publish_internal.py
+++ b/tools/release/tests/test_publish_internal.py
@@ -1,0 +1,236 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "publish_internal.py"
+SPEC = importlib.util.spec_from_file_location("publish_internal", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+publish_internal = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(publish_internal)
+
+AppStoreConnectError = publish_internal.AppStoreConnectError
+
+
+class FakeClient:
+    """Records requests and replays queued responses."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = []
+
+    def request(self, method, path, *, query=None, body=None, expected=(200,)):
+        self.calls.append((method, path, query, body))
+        if not self._responses:
+            raise AssertionError(f"No queued response for {method} {path}")
+        return self._responses.pop(0)
+
+
+def build(state, build_id="b1"):
+    return {"id": build_id, "attributes": {"processingState": state}}
+
+
+class WaitForBuildTests(unittest.TestCase):
+    def test_returns_the_build_once_it_is_valid(self):
+        client = FakeClient([{"data": [build("VALID")]}])
+        result = publish_internal.wait_for_build(
+            client,
+            app_id="app",
+            build_number="23",
+            timeout_seconds=60,
+            poll_seconds=1,
+        )
+        self.assertEqual(result["id"], "b1")
+
+    def test_waits_through_a_build_that_is_not_visible_yet(self):
+        # altool reports success well before the build appears; build 23 took
+        # about two and a half minutes. "Not found" is a state to wait through.
+        client = FakeClient(
+            [
+                {"data": []},
+                {"data": []},
+                {"data": [build("PROCESSING")]},
+                {"data": [build("VALID")]},
+            ]
+        )
+        slept = []
+        clock = iter([0, 1, 2, 3, 4, 5])
+        result = publish_internal.wait_for_build(
+            client,
+            app_id="app",
+            build_number="23",
+            timeout_seconds=60,
+            poll_seconds=7,
+            sleep=slept.append,
+            now=lambda: next(clock),
+        )
+        self.assertEqual(result["id"], "b1")
+        self.assertEqual(slept, [7, 7, 7])
+
+    def test_a_failed_build_stops_immediately(self):
+        client = FakeClient([{"data": [build("INVALID")]}])
+        with self.assertRaises(AppStoreConnectError) as caught:
+            publish_internal.wait_for_build(
+                client,
+                app_id="app",
+                build_number="23",
+                timeout_seconds=60,
+                poll_seconds=1,
+            )
+        self.assertIn("INVALID", str(caught.exception))
+
+    def test_a_timeout_reports_the_last_state_seen(self):
+        client = FakeClient([{"data": [build("PROCESSING")]}])
+        clock = iter([0, 100])
+        with self.assertRaises(AppStoreConnectError) as caught:
+            publish_internal.wait_for_build(
+                client,
+                app_id="app",
+                build_number="23",
+                timeout_seconds=10,
+                poll_seconds=1,
+                sleep=lambda _: None,
+                now=lambda: next(clock),
+            )
+        self.assertIn("PROCESSING", str(caught.exception))
+
+
+class FindInternalGroupTests(unittest.TestCase):
+    def test_finds_the_named_internal_group(self):
+        client = FakeClient(
+            [
+                {
+                    "data": [
+                        {
+                            "id": "g1",
+                            "attributes": {"name": "Internal Testing", "isInternalGroup": True},
+                        },
+                        {
+                            "id": "g2",
+                            "attributes": {"name": "Public Beta", "isInternalGroup": False},
+                        },
+                    ]
+                }
+            ]
+        )
+        group = publish_internal.find_internal_group(
+            client, app_id="app", group_name="Internal Testing"
+        )
+        self.assertEqual(group["id"], "g1")
+
+    def test_refuses_an_external_group_with_a_matching_name(self):
+        # Attaching to an external group needs beta review and is a different
+        # act. Being pointed at the wrong name must fail, not escalate.
+        client = FakeClient(
+            [
+                {
+                    "data": [
+                        {
+                            "id": "g2",
+                            "attributes": {"name": "Internal Testing", "isInternalGroup": False},
+                        }
+                    ]
+                }
+            ]
+        )
+        with self.assertRaises(AppStoreConnectError):
+            publish_internal.find_internal_group(
+                client, app_id="app", group_name="Internal Testing"
+            )
+
+
+class EnsureGroupAccessTests(unittest.TestCase):
+    def test_attaches_a_build_that_is_not_in_the_group(self):
+        client = FakeClient([{"data": []}, {}])
+        changed = publish_internal.ensure_group_access(
+            client, build_id="b1", group={"id": "g1"}, dry_run=False
+        )
+        self.assertTrue(changed)
+        self.assertEqual(client.calls[1][0], "POST")
+
+    def test_is_idempotent(self):
+        client = FakeClient([{"data": [{"id": "g1"}]}])
+        changed = publish_internal.ensure_group_access(
+            client, build_id="b1", group={"id": "g1"}, dry_run=False
+        )
+        self.assertFalse(changed)
+        self.assertEqual(len(client.calls), 1)
+
+    def test_a_dry_run_reports_without_posting(self):
+        client = FakeClient([{"data": []}])
+        self.assertTrue(
+            publish_internal.ensure_group_access(
+                client, build_id="b1", group={"id": "g1"}, dry_run=True
+            )
+        )
+        self.assertEqual(len(client.calls), 1)
+
+
+class SetWhatsNewTests(unittest.TestCase):
+    def test_patches_the_localisation_app_store_connect_made_itself(self):
+        # The reason this function exists. App Store Connect creates an empty
+        # record for the primary locale, and POSTing over it 409s with
+        # "There is an entity with same 'locale'".
+        client = FakeClient([{"data": [{"id": "loc1", "attributes": {"locale": "en-GB"}}]}, {}])
+        outcome = publish_internal.set_whats_new(
+            client, build_id="b1", locale="en-GB", notes="What changed", dry_run=False
+        )
+        self.assertEqual(outcome, "updated")
+        method, path, _, body = client.calls[1]
+        self.assertEqual(method, "PATCH")
+        self.assertEqual(path, "/betaBuildLocalizations/loc1")
+        self.assertEqual(body["data"]["attributes"]["whatsNew"], "What changed")
+
+    def test_creates_a_localisation_for_a_locale_that_has_none(self):
+        client = FakeClient([{"data": [{"id": "loc1", "attributes": {"locale": "en-US"}}]}, {}])
+        outcome = publish_internal.set_whats_new(
+            client, build_id="b1", locale="en-GB", notes="What changed", dry_run=False
+        )
+        self.assertEqual(outcome, "created")
+        self.assertEqual(client.calls[1][0], "POST")
+
+    def test_refuses_empty_notes(self):
+        # A build with no notes tells the tester nothing about what to try, and
+        # the whole point of keeping them in the repo is that they get written.
+        client = FakeClient([])
+        with self.assertRaises(AppStoreConnectError):
+            publish_internal.set_whats_new(
+                client, build_id="b1", locale="en-GB", notes="   \n ", dry_run=False
+            )
+
+    def test_refuses_notes_longer_than_app_store_connect_accepts(self):
+        client = FakeClient([])
+        with self.assertRaises(AppStoreConnectError) as caught:
+            publish_internal.set_whats_new(
+                client,
+                build_id="b1",
+                locale="en-GB",
+                notes="x" * (publish_internal.MAX_WHATS_NEW + 1),
+                dry_run=False,
+            )
+        self.assertIn("limit", str(caught.exception))
+
+
+class ParseArgsTests(unittest.TestCase):
+    def test_defaults_to_the_internal_group_and_uk_english(self):
+        args = publish_internal.parse_args(
+            [
+                "--bundle-id",
+                "dev.osholt.tideandseek",
+                "--build-number",
+                "23",
+                "--notes",
+                "RELEASE_NOTES.md",
+                "--issuer-id",
+                "i",
+                "--key-id",
+                "k",
+                "--private-key",
+                "k.p8",
+            ]
+        )
+        self.assertEqual(args.group, "Internal Testing")
+        self.assertEqual(args.locale, "en-GB")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/testflight/submit_external.py
+++ b/tools/testflight/submit_external.py
@@ -54,7 +54,7 @@ class AppStoreConnectClient:
         if query:
             url = f"{url}?{urllib.parse.urlencode(query)}"
         encoded_body = None if body is None else json.dumps(body).encode()
-        request = urllib.request.Request(
+        request = urllib.request.Request(  # noqa: S310 - see below
             url,
             data=encoded_body,
             method=method,
@@ -64,20 +64,20 @@ class AppStoreConnectClient:
             },
         )
         try:
-            with urllib.request.urlopen(request, timeout=30) as response:
+            # S310 guards against attacker-chosen schemes. Every URL here is
+            # API_ROOT, a literal https:// constant, plus a path this module
+            # writes - there is no scheme to choose.
+            with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310
                 payload = response.read()
                 if response.status not in expected:
-                    raise AppStoreConnectError(
-                        f"{method} {path} returned HTTP {response.status}"
-                    )
+                    raise AppStoreConnectError(f"{method} {path} returned HTTP {response.status}")
                 return {} if not payload else json.loads(payload)
         except urllib.error.HTTPError as error:
             response_body = error.read().decode(errors="replace")
             try:
                 errors = json.loads(response_body).get("errors", [])
                 detail = "; ".join(
-                    item.get("detail") or item.get("title") or "unknown error"
-                    for item in errors
+                    item.get("detail") or item.get("title") or "unknown error" for item in errors
                 )
             except json.JSONDecodeError:
                 detail = response_body[:500]
@@ -131,9 +131,7 @@ def wait_for_build(
             if last_state == "VALID":
                 return build
             if last_state in TERMINAL_PROCESSING_FAILURES:
-                raise AppStoreConnectError(
-                    f"Build {build_number} processing ended in {last_state}"
-                )
+                raise AppStoreConnectError(f"Build {build_number} processing ended in {last_state}")
         if time.monotonic() >= deadline:
             raise AppStoreConnectError(
                 f"Build {build_number} did not become VALID within "
@@ -188,9 +186,7 @@ def submit_for_review(client: Any, *, build_id: str, dry_run: bool) -> tuple[str
     if submissions:
         state = submissions[0].get("attributes", {}).get("betaReviewState", "UNKNOWN")
         if state == "REJECTED":
-            raise AppStoreConnectError(
-                "The build has a rejected beta review submission"
-            )
+            raise AppStoreConnectError("The build has a rejected beta review submission")
         if state in ACTIVE_REVIEW_STATES:
             return state, False
         raise AppStoreConnectError(
@@ -264,9 +260,7 @@ def main() -> int:
     group_added = ensure_group_access(
         client, build_id=build["id"], group=group, dry_run=args.dry_run
     )
-    review_state, submitted = submit_for_review(
-        client, build_id=build["id"], dry_run=args.dry_run
-    )
+    review_state, submitted = submit_for_review(client, build_id=build["id"], dry_run=args.dry_run)
     prefix = "Would add" if args.dry_run and group_added else "Added"
     if not group_added:
         prefix = "Already assigned"


### PR DESCRIPTION
Closes #42.

Builds 22 and 23 were both assembled by hand from one session's shell history, and each one rediscovered the same traps. `tools/release/release.sh` is now the whole path — analyse, test, archive, export, validate, upload, wait, attach, notes — with every non-obvious step commented where it happens.

## The traps, all found by hitting them

- **`flutter build ipa` archives correctly and then fails its own export.** The App Store profile must carry Push Notifications, and the Bundle ID has the capability with no provisioning profile behind it. The archive it leaves is good, so the script swallows that failure deliberately and exports it with `xcodebuild`.
- **That export needs `-allowProvisioningUpdates` against Xcode's signed-in account.** Passing the App Store Connect API key instead gives *"Cloud signing permission error"* — an App Manager key can upload but cannot cloud-sign.
- **The key must be App Manager or better.** A Developer-role key can do neither.
- **A build is not in `/v1/builds` when `altool` reports success.** Build 23 took about two and a half minutes to appear, so "not found" is a state to wait through rather than an error.
- **App Store Connect creates an empty `betaBuildLocalizations` itself** for the app's primary locale. POSTing one 409s with *"There is an entity with same 'locale'"*, so notes are PATCHed when a record already exists. This one bit me an hour ago publishing build 23.

## Why the App Store Connect half is Python

So it can be tested. 14 unit tests cover `publish_internal.py`:

- the wait tolerating a build that is not visible yet, and sleeping between polls
- a `FAILED`/`INVALID` build stopping at once rather than timing out
- a timeout naming the last state it saw
- attach being idempotent, and a dry run reporting without POSTing
- notes going by PATCH when the locale exists and POST when it does not
- empty notes and over-long notes refused rather than published

`find_internal_group` insists the group is internal. Attaching a build to an external group needs beta review and is a materially different act — being pointed at the wrong name must fail, not escalate.

## Notes move into the repo

`RELEASE_NOTES.md` holds the tester-facing text, so it is reviewed in a pull request rather than typed into a web form, and the script refuses to publish without it. Build 23's notes are checked in as the first entry.

## Two things this turned up

**`tools/testflight` was neither linted nor tested in CI.** A release tool nobody checks is how the path came to live only in a shell history. Both `tools/release` and `tools/testflight` are now in the server workflow, with `bash -n` on the script as well.

**ruff's S310 fires on both ASC clients.** It guards against attacker-chosen URL schemes; every URL in these files is `API_ROOT` — a literal `https://` constant — plus a path the module writes itself. The suppression says that rather than leaving the next reader to work it out.

## Secrets

None checked in. `ASC_ISSUER_ID` and `ASC_KEY_ID` come from the environment, and the key file from `~/.appstoreconnect/private_keys/AuthKey_$ASC_KEY_ID.p8` unless `ASC_PRIVATE_KEY` overrides it.

## Verification

- `ruff format --check` and `ruff check` clean on `tools/release` and `tools/testflight`
- `python3 -m unittest discover -s tools/release/tests` — **14 pass**
- `python3 -m unittest discover -s tools/testflight` — **3 pass** (previously not run anywhere)
- `bash -n tools/release/release.sh`
- `--help` prints the header; an unknown option exits 2 rather than proceeding
- The version reader was checked against the real `pubspec.yaml` and produced the right marketing version and build number

## Not done

The script has not been run end to end, because build 23 is already up and re-uploading the same build number would be rejected. Its first real exercise is build 24. Every individual command in it is one I ran by hand for 22 and 23, and `--dry-run` stops after validation for exactly this reason.