### PR TITLE
chore: only setup-uv could actually be bumped

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -25,7 +25,7 @@ jobs:
         working-directory: ${{ env.SERVER_DIR }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           working-directory: ${{ env.SERVER_DIR }}
           python-version: '3.12'
@@ -76,7 +76,7 @@ jobs:
       TIDE_AND_SEEK_CURSOR_SIGNING_KEY: CwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCws
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           working-directory: ${{ env.SERVER_DIR }}
           python-version: '3.12'

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,18 +1,26 @@
-Build 23. Seven fixes since build 22, most of them found by running build 22 on an iPad — which is the argument for shipping early.
+Build 24. The big one is a manoeuvre list that finally means something at sea, and about 5,500 lines of motorcycle code gone from underneath it.
 
-Fixed since build 22:
-- Every invitation used to lead with a link that could not open. It pointed at tideandseek.invalid, a reserved domain guaranteed never to resolve, with no Associated Domain and no URL scheme behind it. Invitations now lead with the six-digit code, which is what you actually type.
-- The onboarding card showed the Skipper glyph captioned "Lead" — the road group-riding role this app was scaffolded from. Skipper everywhere now. The relay was pinning the old spelling and would have rejected every crew payload once the app changed, so both sides accept both.
-- A sailor name was mandatory before the app would open, and "Skip tour" did not skip it. So a solo-first app made you name yourself for a crew you may never have. Optional now: leave it blank and you sail as Skipper.
-- Onboarding used to end on "Create a voyage" or "Join a voyage", both crew activities. "Sail on my own" is now the first option, and screen one says what the app does alone — plus a card stating plainly that this is not a chart and the courses are unchecked.
-- Choosing to sail alone then showed "Waiting for the skipper's route", to a sailor with no voyage and no crew. Gone.
-- The launch screen was Flutter's placeholder: a transparent pixel on white, so a dark app flashed white on every launch. It is the yacht from the app icon now, on the app's own background.
-- A mark added to an imported passage could not be removed — the delete button was gated on a flag that is false for exactly those passages. Marks can now be named too, and a name survives GPX.
+You asked for a manoeuvre list appropriate to nautical navigation. Open the demo passage, review it, and tap "All alterations (3)":
 
-Worth trying on this build:
-- On the iPad in landscape, open a passage for review: the chart now sits beside the leg table instead of above it, both full height. This is the layout I could verify in tests but not on a running device — please tell me if it reads wrong.
-- Setup with no name at all, then "Sail on my own".
-- The demo passage (Lymington to Cowes, 5 marks, 4 legs, 8.6 NM), its leg table, and adding then naming then removing a mark.
-- Navigation instruments under way. Still the thing that most needs a real GNSS fix — the simulator has none, so nothing in it has been seen with live values.
+  Alter 22° to port onto 074°T          at Mid Solent, off Hamstead
+  FROM 096°T · TO RUN 2.7 NM · AT 5 KN 31 min · FROM START 2.7 NM
+
+  Alter 15° to port onto 059°T          at Off Salt Mead
+  Alter 42° to starboard onto 101°T     at Gurnard, Cowes approach
+
+The old list was built from road steps — turn left, third exit, get in lane — and had been permanently empty since passages stopped being road routes. This one is derived from the marks you chose, so it needs no connection and cannot go stale.
+
+Three judgements in it I would like you to check:
+- An alteration under 5° does not become an instruction. A helm cannot hold a course that finely. Those marks stay in the leg table with their exact course, and the screen tells you how many were left out.
+- It will not say which side to leave a mark. That needs buoyage the app does not have, and guessing from geometry would be inventing information. The screen says so.
+- 60° is where an alteration gets flagged for a second look.
+
+Also worth trying:
+- "Where are you bound?" used to offer a routing style of "Twisty (up to 50% longer)" and switches for motorways, tolls and — on a sailing app — ferries. Every one of them did nothing. The whole panel is gone, and the sheet now says what it does before you tap: one direct leg, unchecked against land, depth or traffic.
+- Creating a voyage now defaults to Solo rather than Group.
+- The review screen calls its marks marks. It used to say "Stop 1", "Stop 2" two sections above the manoeuvre list that correctly called the same positions marks.
+- Settings said "RIDER PROFILE". The roster offered "Ask to be TEC". The map counted "3 RIDERS". All gone, along with about thirty other strings a sailor could read, and a source scan now fails the build if any of them come back.
 
 Still deliberately absent: tides, tidal streams, charted depth, wrecks and obstructions. The free UKHO data may carry a field-of-use restriction that blocks a navigation app and that question is unanswered. With no tide, a passage this plans is a passage in still water. Not a substitute for an official chart.
+
+Still unverified by me, and the two things I would most value your eyes on: the iPad landscape layout, where the chart sits beside the leg table — pinned by tests but never seen by me on a real device — and the navigation instruments under way, which have never had a live GNSS fix.

--- a/apps/mobile/pubspec.lock
+++ b/apps/mobile/pubspec.lock
@@ -311,18 +311,18 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_secure_storage
-      sha256: "15e8c8fe269fdf7d469b23008ab3df521c8b826ed345820532364c31bdebace6"
+      sha256: "7686b1d6a29985dcbb808c59518226e603e3bfa7c0ddfd1a0d00e4cda77c868e"
       url: "https://pub.dev"
     source: hosted
-    version: "11.0.0"
+    version: "10.3.1"
   flutter_secure_storage_darwin:
     dependency: transitive
     description:
       name: flutter_secure_storage_darwin
-      sha256: ac6d76a752de0cd738334eb4b21743fc4943f449f5b6e308f18838b048c02ac0
+      sha256: "82329fa5cdf343773b1b6897dea959105a29f092454259edff92f9f6637e8149"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.0"
+    version: "0.3.2"
   flutter_secure_storage_linux:
     dependency: transitive
     description:

--- a/apps/mobile/pubspec.lock
+++ b/apps/mobile/pubspec.lock
@@ -311,18 +311,18 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_secure_storage
-      sha256: "7686b1d6a29985dcbb808c59518226e603e3bfa7c0ddfd1a0d00e4cda77c868e"
+      sha256: "15e8c8fe269fdf7d469b23008ab3df521c8b826ed345820532364c31bdebace6"
       url: "https://pub.dev"
     source: hosted
-    version: "10.3.1"
+    version: "11.0.0"
   flutter_secure_storage_darwin:
     dependency: transitive
     description:
       name: flutter_secure_storage_darwin
-      sha256: "82329fa5cdf343773b1b6897dea959105a29f092454259edff92f9f6637e8149"
+      sha256: ac6d76a752de0cd738334eb4b21743fc4943f449f5b6e308f18838b048c02ac0
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.2"
+    version: "0.4.0"
   flutter_secure_storage_linux:
     dependency: transitive
     description:

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -39,11 +39,14 @@ dependencies:
   crypto: ^3.0.7
   file_selector: ^1.1.0
   flutter_map: ^8.3.1
-  flutter_secure_storage: ^10.3.1
+  flutter_secure_storage: ^11.0.0
   geolocator: ^14.0.3
   http: ^1.6.0
   latlong2: ^0.10.1
   maplibre_gl: ^0.26.0
+  # Pinned by the Flutter SDK: flutter_test depends on meta 1.18.0 exactly, so
+  # ^1.19.0 makes flutter_test unresolvable. Dependabot proposes the bump anyway
+  # (#4); it cannot be taken until the SDK moves.
   meta: ^1.18.0
   path: ^1.9.1
   path_provider: ^2.1.5

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -39,7 +39,11 @@ dependencies:
   crypto: ^3.0.7
   file_selector: ^1.1.0
   flutter_map: ^8.3.1
-  flutter_secure_storage: ^11.0.0
+  # Held at 10.x. 11.0.0 requires Android compileSdk 37, and this app takes
+  # `flutter.compileSdkVersion` from the SDK - the Android build fails at
+  # `checkDebugAarMetadata` on the AAR's minimum. Dependabot proposes it (#3);
+  # taking it means an Android toolchain bump, not a version bump.
+  flutter_secure_storage: ^10.3.1
   geolocator: ^14.0.3
   http: ^1.6.0
   latlong2: ^0.10.1


### PR DESCRIPTION
Supersedes #1, #3 and #4. All three were raised before this session's work, with CI runs from a tree about thirty commits behind.

I set out to take all three and **two of them turn out to be blocked**, each differently. Both now carry the reason in `pubspec.yaml` rather than waiting to be retried.

## Taken

**`astral-sh/setup-uv` v9.0.0 → v10.0.1** — both pins in `server.yml`, SHA and `# v` comment moved together so they cannot drift apart.

## Blocked: `meta` 1.19.0 (#4)

```
Note: meta is pinned to version 1.18.0 by flutter_test from the flutter SDK.
Because every version of flutter_test from sdk depends on meta 1.18.0 and
tide_and_seek depends on meta ^1.19.0, flutter_test from sdk is forbidden.
```

`pub get` fails outright. Not takeable until the SDK moves.

## Blocked: `flutter_secure_storage` 11.0.0 (#3)

This one is worth reading, because it passed everything that usually decides:

- `pub get` resolved
- `flutter analyze` clean
- `flutter test` — 1,715 pass, unchanged

…and then the **Android job failed**:

```
Warning: The plugin flutter_secure_storage requires Android SDK version 37 or higher.
FAILURE: Build failed with an exception.
Execution failed for task ':app:checkDebugAarMetadata'.
  Dependency ':flutter_secure_storage' requires libraries and applications that
  minSdk (which determines which devices the app can be installed …
```

`compileSdk = flutter.compileSdkVersion` in `android/app/build.gradle.kts`, so raising it means moving the Android toolchain — Gradle and AGP too, for an SDK level that is very new. That is not a version bump, and not something to do the day a build ships.

Worth noting *how* this was caught: nothing on the Dart side notices. Only the per-PR Android build does. A repo without that job would have merged this and found out at release time.

## Verification

- `flutter pub get` resolves; `flutter analyze` clean
- `flutter test` — **1,715 pass**, 24 skipped
- The Android failure above is from CI on the first push of this branch, with 11.0.0 in place

Once this lands I will close #1 as superseded, and #3 and #4 with their blockers recorded, so dependabot's re-proposals have somewhere to point.