### PR TITLE
fix: a mark is not a stop, and solo is the default (#68)

### DIFF
--- a/apps/mobile/lib/features/home/home_destination_search.dart
+++ b/apps/mobile/lib/features/home/home_destination_search.dart
@@ -59,8 +59,8 @@ enum VoyageStartChoice {
   };
 
   String get label => switch (this) {
-    VoyageStartChoice.solo => 'Voyage solo',
-    VoyageStartChoice.group => 'Voyage as a group',
+    VoyageStartChoice.solo => 'Sail on my own',
+    VoyageStartChoice.group => 'Sail with crew',
   };
 
   String get detail => switch (this) {
@@ -136,7 +136,9 @@ enum HomeSearchHandoffKind {
   /// Join somebody else's voyage with their six-digit code.
   joinWithCode,
 
-  /// Recall a route planned on the web planner, by its code.
+  /// Recall a passage published to the relay, by its code (#68). The web
+  /// planner this once meant does not exist for this app, and nothing here
+  /// posts a plan yet - only fetches one.
   plannedRouteCode,
 
   /// Voyage something already on the phone.
@@ -348,7 +350,7 @@ class _HomeDestinationSearchSheetState
                   key: const Key('home-search-planned-code'),
                   leading: const Icon(Icons.route_outlined),
                   title: const Text('Recall a planned route'),
-                  subtitle: const Text('With a code from the web planner'),
+                  subtitle: const Text('With a code someone gave you'),
                   onTap: () => Navigator.of(context).pop(
                     const HomeSearchHandoff(
                       HomeSearchHandoffKind.plannedRouteCode,

--- a/apps/mobile/lib/features/home/home_screen.dart
+++ b/apps/mobile/lib/features/home/home_screen.dart
@@ -801,8 +801,12 @@ class _VoyageFormState extends State<_VoyageForm> with WidgetsBindingObserver {
   final _planCodeController = TextEditingController();
   final _codeFocusNode = FocusNode();
   final _codeFieldKey = GlobalKey();
+
+  /// Solo, because that is what this app is for (#68). Onboarding leads with
+  /// "Sail on my own" (#54) and this sheet used to default the other way, so a
+  /// solo sailor had to deselect a crew before creating a voyage alone.
   VoyageCoordinationMode _selectedCoordinationMode =
-      VoyageCoordinationMode.crew;
+      VoyageCoordinationMode.solo;
 
   /// Set once a created voyage's code needs sharing before handing off to the
   /// map - the moment a skipper most needs it, with people waiting nearby.
@@ -891,7 +895,7 @@ class _VoyageFormState extends State<_VoyageForm> with WidgetsBindingObserver {
                     ButtonSegment(
                       value: true,
                       icon: Icon(Icons.groups_2_outlined),
-                      label: Text('Group'),
+                      label: Text('With crew'),
                     ),
                   ],
                   selected: {_selectedCoordinationMode.isGroup},
@@ -935,8 +939,16 @@ class _VoyageFormState extends State<_VoyageForm> with WidgetsBindingObserver {
                   decoration: InputDecoration(
                     labelText: 'Planned route code (optional)',
                     hintText: 'e.g. 7F3K9QRT',
+                    // Was "From the web planner", which does not exist for this
+                    // app (#68). The relay does serve plans by code
+                    // (GET /api/v1/plans/{code}) and the POST that would create
+                    // one has no client here, so nothing in the app can produce
+                    // a code today - said plainly rather than pointing at a
+                    // website that is not there.
                     helperText:
-                        'From the web planner. The route opens for review after the voyage is created.',
+                        'For a code someone gave you. Nothing in this app '
+                        'creates one yet. The passage opens for review after '
+                        'the voyage is created.',
                     errorText: _planCodeError,
                     counterText: '',
                     suffixIcon: const Icon(Icons.qr_code),

--- a/apps/mobile/lib/features/map/destination_route_sheet.dart
+++ b/apps/mobile/lib/features/map/destination_route_sheet.dart
@@ -129,7 +129,7 @@ class _DestinationRouteSheetState extends State<DestinationRouteSheet> {
                       controller: _stopControllers[index],
                       textInputAction: TextInputAction.next,
                       decoration: InputDecoration(
-                        labelText: 'Stop ${index + 1}',
+                        labelText: 'Mark ${index + 1}',
                         hintText: 'Place, postcode, or coordinates',
                         prefixIcon: const Icon(Icons.add_location_alt_outlined),
                       ),
@@ -140,7 +140,7 @@ class _DestinationRouteSheetState extends State<DestinationRouteSheet> {
                     children: [
                       IconButton(
                         key: Key('move-route-stop-up-$index'),
-                        tooltip: 'Move stop earlier',
+                        tooltip: 'Move mark earlier',
                         onPressed: index == 0
                             ? null
                             : () => _moveStop(index, index - 1),
@@ -148,7 +148,7 @@ class _DestinationRouteSheetState extends State<DestinationRouteSheet> {
                       ),
                       IconButton(
                         key: Key('move-route-stop-down-$index'),
-                        tooltip: 'Move stop later',
+                        tooltip: 'Move mark later',
                         onPressed: index == _stopControllers.length - 1
                             ? null
                             : () => _moveStop(index, index + 1),
@@ -156,7 +156,7 @@ class _DestinationRouteSheetState extends State<DestinationRouteSheet> {
                       ),
                       IconButton(
                         key: Key('remove-route-stop-$index'),
-                        tooltip: 'Remove stop',
+                        tooltip: 'Remove mark',
                         onPressed: () => _removeStop(index),
                         icon: const Icon(Icons.delete_outline),
                       ),
@@ -170,7 +170,7 @@ class _DestinationRouteSheetState extends State<DestinationRouteSheet> {
               key: const Key('add-route-stop'),
               onPressed: _stopControllers.length >= 8 ? null : _addStop,
               icon: const Icon(Icons.add),
-              label: const Text('Add an intermediate stop'),
+              label: const Text('Add an intermediate mark'),
             ),
             const SizedBox(height: 14),
             TextField(

--- a/apps/mobile/lib/features/map/route_progress_panel.dart
+++ b/apps/mobile/lib/features/map/route_progress_panel.dart
@@ -30,7 +30,7 @@ class RouteProgressPanel extends StatelessWidget {
       '$timeRemaining and ${formatter.distance(progress.remainingDistanceMeters)} remaining',
       if (arrival != '—') 'route ETA $arrival',
       if (nextName != null && nextDistance != null)
-        'next stop $nextName, ${formatter.distance(nextDistance)}'
+        'next mark $nextName, ${formatter.distance(nextDistance)}'
             '${nextArrival == '—' ? '' : ', ETA $nextArrival'}',
     ].join('. ');
 

--- a/apps/mobile/lib/features/map/route_review_screen.dart
+++ b/apps/mobile/lib/features/map/route_review_screen.dart
@@ -167,7 +167,8 @@ class _RouteReviewScreenState extends State<RouteReviewScreen> {
   @override
   void initState() {
     super.initState();
-    // A destination plan opens ready to manipulate, matching the web planner.
+    // A destination plan opens ready to manipulate; an imported or recorded
+    // passage keeps the quieter review-only default.
     // Imported/recorded routes retain the quieter review-only default.
     _reshapeEnabled = canEditStops && widget.onReshapeRoute != null;
   }
@@ -440,7 +441,7 @@ class _RouteReviewScreenState extends State<RouteReviewScreen> {
           if (canEditStops)
             IconButton(
               key: const Key('edit-reviewed-route'),
-              tooltip: 'Edit stops',
+              tooltip: 'Edit marks',
               onPressed: () =>
                   Navigator.of(context).pop(RouteReviewAction.edit),
               icon: const Icon(Icons.edit_location_alt_outlined),
@@ -791,7 +792,7 @@ class _RouteReviewScreenState extends State<RouteReviewScreen> {
                               ),
                               label: Text('Adjustment ${entry.$1 + 1}'),
                               tooltip:
-                                  'Route shaping point. This is not a stop.',
+                                  'Passage shaping point. This is not a mark.',
                               onDeleted: () => _removeShapingPoint(entry.$2.id),
                             ),
                         ],
@@ -817,13 +818,13 @@ class _RouteReviewScreenState extends State<RouteReviewScreen> {
                     childrenPadding: EdgeInsets.zero,
                     initiallyExpanded: reviewWaypoints.length <= 8,
                     title: Text(
-                      'Route points (${reviewWaypoints.length})',
+                      'Marks (${reviewWaypoints.length})',
                       style: Theme.of(context).textTheme.titleMedium,
                     ),
                     subtitle: Text(
                       reviewWaypoints.length > 8
                           ? 'Tap to review the full ordered list.'
-                          : 'Start, stops and destination in order.',
+                          : 'Start, marks and destination in order.',
                     ),
                     children: [
                       if (reviewWaypoints.isEmpty)
@@ -1080,10 +1081,16 @@ String _durationLabel(Duration duration) {
   return remainder == 0 ? '$hours hr' : '$hours hr $remainder min';
 }
 
+/// A passage has marks, and you do not stop at them - you pass them (#68).
+///
+/// That distinction is the whole basis of the manoeuvre list (#63), which
+/// describes these same positions as marks two sections down the same screen.
+/// "Mark n" also matches `nextMarkName`, which has been naming newly placed ones
+/// "Mark 1", "Mark 2" since #43.
 String _waypointRole(int index, int count) {
   if (index == 0) return 'Start';
   if (index == count - 1) return 'Destination';
-  return 'Stop $index';
+  return 'Mark $index';
 }
 
 String _waypointLabel(int index, int count, RouteWaypoint waypoint) {

--- a/apps/mobile/lib/features/map/voyage_map_feature.dart
+++ b/apps/mobile/lib/features/map/voyage_map_feature.dart
@@ -4655,7 +4655,7 @@ class _VoyageMapScreenState extends State<VoyageMapScreen> {
     }
   }
 
-  /// Loads a route prepared on the web planner. The plan code has no
+  /// Loads a passage published to the relay by its code. The plan code has no
   /// relationship to a live voyage or its credentials - this only fetches a
   /// GPX file through the same parse-and-activate pipeline as a manual
   /// import, exactly like [_importGpx] and [_importSharedGpx] above.
@@ -6036,7 +6036,7 @@ class _EmptyRoutePrompt extends StatelessWidget {
                         ),
                         TextButton(
                           onPressed: onLoadDemo,
-                          child: const Text('Use demo route'),
+                          child: const Text('Use the demo passage'),
                         ),
                       ],
                     ),

--- a/apps/mobile/lib/features/settings/unit_settings_sheet.dart
+++ b/apps/mobile/lib/features/settings/unit_settings_sheet.dart
@@ -265,7 +265,7 @@ class UnitSettingsSheet extends StatelessWidget {
               title: const Text('Show route time and distance'),
               subtitle: const Text(
                 'Shows the current time, total distance and estimated time '
-                'remaining, plus the next named stop and its ETA. Estimates '
+                'remaining, plus the next named mark and its ETA. Estimates '
                 'use your recent speed over ground and stay blank until you move.',
               ),
             ),

--- a/apps/mobile/lib/features/voyage/active_voyage_shell.dart
+++ b/apps/mobile/lib/features/voyage/active_voyage_shell.dart
@@ -825,7 +825,7 @@ class _PreStartVoyagePanel extends StatelessWidget {
                 Expanded(
                   child: Text(
                     routeName == null
-                        ? 'No route selected'
+                        ? 'No passage planned'
                         : 'Route: $routeName',
                     maxLines: 2,
                     style: const TextStyle(
@@ -838,7 +838,9 @@ class _PreStartVoyagePanel extends StatelessWidget {
                   TextButton(
                     key: const Key('pre-start-choose-route'),
                     onPressed: busy ? null : onChooseRoute,
-                    child: Text(routeName == null ? 'Choose route' : 'Change'),
+                    child: Text(
+                      routeName == null ? 'Plan a passage' : 'Change',
+                    ),
                   ),
               ],
             ),
@@ -3609,7 +3611,7 @@ class _ActiveVoyageShellState extends State<ActiveVoyageShell>
                   _StartVoyageDecision.chooseRoute,
                 ),
                 icon: const Icon(Icons.route_outlined),
-                label: const Text('Choose route'),
+                label: const Text('Plan a passage'),
               ),
             ] else
               FilledButton.icon(

--- a/apps/mobile/test/features/home/home_destination_search_test.dart
+++ b/apps/mobile/test/features/home/home_destination_search_test.dart
@@ -47,8 +47,8 @@ void main() {
       await tester.tap(find.text('Bath, Somerset'));
       await tester.pumpAndSettle();
 
-      expect(find.text('Voyage solo'), findsOneWidget);
-      expect(find.text('Voyage as a group'), findsOneWidget);
+      expect(find.text('Sail on my own'), findsOneWidget);
+      expect(find.text('Sail with crew'), findsOneWidget);
 
       await tester.tap(find.byKey(const Key('voyage-start-group')));
       await tester.pumpAndSettle();

--- a/apps/mobile/test/features/map/route_review_screen_test.dart
+++ b/apps/mobile/test/features/map/route_review_screen_test.dart
@@ -70,14 +70,14 @@ void main() {
     final confirm = find.byKey(const Key('confirm-reviewed-route'));
     expect(confirm, findsOneWidget);
     expect(tester.getTopLeft(confirm).dy, lessThan(80));
-    expect(find.text('Route points (102)'), findsOneWidget);
+    expect(find.text('Marks (102)'), findsOneWidget);
     expect(
       find.byKey(const Key('route-review-waypoint-0')),
       findsNothing,
       reason: 'the long detail list starts collapsed',
     );
 
-    await tester.tap(find.text('Route points (102)'));
+    await tester.tap(find.text('Marks (102)'));
     await tester.pumpAndSettle();
 
     expect(find.byKey(const Key('route-review-waypoint-0')), findsOneWidget);

--- a/apps/mobile/test/features/map/stored_route_source_test.dart
+++ b/apps/mobile/test/features/map/stored_route_source_test.dart
@@ -212,7 +212,7 @@ void main() {
 
     expect(find.text('Import GPX'), findsOneWidget);
     expect(find.text('Lay a course to a place'), findsOneWidget);
-    expect(find.text('Use demo route'), findsOneWidget);
+    expect(find.text('Use the demo passage'), findsOneWidget);
     expect(
       find.byKey(const Key('use-stored-route-empty-button')),
       findsOneWidget,

--- a/apps/mobile/test/features/map/voyage_map_feature_test.dart
+++ b/apps/mobile/test/features/map/voyage_map_feature_test.dart
@@ -608,7 +608,7 @@ void main() {
         findsNothing,
       );
       expect(find.text('Import GPX'), findsNothing);
-      expect(find.text('Use demo route'), findsNothing);
+      expect(find.text('Use the demo passage'), findsNothing);
       expect(
         find.byKey(const Key('dismiss-waiting-route-prompt')),
         findsOneWidget,
@@ -819,8 +819,8 @@ void main() {
     expect(find.text('Use a saved passage'), findsOneWidget);
     await tester.ensureVisible(find.text('Import GPX'));
     expect(find.text('Import GPX'), findsOneWidget);
-    await tester.ensureVisible(find.text('Use demo route'));
-    expect(find.text('Use demo route'), findsOneWidget);
+    await tester.ensureVisible(find.text('Use the demo passage'));
+    expect(find.text('Use the demo passage'), findsOneWidget);
     expect(tester.takeException(), isNull);
   });
 
@@ -1370,8 +1370,8 @@ void main() {
     expect(find.textContaining('2.0 mi'), findsOneWidget);
     expect(find.textContaining('0.1 mi'), findsOneWidget);
 
-    await tester.ensureVisible(find.text('Use demo route'));
-    await tester.tap(find.text('Use demo route'));
+    await tester.ensureVisible(find.text('Use the demo passage'));
+    await tester.tap(find.text('Use the demo passage'));
     for (var i = 0; i < 5; i += 1) {
       await tester.pump(const Duration(milliseconds: 100));
     }
@@ -1435,8 +1435,8 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 100));
 
-    await tester.ensureVisible(find.text('Use demo route'));
-    await tester.tap(find.text('Use demo route'));
+    await tester.ensureVisible(find.text('Use the demo passage'));
+    await tester.tap(find.text('Use the demo passage'));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
 

--- a/apps/mobile/test/vocabulary/no_road_vocabulary_test.dart
+++ b/apps/mobile/test/vocabulary/no_road_vocabulary_test.dart
@@ -44,6 +44,15 @@ void main() {
     // now because renaming by hand has missed them three times.
     r'\blead\b(?! time)': 'Skipper',
     r'\btec\b': 'Sweeper',
+    // Not a road word, which is why the first pass missed it: there is no Tide
+    // and Seek web planner for a route code to come from (#68).
+    r'\bweb planner\b': 'the relay, or nothing',
+    // "stop" is deliberately absent. A passage has marks and you pass them
+    // rather than stop at them, so the noun is wrong - but "Stop sharing",
+    // "location sharing stops" and "emergency stop" are all correct, and no
+    // regex separates the noun from the verb. The noun uses were fixed by hand
+    // in #68; a rule here would cry wolf on eighteen legitimate strings and get
+    // switched off.
   };
 
   /// Files whose road words are correct, each for a stated reason.
@@ -66,7 +75,8 @@ void main() {
     'lib/services/road_routing.dart':
         'the road routing engines themselves, unreachable and awaiting #31',
     'lib/domain/route_preferences.dart':
-        'road-only preferences still serialised into saved routes, awaiting #31',
+        'road-only preferences still serialised into saved routes, awaiting '
+        '#31; their doc also records the web-planner contract they came from',
     'lib/features/map/maneuver_symbol.dart':
         'turn-by-turn symbols, unreachable since a passage has no manoeuvres',
     'lib/features/map/maneuver_diagnostics.dart':

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -179,7 +179,10 @@ void main() {
     },
   );
 
-  testWidgets('create voyage accepts a web-planner route code', (tester) async {
+  // Named for a web planner that does not exist for this app (#68). The code
+  // path is real - the relay serves plans by code - so the test stays and only
+  // its name changes.
+  testWidgets('create voyage accepts a shared passage code', (tester) async {
     final controller = await _controller();
     addTearDown(controller.dispose);
     _sharedRoutes.clearPending();
@@ -192,6 +195,10 @@ void main() {
 
     expect(find.byKey(const Key('planned-route-code-field')), findsOneWidget);
     expect(find.text('Planned route code (optional)'), findsOneWidget);
+    // Solo is the default (#68), and solo has no code to share, so this test's
+    // subject - the share-code handoff - needs crew chosen.
+    await tester.tap(find.text('With crew'));
+    await tester.pumpAndSettle();
     await tester.enterText(
       find.byKey(const Key('planned-route-code-field')),
       'AB12CD34',
@@ -220,8 +227,14 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byKey(const Key('voyage-scope-selector')), findsOneWidget);
-    // The junction-handling choice went with the road surfaces; solo versus
-    // crew is the whole decision now.
+    // Solo is the default now (#68), so this reaches Create without touching the
+    // selector - which is the point of a solo-first app. The crew description
+    // appears only once crew is chosen.
+    expect(find.text(VoyageCoordinationMode.solo.description), findsOneWidget);
+    expect(find.text(VoyageCoordinationMode.crew.description), findsNothing);
+
+    await tester.tap(find.text('With crew'));
+    await tester.pumpAndSettle();
     expect(find.text(VoyageCoordinationMode.crew.description), findsOneWidget);
 
     await tester.tap(find.text('Solo'));
@@ -853,6 +866,10 @@ void main() {
     expect(find.byKey(const Key('set-aside-voyage-banner')), findsOneWidget);
 
     await tester.tap(find.text('New voyage'));
+    await tester.pumpAndSettle();
+    // Crew, because "Continue to voyage" is the share-code handoff and solo -
+    // the default since #68 - has no code to share.
+    await tester.tap(find.text('With crew'));
     await tester.pumpAndSettle();
     await tester.scrollUntilVisible(
       find.widgetWithText(FilledButton, 'Create voyage'),


### PR DESCRIPTION
Closes #68. Three leftovers the source scan from #61 could not catch, because none of them is a road word.

## Solo is the default

"Create a private voyage" opened with **Group** selected, on an app whose onboarding leads with "Sail on my own" (#54). A solo sailor had to deselect a crew before sailing alone.

The segment now reads **Solo / With crew**, defaulting to solo, and the two voyage-start choices say *"Sail on my own"* and *"Sail with crew"* rather than inventing a third phrasing alongside onboarding's.

## A mark is not a stop

The review screen listed **"Stop 1: Mid Solent, off Hamstead"** two sections above a manoeuvre list calling that same position a *mark* (#63). You do not stop at a mark — you pass it, and that distinction is the whole basis of the manoeuvre list.

- "Route points (5)" → **"Marks (5)"**, "Start, stops and destination in order" → "Start, marks and destination in order"
- "Stop n" → **"Mark n"**, matching `nextMarkName`, which has been naming newly placed ones "Mark 1" since #43
- the destination sheet's reorder controls: "Move stop earlier/later", "Remove stop", "Add an intermediate stop"
- the progress panel's "next stop" → "next mark"
- the settings description of what the voyage clock shows
- "Route shaping point. This is not a stop." → "Passage shaping point. This is not a mark."

## The web planner does not exist

The route-code field said *"From the web planner. The route opens for review after the voyage is created."* #61 removed the same claim from the destination sheet and missed this one because "web planner" is not a road word.

Checking what the field actually does: the relay **does** serve plans by code (`GET /api/v1/plans/{code}`), and the `POST /api/v1/plans` that would create one **has no client in the app**. So a code can only come from outside — which was the web planner. The helper text now says it is for a code someone gave you, and that nothing here creates one. True, and more use than pointing at a website that is not there.

## Also

"No route selected" / "Choose route" in the voyage header became **"No passage planned" / "Plan a passage"**, matching the chooser they open — which #61 had already retitled. And "Use demo route" is "Use the demo passage".

## Why the guard does not gain a "stop" rule

I added one, and it fired on **eighteen** strings — *"Stop sharing and leave this voyage"*, *"location sharing stops on this device"*, *"your help or emergency-stop status"*, *"Stops serving after"*. All correct English. The noun is wrong on a passage and the verb is fine, and no regex separates them.

So the rule is out and the comment says why, because a check that cries wolf gets switched off. It does gain `web planner`. The noun uses are fixed by hand.

## Verification

- `flutter analyze` clean; `flutter test` — **1,715 pass**, 24 skipped
- Two tests in `widget_test.dart` now choose crew explicitly: *"Continue to voyage"* is the share-code handoff, and solo has no code to share. That they broke is the change working.
- The solo-default test asserts the solo description shows *without touching the selector*, and that choosing crew swaps it — so the default is pinned in both directions.