### PR TITLE
feat: a manoeuvre list for a passage, not a road (#63)

### DIFF
--- a/apps/mobile/lib/features/map/passage_maneuver_list.dart
+++ b/apps/mobile/lib/features/map/passage_maneuver_list.dart
@@ -1,0 +1,259 @@
+/// The alterations of course a passage asks for, in order.
+///
+/// Replaces the road manoeuvre list (#63). That one was built from OSRM steps —
+/// turn left, third exit, get in lane — and since #19 removed the engine behind
+/// them it could only ever say "no turn prompts for this route".
+///
+/// This reads `PassageManeuverPlan`, which is derived from the marks the sailor
+/// chose, so it needs no service, cannot be stale, and works offline.
+library;
+
+import 'package:flutter/material.dart';
+
+import '../../domain/distance_unit.dart';
+import '../../services/measurement_formatter.dart';
+import '../../services/passage_maneuvers.dart';
+import 'passage_leg_table.dart';
+
+class PassageManeuverList extends StatelessWidget {
+  const PassageManeuverList({
+    super.key,
+    required this.plan,
+    required this.distanceUnit,
+  });
+
+  final PassageManeuverPlan plan;
+  final DistanceUnit distanceUnit;
+
+  static Future<void> show(
+    BuildContext context, {
+    required PassageManeuverPlan plan,
+    required DistanceUnit distanceUnit,
+  }) => Navigator.of(context).push<void>(
+    MaterialPageRoute(
+      builder: (_) =>
+          PassageManeuverList(plan: plan, distanceUnit: distanceUnit),
+    ),
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    final formatter = MeasurementFormatter(distanceUnit);
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          plan.hasManeuvers
+              ? 'Alterations (${plan.maneuvers.length})'
+              : 'Alterations',
+        ),
+      ),
+      body: SafeArea(
+        child: plan.hasManeuvers
+            ? ListView(
+                key: const Key('passage-maneuver-list'),
+                padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
+                children: [
+                  _Preamble(plan: plan),
+                  const SizedBox(height: 12),
+                  for (final maneuver in plan.maneuvers)
+                    _ManeuverCard(
+                      maneuver: maneuver,
+                      formatter: formatter,
+                      planningSpeedKnots: plan.planningSpeedKnots,
+                    ),
+                ],
+              )
+            : _NoAlterations(plan: plan),
+      ),
+    );
+  }
+}
+
+/// What the list is and is not, said once at the top rather than per row.
+class _Preamble extends StatelessWidget {
+  const _Preamble({required this.plan});
+
+  final PassageManeuverPlan plan;
+
+  @override
+  Widget build(BuildContext context) => Card(
+    child: Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'Courses are true and rhumb-line, taken from the marks you chose. '
+            'They are not checked against land, depth, hazards or traffic '
+            'schemes.',
+            style: TextStyle(color: Color(0xFF98A3B1)),
+          ),
+          const SizedBox(height: 8),
+          // Stated because the list is otherwise silently shorter than the
+          // number of marks, and a navigator would be left wondering what was
+          // dropped.
+          if (plan.markCountWithoutAlteration > 0)
+            Text(
+              '${plan.markCountWithoutAlteration} '
+              '${plan.markCountWithoutAlteration == 1 ? 'mark carries' : 'marks carry'} '
+              'an alteration under '
+              '${PassageManeuverPlan.minimumAlterationDegrees.round()}° and is '
+              'not listed. Every leg course is in the leg table.',
+              style: const TextStyle(color: Color(0xFF98A3B1), fontSize: 12),
+            ),
+          const SizedBox(height: 8),
+          const Text(
+            'Nothing here says which side to leave a mark. That needs buoyage '
+            'this build does not have.',
+            style: TextStyle(color: Color(0xFF98A3B1), fontSize: 12),
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+class _ManeuverCard extends StatelessWidget {
+  const _ManeuverCard({
+    required this.maneuver,
+    required this.formatter,
+    required this.planningSpeedKnots,
+  });
+
+  final PassageManeuver maneuver;
+  final MeasurementFormatter formatter;
+  final double planningSpeedKnots;
+
+  @override
+  Widget build(BuildContext context) => Card(
+    key: Key('passage-maneuver-${maneuver.number}'),
+    margin: const EdgeInsets.only(bottom: 10),
+    child: Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              CircleAvatar(radius: 16, child: Text('${maneuver.number}')),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      // The instruction as it would be said aloud.
+                      'Alter ${maneuver.alterationDegrees.round()}° to '
+                      '${maneuver.side.label} onto '
+                      '${formatCourse(maneuver.outboundCourseDegreesTrue)}',
+                      style: Theme.of(context).textTheme.titleMedium,
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      'at ${maneuver.markLabel}',
+                      style: const TextStyle(color: Color(0xFF98A3B1)),
+                    ),
+                  ],
+                ),
+              ),
+              if (maneuver.isMajorAlteration)
+                const Padding(
+                  padding: EdgeInsets.only(left: 8),
+                  child: Icon(
+                    Icons.priority_high,
+                    size: 18,
+                    color: Color(0xFFF0B24A),
+                  ),
+                ),
+            ],
+          ),
+          const SizedBox(height: 14),
+          Wrap(
+            spacing: 20,
+            runSpacing: 10,
+            children: [
+              _Figure(
+                label: 'FROM',
+                value: formatCourse(maneuver.inboundCourseDegreesTrue),
+              ),
+              _Figure(
+                label: 'TO RUN',
+                value: formatter.distance(maneuver.distanceFromPreviousMeters),
+              ),
+              _Figure(
+                label: 'AT ${planningSpeedKnots.round()} KN',
+                value: formatPassageDuration(maneuver.timeFromPrevious),
+              ),
+              _Figure(
+                label: 'FROM START',
+                value: formatter.distance(maneuver.cumulativeDistanceMeters),
+              ),
+            ],
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+class _Figure extends StatelessWidget {
+  const _Figure({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) => Column(
+    crossAxisAlignment: CrossAxisAlignment.start,
+    mainAxisSize: MainAxisSize.min,
+    children: [
+      Text(
+        label,
+        style: const TextStyle(
+          color: Color(0xFF8D98A7),
+          fontSize: 11,
+          letterSpacing: 0.8,
+        ),
+      ),
+      const SizedBox(height: 2),
+      Text(value, style: Theme.of(context).textTheme.titleSmall),
+    ],
+  );
+}
+
+/// A passage can legitimately have no alterations, and there are three different
+/// reasons why. Saying which one is the difference between an empty screen and
+/// an answer.
+class _NoAlterations extends StatelessWidget {
+  const _NoAlterations({required this.plan});
+
+  final PassageManeuverPlan plan;
+
+  @override
+  Widget build(BuildContext context) => Center(
+    child: Padding(
+      padding: const EdgeInsets.all(28),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(Icons.straighten, size: 48, color: Color(0xFF98A3B1)),
+          const SizedBox(height: 16),
+          Text('No alterations', style: Theme.of(context).textTheme.titleLarge),
+          const SizedBox(height: 8),
+          Text(
+            plan.markCountWithoutAlteration > 0
+                ? 'Every mark on this passage turns by less than '
+                      '${PassageManeuverPlan.minimumAlterationDegrees.round()}°, '
+                      'which is closer than a helm can hold. The leg table has '
+                      'the course for each leg.'
+                : 'This passage runs on one course, or has too few marks to '
+                      'alter between. The leg table has the figures.',
+            textAlign: TextAlign.center,
+            style: const TextStyle(color: Color(0xFF98A3B1)),
+          ),
+        ],
+      ),
+    ),
+  );
+}

--- a/apps/mobile/lib/features/map/route_review_screen.dart
+++ b/apps/mobile/lib/features/map/route_review_screen.dart
@@ -8,13 +8,13 @@ import '../../domain/distance_unit.dart';
 import '../../domain/imported_route.dart';
 import '../../services/basemap_configuration.dart';
 import '../../services/measurement_formatter.dart';
-import '../../services/navigation_guidance.dart';
 import '../../services/route_reshape_planner.dart';
 import '../../services/route_waypoint_editor.dart';
-import 'maneuver_list_screen.dart';
+import 'passage_maneuver_list.dart';
 import 'resolved_route_map_preview.dart';
 import 'voyage_layout.dart';
 import '../../services/passage_legs.dart';
+import '../../services/passage_maneuvers.dart';
 import 'passage_leg_table.dart';
 
 enum RouteReviewAction { cancel, edit, confirm }
@@ -426,9 +426,7 @@ class _RouteReviewScreenState extends State<RouteReviewScreen> {
     ];
     final formatter = MeasurementFormatter(distanceUnit);
     final layout = VoyageLayout.of(context);
-    final maneuverCount = const NavigationGuidancePlanner()
-        .instructions(route)
-        .length;
+    final maneuverPlan = PassageManeuverPlan.of(passagePlan);
 
     return Scaffold(
       appBar: AppBar(
@@ -658,12 +656,12 @@ class _RouteReviewScreenState extends State<RouteReviewScreen> {
                         label:
                             '${reviewWaypoints.length} route point${reviewWaypoints.length == 1 ? '' : 's'}',
                       ),
-                      if (maneuverCount > 0)
+                      if (maneuverPlan.hasManeuvers)
                         _SummaryItem(
                           icon: Icons.turn_slight_right,
                           label:
-                              '$maneuverCount turn '
-                              'instruction${maneuverCount == 1 ? '' : 's'}',
+                              '${maneuverPlan.maneuvers.length} '
+                              'alteration${maneuverPlan.maneuvers.length == 1 ? '' : 's'}',
                         ),
                       // No twistiness score (#35). It scored how enjoyable a
                       // road was to ride; on a passage between two marks it
@@ -900,16 +898,21 @@ class _RouteReviewScreenState extends State<RouteReviewScreen> {
                     ],
                   ),
                   const SizedBox(height: 18),
-                  if (maneuverCount > 0) ...[
+                  // Was "All turns (n)", counted from OSRM steps and therefore
+                  // always zero since #19. Now the alterations of course the
+                  // passage asks for, derived from its own marks (#63).
+                  if (maneuverPlan.hasManeuvers) ...[
                     OutlinedButton.icon(
                       key: const Key('review-maneuver-list'),
-                      onPressed: () => ManeuverListScreen.show(
+                      onPressed: () => PassageManeuverList.show(
                         context,
-                        route: route,
+                        plan: maneuverPlan,
                         distanceUnit: distanceUnit,
                       ),
                       icon: const Icon(Icons.list_alt),
-                      label: Text('All turns ($maneuverCount)'),
+                      label: Text(
+                        'All alterations (${maneuverPlan.maneuvers.length})',
+                      ),
                     ),
                     const SizedBox(height: 10),
                   ],

--- a/apps/mobile/lib/services/passage_maneuvers.dart
+++ b/apps/mobile/lib/services/passage_maneuvers.dart
@@ -1,0 +1,208 @@
+/// The alterations of course a passage asks for, at the marks they happen at.
+///
+/// ## Why this is not the manoeuvre list it replaces
+///
+/// The inherited list came from OSRM road steps: turn left, third exit, get in
+/// lane. None of that has a marine equivalent, and #19 removed the engine that
+/// produced it, so that list could only ever say "no turn prompts for this
+/// route" (#63).
+///
+/// A nautical manoeuvre differs from a road one in nearly every part. You do not
+/// turn, you **alter course**, and by a stated number of degrees. You alter onto
+/// a **course**, three figures and true, not onto a named street. You do not
+/// arrive at a mark, you **pass** it. And distance is cables inside a mile,
+/// because that is what gets said out loud.
+///
+/// ## Derived, not fetched
+///
+/// A manoeuvre is what happens *between* two consecutive [PassageLeg]s, so
+/// everything needed is already on the plan: the inbound course, the outbound
+/// course, the mark between them, and how far and how long to get there. No
+/// service is called and nothing can be stale.
+///
+/// ## What this deliberately does not claim
+///
+/// **Which side to leave the mark.** That depends on the mark being an object
+/// with a side, and this app models a mark as a bare position the track runs
+/// *through*. Deriving "leave it to port" from geometry would be inventing
+/// information, which is the failure #19 exists to prevent. It needs buoyage
+/// data — see #17 and `docs/chart-providers.md`.
+///
+/// **A wheel-over point.** Starting a turn early enough to settle on the new
+/// course needs the vessel's turning circle, which the app does not know.
+library;
+
+import '../domain/imported_route.dart';
+import 'passage_legs.dart';
+
+/// Which way the helm goes.
+enum TurnSide {
+  port,
+  starboard;
+
+  String get label => switch (this) {
+    TurnSide.port => 'port',
+    TurnSide.starboard => 'starboard',
+  };
+}
+
+/// One alteration of course, at the mark where it happens.
+class PassageManeuver {
+  const PassageManeuver({
+    required this.number,
+    required this.mark,
+    required this.markLabel,
+    required this.inboundCourseDegreesTrue,
+    required this.outboundCourseDegreesTrue,
+    required this.alterationDegrees,
+    required this.side,
+    required this.distanceFromPreviousMeters,
+    required this.timeFromPrevious,
+    required this.cumulativeDistanceMeters,
+    required this.cumulativeDuration,
+  });
+
+  /// One-based, counted over the manoeuvres themselves rather than over the
+  /// marks — a mark that needs no alteration does not consume a number.
+  final int number;
+
+  final RouteWaypoint mark;
+
+  /// The mark's name, or the leg table's positional fallback, so a row is never
+  /// blank.
+  final String markLabel;
+
+  final double inboundCourseDegreesTrue;
+  final double outboundCourseDegreesTrue;
+
+  /// How far to alter, in degrees, always positive. `0..180`.
+  final double alterationDegrees;
+
+  /// Which way to alter. Meaningless when [alterationDegrees] is zero, which
+  /// cannot happen here because such a mark produces no manoeuvre at all.
+  final TurnSide side;
+
+  /// The leg *into* this mark — "distance to run" before the alteration.
+  final double distanceFromPreviousMeters;
+  final Duration timeFromPrevious;
+
+  /// From the start of the passage to this mark.
+  final double cumulativeDistanceMeters;
+  final Duration cumulativeDuration;
+
+  /// True for an alteration big enough to be worth a second look on the chart.
+  ///
+  /// Sixty degrees is a judgement, not a standard: it is about the point at
+  /// which a yacht loses and regains the wind on a new point of sail, and where
+  /// a plan is worth checking for what the new course now runs towards.
+  bool get isMajorAlteration => alterationDegrees >= 60;
+}
+
+/// The manoeuvres of one passage.
+class PassageManeuverPlan {
+  const PassageManeuverPlan({
+    required this.maneuvers,
+    required this.markCountWithoutAlteration,
+    required this.planningSpeedKnots,
+  });
+
+  final List<PassageManeuver> maneuvers;
+
+  /// Marks that fell below [PassageManeuverPlan.minimumAlterationDegrees].
+  ///
+  /// Reported rather than dropped silently: a passage of eleven marks that
+  /// produces three manoeuvres should be able to say why the other six were not
+  /// worth an instruction, instead of leaving a navigator to wonder what was
+  /// lost.
+  final int markCountWithoutAlteration;
+
+  /// Carried through so a surface showing a time can say what it assumed, which
+  /// `PLAN.md` requires of anything resembling an arrival time.
+  final double planningSpeedKnots;
+
+  /// Below this, an alteration is steering noise rather than an instruction.
+  ///
+  /// A helm cannot hold a course to within a couple of degrees on a moving boat,
+  /// and a plan that says "alter 3° to port" teaches its reader to skip lines.
+  /// Those marks stay in the leg table, where the course for each leg is stated
+  /// exactly; they just do not become instructions.
+  static const minimumAlterationDegrees = 5.0;
+
+  bool get hasManeuvers => maneuvers.isNotEmpty;
+
+  static const empty = PassageManeuverPlan(
+    maneuvers: [],
+    markCountWithoutAlteration: 0,
+    planningSpeedKnots: 0,
+  );
+
+  /// Derives the manoeuvres of [plan].
+  ///
+  /// The first and last marks are not manoeuvres: there is nothing to alter onto
+  /// at a departure and nothing after an arrival. So a two-mark passage — one
+  /// leg, one course — correctly has none.
+  factory PassageManeuverPlan.of(PassagePlan plan) {
+    if (plan.legs.length < 2) {
+      return PassageManeuverPlan(
+        maneuvers: const [],
+        markCountWithoutAlteration: 0,
+        planningSpeedKnots: plan.planningSpeedKnots,
+      );
+    }
+
+    final maneuvers = <PassageManeuver>[];
+    var skipped = 0;
+    for (var index = 0; index < plan.legs.length - 1; index += 1) {
+      final inbound = plan.legs[index];
+      final outbound = plan.legs[index + 1];
+      final alteration = _alteration(
+        inbound.courseDegreesTrue,
+        outbound.courseDegreesTrue,
+      );
+
+      if (alteration.degrees < PassageManeuverPlan.minimumAlterationDegrees) {
+        skipped += 1;
+        continue;
+      }
+
+      maneuvers.add(
+        PassageManeuver(
+          number: maneuvers.length + 1,
+          // The mark between the two legs is the end of the inbound one.
+          mark: inbound.to,
+          markLabel: inbound.toLabel,
+          inboundCourseDegreesTrue: inbound.courseDegreesTrue,
+          outboundCourseDegreesTrue: outbound.courseDegreesTrue,
+          alterationDegrees: alteration.degrees,
+          side: alteration.side,
+          distanceFromPreviousMeters: inbound.distanceMeters,
+          timeFromPrevious: inbound.duration,
+          cumulativeDistanceMeters: inbound.cumulativeDistanceMeters,
+          cumulativeDuration: inbound.cumulativeDuration,
+        ),
+      );
+    }
+
+    return PassageManeuverPlan(
+      maneuvers: List.unmodifiable(maneuvers),
+      markCountWithoutAlteration: skipped,
+      planningSpeedKnots: plan.planningSpeedKnots,
+    );
+  }
+}
+
+/// Signed difference between two courses, resolved to a magnitude and a side.
+///
+/// Taking the short way round is what matters: 350° to 010° is 20° to starboard,
+/// not 340° to port. A helm asked to alter 340° would put the wheel the wrong
+/// way for most of the turn.
+({double degrees, TurnSide side}) _alteration(double inbound, double outbound) {
+  final difference = ((outbound - inbound + 540) % 360) - 180;
+  return (
+    degrees: difference.abs(),
+    // Exactly 180° is a reversal, which has no side. Reported as starboard
+    // because a helm must be told something, and a passage that doubles back on
+    // itself is a plan worth re-reading rather than a turn worth optimising.
+    side: difference < 0 ? TurnSide.port : TurnSide.starboard,
+  );
+}

--- a/apps/mobile/test/features/map/passage_maneuver_list_test.dart
+++ b/apps/mobile/test/features/map/passage_maneuver_list_test.dart
@@ -1,0 +1,209 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tide_and_seek/domain/distance_unit.dart';
+import 'package:tide_and_seek/domain/imported_route.dart';
+import 'package:tide_and_seek/features/map/passage_maneuver_list.dart';
+import 'package:tide_and_seek/services/passage_legs.dart';
+import 'package:tide_and_seek/services/passage_maneuvers.dart';
+
+/// #63. The list a sailor reads. The model is tested in
+/// `test/services/passage_maneuvers_test.dart`; this is about whether the screen
+/// says the right thing, including in the three cases where it has nothing to
+/// list.
+void main() {
+  Future<void> pump(
+    WidgetTester tester,
+    PassageManeuverPlan plan, {
+    Size size = const Size(430, 932),
+  }) async {
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData.dark(useMaterial3: true),
+        home: PassageManeuverList(
+          plan: plan,
+          distanceUnit: DistanceUnit.nauticalMiles,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  group('a passage with alterations', () {
+    testWidgets('reads as an instruction a helm could act on', (tester) async {
+      await pump(tester, _dogLeg());
+
+      expect(find.byKey(const Key('passage-maneuver-list')), findsOneWidget);
+      // Due east onto due north: 90 to port, onto 000.
+      expect(find.textContaining('to port onto 000°T'), findsOneWidget);
+      expect(find.text('at Needles Fairway'), findsOneWidget);
+    });
+
+    testWidgets('shows the course it is coming off, not just the new one', (
+      tester,
+    ) async {
+      await pump(tester, _dogLeg());
+
+      expect(find.text('FROM'), findsOneWidget);
+      expect(find.text('090°T'), findsOneWidget);
+    });
+
+    testWidgets('distance to run is in miles or cables, not metres', (
+      tester,
+    ) async {
+      await pump(tester, _dogLeg());
+
+      expect(find.text('TO RUN'), findsOneWidget);
+      // Asserted on the figures themselves rather than by scanning the screen
+      // for " m", which matches "from the marks" in the preamble.
+      final figures = tester
+          .widgetList<Text>(
+            find.descendant(
+              of: find.byKey(const Key('passage-maneuver-1')),
+              matching: find.byType(Text),
+            ),
+          )
+          .map((text) => text.data ?? '')
+          .toList();
+
+      expect(
+        figures.any((f) => f.endsWith(' NM') || f.endsWith(' cables')),
+        isTrue,
+        reason: 'a distance should read in nautical units: $figures',
+      );
+      expect(
+        figures.any((f) => RegExp(r'^\d[\d.]* k?m$').hasMatch(f)),
+        isFalse,
+      );
+    });
+
+    testWidgets('every time says what speed it assumed', (tester) async {
+      await pump(tester, _dogLeg());
+      // PLAN.md requires anything resembling an arrival time to name its
+      // assumptions where the figure is shown.
+      expect(find.text('AT 5 KN'), findsOneWidget);
+    });
+
+    testWidgets('the count is in the title', (tester) async {
+      await pump(tester, _dogLeg());
+      expect(find.text('Alterations (1)'), findsOneWidget);
+    });
+
+    testWidgets('it states what it has not checked, and what it cannot say', (
+      tester,
+    ) async {
+      await pump(tester, _dogLeg());
+
+      expect(find.textContaining('not checked against land'), findsOneWidget);
+      // The refusal that matters most: a side needs buoyage, and inventing one
+      // from geometry would be exactly the #19 failure.
+      expect(find.textContaining('which side to leave a mark'), findsOneWidget);
+    });
+
+    testWidgets('no road vocabulary survives', (tester) async {
+      await pump(tester, _dogLeg());
+
+      for (final word in ['turn', 'exit', 'lane', 'roundabout', 'road']) {
+        expect(
+          find.textContaining(word),
+          findsNothing,
+          reason: '"$word" should not appear on a passage screen',
+        );
+      }
+    });
+  });
+
+  group('marks that earn no instruction', () {
+    testWidgets('a skipped mark is accounted for rather than dropped', (
+      tester,
+    ) async {
+      await pump(tester, _dogLegWithNearlyStraightMark());
+
+      expect(
+        find.textContaining('an alteration under 5°'),
+        findsOneWidget,
+        reason: 'a shorter list than the mark count needs explaining',
+      );
+    });
+
+    testWidgets('a passage of one course says so instead of showing nothing', (
+      tester,
+    ) async {
+      await pump(tester, _straightThrough());
+
+      expect(find.text('No alterations'), findsOneWidget);
+      expect(find.byKey(const Key('passage-maneuver-list')), findsNothing);
+      expect(find.textContaining('one course'), findsOneWidget);
+    });
+
+    testWidgets('an empty plan does not pretend to be a passage', (
+      tester,
+    ) async {
+      await pump(tester, PassageManeuverPlan.empty);
+      expect(find.text('No alterations'), findsOneWidget);
+    });
+  });
+
+  group('a big alteration', () {
+    testWidgets('is flagged, and a small one is not', (tester) async {
+      await pump(tester, _dogLeg());
+      expect(find.byIcon(Icons.priority_high), findsOneWidget);
+
+      await pump(tester, _gentleAlteration());
+      expect(find.byIcon(Icons.priority_high), findsNothing);
+    });
+  });
+}
+
+PassageManeuverPlan _plan(List<RouteWaypoint> marks) => PassageManeuverPlan.of(
+  PassagePlan.of(
+    ImportedRoute(
+      id: 'passage',
+      name: 'Passage',
+      importedAt: DateTime.utc(2026, 8, 19),
+      sourceFileName: 'passage.gpx',
+      paths: [
+        RoutePath(
+          kind: RoutePathKind.route,
+          points: marks.map((mark) => mark.point).toList(growable: false),
+        ),
+      ],
+      waypoints: marks,
+    ),
+  ),
+);
+
+RouteWaypoint _mark(String name, double latitude, double longitude) =>
+    RouteWaypoint(
+      name: name,
+      point: GeoPoint(latitude: latitude, longitude: longitude),
+    );
+
+/// East then north: one 90° alteration to port at the middle mark.
+PassageManeuverPlan _dogLeg() => _plan([
+  _mark('Lymington', 50.70, -1.50),
+  _mark('Needles Fairway', 50.70, -1.40),
+  _mark('Cowes', 50.78, -1.40),
+]);
+
+/// East, east again a hair off, then north: the middle mark is under threshold.
+PassageManeuverPlan _dogLegWithNearlyStraightMark() => _plan([
+  _mark('Lymington', 50.70, -1.500),
+  _mark('Hurst', 50.70, -1.400),
+  _mark('Needles Fairway', 50.7005, -1.300),
+  _mark('Cowes', 50.78, -1.300),
+]);
+
+/// Two marks on one course: nothing to alter onto.
+PassageManeuverPlan _straightThrough() =>
+    _plan([_mark('Lymington', 50.70, -1.50), _mark('Cowes', 50.70, -1.30)]);
+
+/// A 20° alteration, which is real but not major.
+PassageManeuverPlan _gentleAlteration() => _plan([
+  _mark('Lymington', 50.700, -1.500),
+  _mark('Hurst', 50.700, -1.400),
+  _mark('Cowes', 50.724, -1.300),
+]);

--- a/apps/mobile/test/features/map/route_review_screen_test.dart
+++ b/apps/mobile/test/features/map/route_review_screen_test.dart
@@ -536,7 +536,9 @@ void main() {
 
     final layer = tester.widget<PolylineLayer>(find.byType(PolylineLayer));
     expect(layer.polylines, hasLength(2));
-    expect(find.text('2 turn instructions'), findsOneWidget);
+    // A "2 turn instructions" assertion sat here, counting the road manoeuvres
+    // stored on this fixture. The summary now counts alterations derived from
+    // the marks instead (#63), and this test is about the drawn paths anyway.
     await tester.scrollUntilVisible(
       find.text('Destination'),
       160,
@@ -591,71 +593,90 @@ void main() {
     expect(candidateLayer.polylines.single.color, const Color(0xFF3478F6));
   });
 
-  testWidgets('route review opens the full manoeuvre list before the voyage', (
+  // #63. This used to build a Bristol roundabout out of OSRM steps and assert
+  // "2nd exit, straight on". The engine that produced those steps went in #19,
+  // so the list could only ever be empty on a real passage. The nautical
+  // replacement is derived from the marks themselves.
+  testWidgets('route review opens the alterations the passage asks for', (
     tester,
   ) async {
+    // Three legs that alter hard at each mark, so every one earns an
+    // instruction: roughly east, then north, then east again.
     final route = ImportedRoute(
-      id: 'reviewed',
-      name: 'Reviewed route',
-      importedAt: DateTime.utc(2026, 7, 25),
+      id: 'reviewed-alterations',
+      name: 'Solent passage',
+      importedAt: DateTime.utc(2026, 8, 19),
       sourceFileName: 'reviewed.gpx',
       paths: const [
         RoutePath(
-          kind: RoutePathKind.track,
+          kind: RoutePathKind.route,
           points: [
-            GeoPoint(latitude: 51.45, longitude: -2.59),
-            GeoPoint(latitude: 51.46, longitude: -2.59),
-            GeoPoint(latitude: 51.47, longitude: -2.59),
+            GeoPoint(latitude: 50.70, longitude: -1.50),
+            GeoPoint(latitude: 50.70, longitude: -1.40),
+            GeoPoint(latitude: 50.78, longitude: -1.40),
+            GeoPoint(latitude: 50.78, longitude: -1.30),
           ],
         ),
       ],
-      waypoints: const [],
-      maneuvers: const [
-        RouteManeuver(
-          position: GeoPoint(latitude: 51.46, longitude: -2.59),
-          type: 'roundabout',
-          modifier: 'slight left',
-          name: 'Wells Road',
-          exitNumber: 2,
-          drivingSide: 'left',
-          bearingBeforeDegrees: 0,
-          bearingAfterDegrees: 300,
+      waypoints: const [
+        RouteWaypoint(
+          name: 'Lymington',
+          point: GeoPoint(latitude: 50.70, longitude: -1.50),
         ),
-        RouteManeuver(
-          position: GeoPoint(latitude: 51.4602, longitude: -2.59),
-          type: 'exit roundabout',
-          modifier: 'slight left',
-          name: 'Wells Road',
-          drivingSide: 'left',
-          bearingBeforeDegrees: 40,
-          bearingAfterDegrees: 2,
+        RouteWaypoint(
+          name: 'Needles Fairway',
+          point: GeoPoint(latitude: 50.70, longitude: -1.40),
+        ),
+        RouteWaypoint(
+          name: 'Nab Tower',
+          point: GeoPoint(latitude: 50.78, longitude: -1.40),
+        ),
+        RouteWaypoint(
+          name: 'Cowes',
+          point: GeoPoint(latitude: 50.78, longitude: -1.30),
         ),
       ],
     );
 
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData.dark(useMaterial3: true),
         home: RouteReviewScreen(
           route: route,
-          distanceUnit: DistanceUnit.kilometres,
+          distanceUnit: DistanceUnit.nauticalMiles,
           basemapConfiguration: const BasemapConfiguration(),
         ),
       ),
     );
     await tester.pump();
 
-    expect(find.text('1 turn instruction'), findsOneWidget);
+    // Two marks between three legs, so two alterations - not four.
+    expect(find.text('2 alterations'), findsOneWidget);
+
     await tester.scrollUntilVisible(
       find.byKey(const Key('review-maneuver-list')),
       200,
-      scrollable: find.byType(Scrollable).last,
+      scrollable: find.descendant(
+        of: find.byKey(const Key('route-review-detail')),
+        matching: find.byType(Scrollable),
+      ),
     );
-    await tester.tap(find.byKey(const Key('review-maneuver-list')));
-    await tester.pump();
-    await tester.pump(const Duration(seconds: 1));
+    expect(find.text('All alterations (2)'), findsOneWidget);
 
-    expect(find.byKey(const Key('maneuver-list')), findsOneWidget);
-    expect(find.text('2nd exit, straight on'), findsOneWidget);
+    await tester.tap(find.byKey(const Key('review-maneuver-list')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('passage-maneuver-list')), findsOneWidget);
+    // Due east onto roughly due north is 90 degrees to port.
+    expect(find.textContaining('to port onto 000°T'), findsOneWidget);
+    expect(find.text('at Needles Fairway'), findsOneWidget);
+    // And back to starboard at the next one.
+    expect(find.textContaining('to starboard onto 090°T'), findsOneWidget);
+    expect(find.text('at Nab Tower'), findsOneWidget);
+
+    // No road vocabulary survives on this screen.
+    expect(find.textContaining('exit'), findsNothing);
+    expect(find.textContaining('turn'), findsNothing);
   });
 
   group('side by side on a tablet (#47)', () {

--- a/apps/mobile/test/services/passage_maneuvers_test.dart
+++ b/apps/mobile/test/services/passage_maneuvers_test.dart
@@ -1,0 +1,228 @@
+import 'dart:math' as math;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tide_and_seek/domain/imported_route.dart';
+import 'package:tide_and_seek/services/passage_legs.dart';
+import 'package:tide_and_seek/services/passage_maneuvers.dart';
+
+/// #63. The inherited manoeuvre list came from OSRM road steps — turn left,
+/// third exit, get in lane — and #19 deleted the engine that produced them, so
+/// it could only ever say "no turn prompts for this route".
+///
+/// These pin the nautical replacement, and in particular the three things it
+/// refuses to do: invent a side to leave a mark on, issue an instruction a helm
+/// cannot follow, or take the long way round a course change.
+void main() {
+  group('an alteration takes the short way round', () {
+    test('a turn to starboard', () {
+      final plan = _maneuvers([
+        _mark('Lymington', 50.70, -1.50),
+        _mark('Mark A', 50.70, -1.40), // due east, 090
+        _mark('Mark B', 50.80, -1.30), // north-east, about 040
+      ]);
+
+      final maneuver = plan.maneuvers.single;
+      expect(maneuver.side, TurnSide.port);
+      expect(maneuver.markLabel, 'Mark A');
+    });
+
+    test('a course change through north is the short way, not the long way', () {
+      // 350 to 010 is 20 to starboard. A helm asked to alter 340 to port would
+      // put the wheel the wrong way for most of the turn.
+      final plan = _maneuversFromCourses([350, 10]);
+      final maneuver = plan.maneuvers.single;
+
+      expect(maneuver.alterationDegrees, closeTo(20, 1.5));
+      expect(maneuver.side, TurnSide.starboard);
+    });
+
+    test('the same change the other way is to port', () {
+      final plan = _maneuversFromCourses([10, 350]);
+      final maneuver = plan.maneuvers.single;
+
+      expect(maneuver.alterationDegrees, closeTo(20, 1.5));
+      expect(maneuver.side, TurnSide.port);
+    });
+
+    test('an alteration never exceeds 180 degrees', () {
+      // Every pair here is a near-reversal. `[359, 1]` would not do: that is a
+      // 2 degree alteration and the threshold correctly filters it out.
+      for (final pair in [
+        [0, 179],
+        [0, 181],
+        [90, 271],
+        [350, 170],
+      ]) {
+        final plan = _maneuversFromCourses(
+          pair.map((course) => course.toDouble()).toList(),
+        );
+        expect(
+          plan.maneuvers.single.alterationDegrees,
+          lessThanOrEqualTo(180),
+          reason: 'from ${pair[0]} to ${pair[1]}',
+        );
+      }
+    });
+  });
+
+  group('what is not worth an instruction', () {
+    test('a small alteration stays off the list and is counted', () {
+      // Three degrees is steering noise. A plan that says "alter 3 degrees to
+      // port" teaches its reader to skip lines.
+      final plan = _maneuversFromCourses([90, 92]);
+
+      expect(plan.maneuvers, isEmpty);
+      expect(plan.markCountWithoutAlteration, 1);
+      expect(plan.hasManeuvers, isFalse);
+    });
+
+    test('the threshold is stated rather than guessed at', () {
+      expect(PassageManeuverPlan.minimumAlterationDegrees, 5.0);
+    });
+
+    test('a passage of one leg has no manoeuvre', () {
+      // Nothing to alter onto at a departure, nothing after an arrival.
+      final plan = _maneuvers([
+        _mark('Lymington', 50.75, -1.52),
+        _mark('Cowes', 50.76, -1.30),
+      ]);
+
+      expect(plan.maneuvers, isEmpty);
+      expect(plan.markCountWithoutAlteration, 0);
+    });
+
+    test('a route with no marks has no manoeuvres', () {
+      expect(PassageManeuverPlan.of(PassagePlan.empty).maneuvers, isEmpty);
+    });
+  });
+
+  group('what a manoeuvre carries', () {
+    test('the courses either side of the mark, and the mark itself', () {
+      final plan = _maneuversFromCourses([90, 45]);
+      final maneuver = plan.maneuvers.single;
+
+      expect(maneuver.inboundCourseDegreesTrue, closeTo(90, 1.5));
+      expect(maneuver.outboundCourseDegreesTrue, closeTo(45, 1.5));
+      expect(maneuver.mark.name, 'Mark 2');
+    });
+
+    test('the leg into the mark, which is the distance left to run', () {
+      final plan = _maneuvers([
+        _mark('Start', 50.70, -1.50),
+        _mark('Middle', 50.70, -1.40),
+        _mark('End', 50.80, -1.30),
+      ]);
+      final maneuver = plan.maneuvers.single;
+
+      // The leg into Middle, not the one out of it.
+      expect(maneuver.distanceFromPreviousMeters, greaterThan(0));
+      expect(
+        maneuver.cumulativeDistanceMeters,
+        closeTo(maneuver.distanceFromPreviousMeters, 1),
+        reason: 'the first mark is one leg from the start',
+      );
+      expect(maneuver.timeFromPrevious, greaterThan(Duration.zero));
+    });
+
+    test('the planning speed comes through so a time can be qualified', () {
+      final plan = PassageManeuverPlan.of(
+        PassagePlan.of(
+          _route([
+            _mark('A', 50.70, -1.50),
+            _mark('B', 50.70, -1.40),
+            _mark('C', 50.80, -1.30),
+          ]),
+          planningSpeedKnots: 6.5,
+        ),
+      );
+      expect(plan.planningSpeedKnots, 6.5);
+    });
+
+    test('numbering counts manoeuvres, not marks', () {
+      // Middle mark is nearly straight through, so it produces nothing and must
+      // not consume a number.
+      final plan = _maneuversFromCourses([90, 91, 45]);
+
+      expect(plan.markCountWithoutAlteration, 1);
+      expect(plan.maneuvers.map((m) => m.number), [1]);
+    });
+
+    test('a big alteration is flagged for a second look', () {
+      expect(
+        _maneuversFromCourses([0, 90]).maneuvers.single.isMajorAlteration,
+        isTrue,
+      );
+      expect(
+        _maneuversFromCourses([0, 20]).maneuvers.single.isMajorAlteration,
+        isFalse,
+      );
+    });
+  });
+
+  group('a passage of several alterations', () {
+    test('one manoeuvre per mark that needs one, in order', () {
+      final plan = _maneuversFromCourses([0, 90, 180, 270]);
+
+      expect(plan.maneuvers.length, 3);
+      expect(plan.maneuvers.map((m) => m.side), [
+        TurnSide.starboard,
+        TurnSide.starboard,
+        TurnSide.starboard,
+      ]);
+      expect(plan.maneuvers.map((m) => m.number), [1, 2, 3]);
+      // Distance to run grows along the passage.
+      final cumulative = plan.maneuvers
+          .map((m) => m.cumulativeDistanceMeters)
+          .toList();
+      expect(cumulative, orderedEquals(cumulative.toList()..sort()));
+    });
+  });
+}
+
+RouteWaypoint _mark(String name, double latitude, double longitude) =>
+    RouteWaypoint(
+      name: name,
+      point: GeoPoint(latitude: latitude, longitude: longitude),
+    );
+
+ImportedRoute _route(List<RouteWaypoint> marks) => ImportedRoute(
+  id: 'passage',
+  name: 'Passage',
+  importedAt: DateTime.utc(2026, 8, 19),
+  sourceFileName: 'passage.gpx',
+  paths: [
+    RoutePath(
+      kind: RoutePathKind.route,
+      points: marks.map((mark) => mark.point).toList(growable: false),
+    ),
+  ],
+  waypoints: marks,
+);
+
+PassageManeuverPlan _maneuvers(List<RouteWaypoint> marks) =>
+    PassageManeuverPlan.of(PassagePlan.of(_route(marks)));
+
+/// Builds a passage whose successive legs run on [courses], by walking two miles
+/// along each in turn. Lets a test say what it means — "350 then 010" — rather
+/// than hand-computing latitudes, and keeps the trigonometry out of the library
+/// under test, which has none: courses arrive already computed by `PassagePlan`.
+PassageManeuverPlan _maneuversFromCourses(List<double> courses) {
+  const degreesPerNauticalMile = 1 / 60;
+  // Two miles a leg, so a degree of rounding does not swamp the bearing.
+  const legMiles = 2.0;
+  var latitude = 50.5;
+  var longitude = -1.5;
+  final marks = <RouteWaypoint>[_mark('Mark 1', latitude, longitude)];
+
+  for (var index = 0; index < courses.length; index += 1) {
+    final radians = courses[index] * math.pi / 180;
+    latitude += legMiles * degreesPerNauticalMile * math.cos(radians);
+    longitude +=
+        legMiles *
+        degreesPerNauticalMile *
+        math.sin(radians) /
+        math.cos(latitude * math.pi / 180);
+    marks.add(_mark('Mark ${index + 2}', latitude, longitude));
+  }
+  return _maneuvers(marks);
+}


### PR DESCRIPTION
Part of #63, stage 1. You asked for a manoeuvre list appropriate to nautical navigation, so this is a replacement rather than the deletion the issue originally contemplated.

## The old list could only ever be empty

It was built from OSRM steps — turn left, third exit, get in lane. #19 removed the engine that produced them, so on any real passage it said *"no turn prompts for this route"*.

## What a nautical manoeuvre is

| Road | Passage |
|---|---|
| turn left | **alter course to port**, by a stated number of degrees |
| onto Church Street | **onto 074°T** — three figures, true |
| in 200 m | **2.7 NM**, or cables inside a mile |
| arrive at a junction | **pass a mark** |
| lanes, roundabout exits, gyratories | none of it exists |

On the Solent demo passage, from the iPad simulator run:

```
Alter 22° to port onto 074°T          at Mid Solent, off Hamstead
FROM 096°T · TO RUN 2.7 NM · AT 5 KN 31 min · FROM START 2.7 NM

Alter 15° to port onto 059°T          at Off Salt Mead
Alter 42° to starboard onto 101°T     at Gurnard, Cowes approach
```

Derived from `PassageLeg`, so no service is called and nothing can be stale — a manoeuvre is what happens between two consecutive legs, and the plan already knows the courses either side, the mark between them, and the distance and time to get there. It works offline.

## Three decisions worth reviewing

**An alteration under 5° is not a manoeuvre.** A helm cannot hold a course that finely, and a plan that says *"alter 3° to port"* teaches its reader to skip lines. Those marks stay in the leg table, where each leg's course is stated exactly — and the screen says **how many were left out**, because a list silently shorter than the mark count leaves a navigator wondering what was lost.

**Departure and arrival are not manoeuvres.** Nothing to alter onto at the start, nothing after the end. A two-mark passage correctly has none, and the empty state says *which* of the three reasons applies rather than showing a blank screen.

**Which side to leave a mark is not derivable, and is not invented.** That needs the mark to be an object with a side; this app models a mark as a bare position the track runs *through*. Asserting a side from geometry would be precisely the confident-wrong-information failure #19 exists to prevent. The screen says so, where a sailor would otherwise assume it.

## One piece of geometry that matters

An alteration takes the short way round: **350° to 010° is 20° to starboard, not 340° to port.** A helm given the latter would put the wheel the wrong way for most of the turn. Tested in both directions, plus four near-reversals to hold the 180° cap.

## Verification

- `flutter analyze` clean; `flutter test` — **1,715 pass**, 24 skipped
- **14 model tests**: short-way-round both ways, the 180° cap, the threshold and its accounting, numbering that counts manoeuvres rather than marks, the leg *into* the mark being the distance to run, and the planning speed coming through
- **11 widget tests**: the instruction wording, the course being left, nautical units, the assumed speed shown beside every time, all three empty states, the major-alteration flag, and that no road vocabulary survives the screen
- The route review screen's *"All turns (n)"* button and *"n turn instructions"* chip — both permanently zero — become *"All alterations (n)"* and *"n alterations"*. Its Bristol-roundabout test is replaced with a Solent passage asserting the real instructions.
- Driven end to end on an iPad Pro 11" simulator; the figures above are that run

## Stage 2, not in this PR

Under-way guidance: replacing `navigation_guidance.dart`'s road instruction generator with one that prompts at **1 NM and again at 2 cables** from the next mark — a yacht at 5 knots covers a mile in 12 minutes, so road prompt distances are useless. That needs the fix-age and cross-track work already in `navigation_instruments.dart` (#34).

Only after stage 2 can `OsrmRoadRoutingService`, `maneuver_symbol.dart`'s roundabout and lane machinery, `roundabout_exit_bucket.dart`, `assets/mini_roundabouts.geojson` and `tools/discovery` all go — the rest of #31.