### PR TITLE
chore: 1.0.3+24 for TestFlight

### DIFF
--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.2+23
+version: 1.0.3+24
 
 environment:
   sdk: ^3.12.2


### PR DESCRIPTION
Version bump. **Build 24 is already uploaded, processed and live for Internal Testing** — this lands the bump that produced it.

## The release script's first real run, and it worked

#42's `tools/release/release.sh` had never been exercised end to end, because build 23 was already up and re-uploading a build number is refused. This is its first outing:

```
==> Tests and analysis
==> Archive
==> Export a signed App Store build      ** EXPORT SUCCEEDED **
==> Validate                             VERIFY SUCCEEDED with no errors
==> Upload                               UPLOAD SUCCEEDED with no errors
==> Publish to Internal Testing
Build 24: not uploaded yet; waiting for App Store Connect     ×5
Build 24 is VALID; attached to "Internal Testing"; notes updated for en-GB

release: 1.0.3 (24) is live for "Internal Testing"
```

Everything the two hand-built releases taught it held: it swallowed `flutter build ipa`'s expected export failure and exported with `xcodebuild -allowProvisioningUpdates`, it waited out the five polls before the build appeared, and it **PATCHed** the release notes rather than POSTing — the 409 that bit me publishing build 23. `--dry-run` was checked first and stopped after validation as designed.

Two builds by hand, one by script. Worth the detour.

## What is in 24 that was not in 23

| | |
|---|---|
| #63 | The nautical manoeuvre list — *"Alter 22° to port onto 074°T at Mid Solent"* |
| #61 | The destination sheet's inert road panel gone, including "Avoid ferries"; ~30 road strings off live screens |
| #31 | Valhalla's motorcycle router, the engine dispatcher and the track matcher deleted |
| #20 | 141 KB of motorcycle cafés and their map pins deleted |
| #68 | Marks called marks; Solo the default; no more phantom web planner |

About 5,500 lines out, one real feature in.

## Verified

- Group now lists builds **24, 23, 22**, all `VALID`, none expired
- `osholt@me.com` shows `INSTALLED` — build 23 was picked up, so 24 should arrive as an update
- Release notes set for `en-GB`, 2,657 characters against the 4,000 limit

`RELEASE_NOTES.md` for this build landed a commit early, in #70 — the content is right, it just travelled with the wrong change.