### PR TITLE
docs: tick off what build 23 fixed, and keep what it did not

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -385,11 +385,19 @@ Not planned; discovered by putting build 22 on a device. Kept as its own group
 because "we shipped it and then looked at it" is a different kind of work from
 the phases around it, and there will be more of it after every build.
 
-- [ ] Crew roles and onboarding copy still speak road, and onboarding is
-      crew-first on a solo-first app — #49
-- [ ] Associated Domains points at a placeholder that can never resolve — #40
-- [ ] The iOS launch image is still the Flutter placeholder — #41
-- [ ] Release builds are hand-assembled and not reproducible — #42
+- [x] Crew roles and onboarding copy spoke road, and onboarding was crew-first
+      on a solo-first app — #49
+- [x] Associated Domains pointed at a placeholder that could never resolve, and
+      every invitation led with a link that could not open — #40, #51
+- [x] The iOS launch image was the Flutter placeholder — #41
+- [x] Release builds were hand-assembled and not reproducible — #42
+- [x] A solo sailor with no voyage was told to wait for the skipper's route,
+      the wrong answer removed — #53 stays open for the right one
+- [ ] The `Marker` role outlived junction markers — #57
+
+**Build 23 (1.0.2)** carries all of the above. Nine of the eleven things in this
+phase were found by putting a build on a device rather than by reading the code,
+which is the argument for doing it early and often.
 
 ### Phase 5 — Evidence before anyone sails with it
 


### PR DESCRIPTION
Bookkeeping on `PLAN.md`'s Phase 4a — the group added for what shipping a build turns up.

Ticked: #49, #40, #51, #41, #42, and the removal half of #53.

Kept open on purpose:

- **#53** — the wrong empty state is gone; the right one (import a GPX, open the demo passage, tap the chart to place a first mark) is not written.
- **#57** — new. The `Marker` role is the road group-riding role where a rider stops at a junction to show the way. #3 removed junction markers; the role stayed, already unselectable and inescapable. It needs deciding, not renaming.

The line worth keeping in the plan: **nine of the eleven items in this phase were found by putting a build on a device**, not by reading the code. That is the argument for the phase existing, and for doing it early and often.