### PR TITLE
feat: make the passage coherent — honest guidance, then guidance that means something (#72, #63)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -405,6 +405,28 @@ the phases around it, and there will be more of it after every build.
 phase were found by putting a build on a device rather than by reading the code,
 which is the argument for doing it early and often.
 
+### Phase 4b — Make the passage coherent
+
+The fitness review of build 24 found the app half-joined-up: a passage can be
+planned in detail and then not sailed. The plan, the instruments and the voice
+all exist and none of them speak to each other. This phase joins them, and it is
+what turns a chart-table aid into something usable under way.
+
+- [x] Stop reporting a correct passage as broken — #72
+- [ ] `PassageGuidance`: one service reading the plan, the alterations and the
+      live fix, and answering "what leg am I on, what is next, how far, and what
+      does the plan ask for there" — #63
+- [ ] The under-way banner reads it, replacing the road guidance planner
+- [ ] Spoken prompts read it: a mark at 1 NM and 2 cables, cross-track beyond a
+      threshold, a stale fix — #73
+- [ ] Retire what that leaves dead: `OsrmRoadRoutingService`, the roundabout and
+      lane machinery, `roundabout_exit_bucket.dart`,
+      `assets/mini_roundabouts.geojson`, `tools/discovery` — the rest of #31
+
+The order matters. Each step is useless without the one before it, and the last
+cannot happen until the first four have taken over everything the road stack
+was still feeding.
+
 ### Phase 5 — Evidence before anyone sails with it
 
 - [ ] Security and privacy review, log redaction, retention — #10

--- a/PLAN.md
+++ b/PLAN.md
@@ -413,11 +413,11 @@ all exist and none of them speak to each other. This phase joins them, and it is
 what turns a chart-table aid into something usable under way.
 
 - [x] Stop reporting a correct passage as broken — #72
-- [ ] `PassageGuidance`: one service reading the plan, the alterations and the
+- [x] `PassageGuidance`: one service reading the plan, the alterations and the
       live fix, and answering "what leg am I on, what is next, how far, and what
       does the plan ask for there" — #63
-- [ ] The under-way banner reads it, replacing the road guidance planner
-- [ ] Spoken prompts read it: a mark at 1 NM and 2 cables, cross-track beyond a
+- [x] The under-way banner reads it, replacing the road guidance planner
+- [x] Spoken prompts read it: a mark at 1 NM and 2 cables, cross-track beyond a
       threshold, a stale fix — #73
 - [ ] Retire what that leaves dead: `OsrmRoadRoutingService`, the roundabout and
       lane machinery, `roundabout_exit_bucket.dart`,

--- a/apps/mobile/lib/features/map/voyage_map_feature.dart
+++ b/apps/mobile/lib/features/map/voyage_map_feature.dart
@@ -8049,15 +8049,11 @@ class _NavigationGuidanceStatusBanner extends StatelessWidget {
         Icons.flag_rounded,
         const Color(0xFF72D69C),
       ),
+      // A mode, not a fault. Every passage is here, and the amber warning icon
+      // this used to draw read as something being wrong (#72).
       NavigationGuidanceState.noManeuvers => (
-        Icons.directions_off_rounded,
-        const Color(0xFFFFC857),
-      ),
-      // Read as a fault rather than a mode: this route was meant to have
-      // directions and does not, which is something the sailor can act on.
-      NavigationGuidanceState.routingUnfinished => (
-        Icons.wrong_location_rounded,
-        const Color(0xFFFF8A65),
+        Icons.timeline_rounded,
+        const Color(0xFF68A9FF),
       ),
       NavigationGuidanceState.noRoute || NavigationGuidanceState.active => (
         Icons.navigation_rounded,

--- a/apps/mobile/lib/features/map/voyage_map_feature.dart
+++ b/apps/mobile/lib/features/map/voyage_map_feature.dart
@@ -204,6 +204,7 @@ class VoyageMapFeature extends StatefulWidget {
     this.onRouteChanged,
     this.onRouteCommitted,
     this.onNavigationGuidanceChanged,
+    this.onPassageGuidanceChanged,
     this.onNavigationViewportChanged,
     this.onMapStyleResolved,
     this.changeRouteRequestToken,
@@ -266,6 +267,7 @@ class VoyageMapFeature extends StatefulWidget {
     ValueChanged<ImportedRoute?>? onRouteChanged,
     ValueChanged<ImportedRoute?>? onRouteCommitted,
     ValueChanged<NavigationGuidance?>? onNavigationGuidanceChanged,
+    ValueChanged<PassageGuidance?>? onPassageGuidanceChanged,
     ValueChanged<NavigationCameraViewport>? onNavigationViewportChanged,
     ValueChanged<String>? onMapStyleResolved,
     Object? changeRouteRequestToken,
@@ -322,6 +324,7 @@ class VoyageMapFeature extends StatefulWidget {
     onRouteChanged: onRouteChanged,
     onRouteCommitted: onRouteCommitted,
     onNavigationGuidanceChanged: onNavigationGuidanceChanged,
+    onPassageGuidanceChanged: onPassageGuidanceChanged,
     onNavigationViewportChanged: onNavigationViewportChanged,
     onMapStyleResolved: onMapStyleResolved,
     changeRouteRequestToken: changeRouteRequestToken,
@@ -415,6 +418,13 @@ class VoyageMapFeature extends StatefulWidget {
   final ValueChanged<ImportedRoute?>? onRouteChanged;
   final ValueChanged<ImportedRoute?>? onRouteCommitted;
   final ValueChanged<NavigationGuidance?>? onNavigationGuidanceChanged;
+
+  /// The passage read against the current fix, for the voice (#73).
+  ///
+  /// Separate from `onNavigationGuidanceChanged` rather than replacing it,
+  /// because they carry different things: that one carries a road manoeuvre,
+  /// which a passage never has, and this one carries prompts.
+  final ValueChanged<PassageGuidance?>? onPassageGuidanceChanged;
   final ValueChanged<NavigationCameraViewport>? onNavigationViewportChanged;
   final ValueChanged<String>? onMapStyleResolved;
   final Object? changeRouteRequestToken;
@@ -593,6 +603,7 @@ class _VoyageMapFeatureState extends State<VoyageMapFeature> {
         onRouteChanged: widget.onRouteChanged,
         onRouteCommitted: widget.onRouteCommitted,
         onNavigationGuidanceChanged: widget.onNavigationGuidanceChanged,
+        onPassageGuidanceChanged: widget.onPassageGuidanceChanged,
         onNavigationViewportChanged: widget.onNavigationViewportChanged,
         changeRouteRequestToken: widget.changeRouteRequestToken,
         onChangeRouteRequestHandled: widget.onChangeRouteRequestHandled,
@@ -678,6 +689,7 @@ class VoyageMapScreen extends StatefulWidget {
     this.onRouteChanged,
     this.onRouteCommitted,
     this.onNavigationGuidanceChanged,
+    this.onPassageGuidanceChanged,
     this.onNavigationViewportChanged,
     this.changeRouteRequestToken,
     this.onChangeRouteRequestHandled,
@@ -780,6 +792,13 @@ class VoyageMapScreen extends StatefulWidget {
   final ValueChanged<ImportedRoute?>? onRouteChanged;
   final ValueChanged<ImportedRoute?>? onRouteCommitted;
   final ValueChanged<NavigationGuidance?>? onNavigationGuidanceChanged;
+
+  /// The passage read against the current fix, for the voice (#73).
+  ///
+  /// Separate from `onNavigationGuidanceChanged` rather than replacing it,
+  /// because they carry different things: that one carries a road manoeuvre,
+  /// which a passage never has, and this one carries prompts.
+  final ValueChanged<PassageGuidance?>? onPassageGuidanceChanged;
   final ValueChanged<NavigationCameraViewport>? onNavigationViewportChanged;
   final Object? changeRouteRequestToken;
   final VoidCallback? onChangeRouteRequestHandled;
@@ -3299,11 +3318,12 @@ class _VoyageMapScreenState extends State<VoyageMapScreen> {
     final fix = _instrumentFix(position);
     if (route == null || fix == null) {
       _passageGuidance.value = null;
+      widget.onPassageGuidanceChanged?.call(null);
       return;
     }
     final now = DateTime.now();
     final plan = PassagePlan.of(route);
-    _passageGuidance.value = PassageGuidance.of(
+    final next = PassageGuidance.of(
       plan: plan,
       maneuvers: PassageManeuverPlan.of(plan),
       instruments: NavigationInstruments.compute(
@@ -3313,6 +3333,8 @@ class _VoyageMapScreenState extends State<VoyageMapScreen> {
       ),
       distanceUnit: widget.distanceUnit,
     );
+    _passageGuidance.value = next;
+    widget.onPassageGuidanceChanged?.call(next);
   }
 
   void _updateNavigationGuidance(GeoPoint? position) {

--- a/apps/mobile/lib/features/map/voyage_map_feature.dart
+++ b/apps/mobile/lib/features/map/voyage_map_feature.dart
@@ -74,7 +74,9 @@ import 'smooth_countdown.dart';
 import 'stored_route_picker.dart';
 import 'marine_glyphs.dart';
 import '../../services/passage_planning.dart';
+import '../../services/passage_guidance.dart';
 import '../../services/passage_legs.dart';
+import '../../services/passage_maneuvers.dart';
 import 'passage_leg_table.dart';
 import '../../services/navigation_instruments.dart';
 import 'navigation_instrument_panel.dart';
@@ -845,6 +847,15 @@ class _VoyageMapScreenState extends State<VoyageMapScreen> {
   final RouteJourneyProgressTracker _routeJourneyProgressTracker =
       RouteJourneyProgressTracker();
   final RouteProgressTracker _rejoinProgressTracker = RouteProgressTracker();
+
+  /// The passage read against the current fix (#63).
+  ///
+  /// Beside `_navigationGuidance` rather than replacing it, for one release:
+  /// the road assessment still drives the manoeuvre banner, which cannot fire
+  /// on a passage but is what an imported route carrying manoeuvres would use.
+  /// When #31 finishes taking the road stack out, this is what remains.
+  final ValueNotifier<PassageGuidance?> _passageGuidance = ValueNotifier(null);
+
   final ValueNotifier<NavigationGuidanceAssessment> _navigationGuidance =
       ValueNotifier(const NavigationGuidanceAssessment.noRoute());
   final Map<int, Offset> _mapPointerOrigins = {};
@@ -1220,6 +1231,7 @@ class _VoyageMapScreenState extends State<VoyageMapScreen> {
     _mapLibreController?.onFeatureTapped.remove(_onMapLibreFeatureTapped);
     _mapLibreController?.removeListener(_scheduleCameraFramingRefresh);
     _mapController.dispose();
+    _passageGuidance.dispose();
     _navigationGuidance.dispose();
     _sailorSpeedStalenessTimer?.cancel();
     _sailorSpeedStalenessTimer = null;
@@ -1823,9 +1835,14 @@ class _VoyageMapScreenState extends State<VoyageMapScreen> {
               builder: (context, assessment, _) {
                 final guidance = assessment.guidance;
                 return guidance == null
-                    ? _NavigationGuidanceStatusBanner(
-                        assessment: assessment,
-                        compact: cramped,
+                    ? ValueListenableBuilder<PassageGuidance?>(
+                        valueListenable: _passageGuidance,
+                        builder: (context, passage, _) =>
+                            _NavigationGuidanceStatusBanner(
+                              assessment: assessment,
+                              compact: cramped,
+                              passage: passage,
+                            ),
                       )
                     : _NavigationGuidanceBanner(
                         guidance: guidance,
@@ -3259,7 +3276,47 @@ class _VoyageMapScreenState extends State<VoyageMapScreen> {
     unawaited(_publishGroupPipSnapshot());
   }
 
+  /// The current fix as the instruments want it, or null with no position.
+  ///
+  /// The instrument sheet builds this too; extracted so the banner and the sheet
+  /// cannot disagree about what the receiver said.
+  NavigationFix? _instrumentFix(GeoPoint? position) {
+    final fix = _navigationFix;
+    final point = position ?? fix?.point ?? _effectivePosition;
+    if (point == null) return null;
+    return NavigationFix(
+      point: point,
+      recordedAt: fix?.recordedAt ?? DateTime.now(),
+      courseOverGroundDegrees: fix?.headingDegrees,
+      speedOverGroundMetersPerSecond: fix?.speedMetersPerSecond,
+      accuracyMeters: fix?.accuracyMeters,
+    );
+  }
+
+  /// Reads the passage against the fix, for the banner and (next) the voice.
+  void _updatePassageGuidance(GeoPoint? position) {
+    final route = _route;
+    final fix = _instrumentFix(position);
+    if (route == null || fix == null) {
+      _passageGuidance.value = null;
+      return;
+    }
+    final now = DateTime.now();
+    final plan = PassagePlan.of(route);
+    _passageGuidance.value = PassageGuidance.of(
+      plan: plan,
+      maneuvers: PassageManeuverPlan.of(plan),
+      instruments: NavigationInstruments.compute(
+        fix: fix,
+        plan: plan,
+        now: now,
+      ),
+      distanceUnit: widget.distanceUnit,
+    );
+  }
+
   void _updateNavigationGuidance(GeoPoint? position) {
+    _updatePassageGuidance(position);
     final navigationRoute = _rejoinRoute ?? _route;
     final next = _navigationGuidancePlanner.assess(
       route: navigationRoute,
@@ -8029,13 +8086,25 @@ class _NavigationGuidanceStatusBanner extends StatelessWidget {
   const _NavigationGuidanceStatusBanner({
     required this.assessment,
     required this.compact,
+    this.passage,
   });
 
   final NavigationGuidanceAssessment assessment;
   final bool compact;
 
+  /// The passage read against the current fix (#63).
+  ///
+  /// Preferred over [assessment] whenever there is a passage to report, which
+  /// is the whole point: `assessment` can only ever say "following the passage
+  /// line", because it is fed by the road planner and a passage has no
+  /// manoeuvres for it to describe. This says which leg, which mark, how far,
+  /// and what the plan asks for there.
+  final PassageGuidance? passage;
+
   @override
   Widget build(BuildContext context) {
+    final live = passage;
+    if (live != null && live.hasPassage) return _passageBanner(context, live);
     final (icon, color) = switch (assessment.state) {
       NavigationGuidanceState.waitingForLocation => (
         Icons.gps_not_fixed_rounded,
@@ -8100,6 +8169,107 @@ class _NavigationGuidanceStatusBanner extends StatelessWidget {
                       fontSize: compact ? 12 : 13,
                       fontWeight: FontWeight.w800,
                     ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Two lines: where the vessel is in the passage, and what is coming.
+  ///
+  /// The detail line is allowed to wrap to two, because "6 cables to run · then
+  /// alter 26° to port onto 068°T" is the sentence a helm is steering by and
+  /// truncating it to an ellipsis would lose the course.
+  Widget _passageBanner(BuildContext context, PassageGuidance live) {
+    final (icon, color) = switch (live.phase) {
+      PassagePhase.offTrack => (
+        Icons.swap_horiz_rounded,
+        const Color(0xFFFFC857),
+      ),
+      PassagePhase.waitingForFix => (
+        Icons.gps_not_fixed_rounded,
+        const Color(0xFFFFC857),
+      ),
+      PassagePhase.arriving => (Icons.flag_rounded, const Color(0xFF72D69C)),
+      PassagePhase.approachingMark => (
+        Icons.turn_sharp_right_rounded,
+        const Color(0xFF72D69C),
+      ),
+      PassagePhase.underWay || PassagePhase.noPassage => (
+        Icons.timeline_rounded,
+        const Color(0xFF68A9FF),
+      ),
+    };
+
+    return Semantics(
+      key: const Key('passage-guidance-banner'),
+      container: true,
+      liveRegion: true,
+      label: [live.headline, ?live.detail].join('. '),
+      excludeSemantics: true,
+      child: Align(
+        alignment: Alignment.topCenter,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 560),
+          child: Container(
+            padding: EdgeInsets.symmetric(
+              horizontal: compact ? 10 : 12,
+              vertical: compact ? 7 : 9,
+            ),
+            decoration: BoxDecoration(
+              color: voyageMapPrimaryPanelFill,
+              borderRadius: BorderRadius.circular(14),
+              border: Border.all(
+                color: live.needsAttention ? color : const Color(0xFF445262),
+              ),
+              boxShadow: const [
+                BoxShadow(
+                  color: Color(0x55000000),
+                  blurRadius: 10,
+                  offset: Offset(0, 3),
+                ),
+              ],
+            ),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.only(top: 1),
+                  child: Icon(icon, size: compact ? 20 : 22, color: color),
+                ),
+                const SizedBox(width: 7),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        live.headline,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          fontSize: compact ? 12 : 13,
+                          fontWeight: FontWeight.w800,
+                        ),
+                      ),
+                      if (live.detail case final detail?) ...[
+                        const SizedBox(height: 1),
+                        Text(
+                          detail,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(
+                            fontSize: compact ? 11 : 12,
+                            color: const Color(0xFFB9C4D0),
+                            height: 1.25,
+                          ),
+                        ),
+                      ],
+                    ],
                   ),
                 ),
               ],

--- a/apps/mobile/lib/features/voyage/active_voyage_shell.dart
+++ b/apps/mobile/lib/features/voyage/active_voyage_shell.dart
@@ -62,6 +62,7 @@ import '../../services/native_push_token_source.dart';
 import '../../services/position_report_policy.dart';
 import '../../services/received_quick_message.dart';
 import '../../services/navigation_guidance.dart';
+import '../../services/passage_guidance.dart';
 import '../../services/voyage_completion_detector.dart';
 import '../../services/route_progress.dart';
 import '../../services/voyage_membership.dart';
@@ -3062,6 +3063,7 @@ class _ActiveVoyageShellState extends State<ActiveVoyageShell>
       onLeaveVoyage: _confirmLeaveVoyageFromMap,
       onRouteCommitted: _onRouteChanged,
       onNavigationGuidanceChanged: _onNavigationGuidanceChanged,
+      onPassageGuidanceChanged: _speakPassage,
       changeRouteRequestToken: _changeRouteRequestToken,
       onChangeRouteRequestHandled: _clearChangeRouteRequest,
       pendingSharedGpxFile: _pendingSharedGpxFile,
@@ -3168,6 +3170,54 @@ class _ActiveVoyageShellState extends State<ActiveVoyageShell>
   /// already exists: it is what surfaces with no symbol beside them use, which is
   /// exactly what audio is. A roundabout says so out loud, where the banner can
   /// leave it to the drawn glyph.
+  /// Says what the passage asks for (#73).
+  ///
+  /// The voice has been mute on every passage since #19: `_speakGuidance` takes
+  /// a `NavigationGuidance`, which is built from a manoeuvre list, and a passage
+  /// has none. Everything else about speaking — the engine, the voice ranking,
+  /// the audio classes, the spoken-key set — was already here and had nothing to
+  /// say.
+  ///
+  /// `PassageGuidance.prompts` is state rather than a stream of events, so this
+  /// filters against the same `_spokenGuidanceKeys` the road path uses. A prompt
+  /// present on twenty consecutive fixes is said once.
+  void _speakPassage(PassageGuidance? passage) {
+    final speaker = _spokenGuidance;
+    if (speaker == null || passage == null) return;
+    final controller = widget.voyageController;
+
+    for (final prompt in passage.prompts) {
+      if (_spokenGuidanceKeys.contains(prompt.key)) continue;
+      // Added before the await, so a slow engine cannot let the same prompt
+      // fire again on the next fix.
+      _spokenGuidanceKeys.add(prompt.key);
+      _diagnostics?.recordSpokenPrompt(
+        phrase: prompt.spoken,
+        distanceToManoeuvreMeters: passage.instruments.distanceToMark.value,
+      );
+      unawaited(
+        speaker.speakManoeuvre(
+          key: prompt.key,
+          phrase: prompt.spoken,
+          // A stale fix is a warning about the instruments rather than a
+          // direction, so it is `safety` and survives an alerts-only mode. The
+          // rest is navigation and is silenced with it, which is what a sailor
+          // choosing alerts-only asked for.
+          enabled: spokenAudioAllows(
+            _spokenAudioMode,
+            prompt.kind == PassagePromptKind.staleFix
+                ? SpokenAudioClass.safety
+                : SpokenAudioClass.navigation,
+          ),
+          voyageActive:
+              controller.voyageStarted &&
+              !controller.voyageEnded &&
+              !controller.voyagePaused,
+        ),
+      );
+    }
+  }
+
   void _speakGuidance(NavigationGuidance? guidance) {
     if (guidance == null) return;
     final controller = widget.voyageController;

--- a/apps/mobile/lib/services/navigation_guidance.dart
+++ b/apps/mobile/lib/services/navigation_guidance.dart
@@ -194,15 +194,17 @@ class NavigationGuidance {
 enum NavigationGuidanceState {
   noRoute,
   waitingForLocation,
-  noManeuvers,
 
-  /// The route was meant to be routed and is not.
+  /// A passage carries no manoeuvres, and that is correct.
   ///
-  /// Distinct from [noManeuvers] because the two need different things from a
-  /// sailor: an imported track without prompts is working as intended and can be
-  /// followed, while this one lost its directions to a failure and can be made
-  /// to work again (#303).
-  routingUnfinished,
+  /// `routingUnfinished` sat beside this until #72. It existed because a
+  /// `RoutePathKind.route` path with no manoeuvres used to mean one thing only:
+  /// a road-routing request that failed. #19 deleted the router, so an empty
+  /// manoeuvre list is now the normal state of every passage - and the old
+  /// reading told a sailor whose GPX carried a `<rte>` that their perfectly good
+  /// passage was broken, and to re-import it, which produced the same message
+  /// forever.
+  noManeuvers,
   offRoute,
   active,
   complete,
@@ -310,8 +312,15 @@ class NavigationGuidancePlanner {
   /// where the original can be preserved and compared safely (#325). This
   /// riding-state message stays concise and truthful for someone who chose to
   /// follow the original line.
+  /// What a passage has instead of turn prompts.
+  ///
+  /// Points at what exists rather than naming what does not. A passage carries
+  /// legs, courses and alterations, all of which are one tap away, and the
+  /// previous wording - "No turn prompts for this route" - both used a road word
+  /// and undersold the surface it was standing on (#72).
   static const noTurnInstructionsMessage =
-      'No turn prompts for this route — follow the line on the map.';
+      'Following the passage line. Courses and alterations are in the leg '
+      'table.';
 
   /// Shown when there is no line to follow at all, which is a different problem:
   /// the sailor has nothing, rather than something without prompts. These two
@@ -320,21 +329,15 @@ class NavigationGuidancePlanner {
   static const noRouteLineMessage =
       'This route has no path to follow. Choose or import it again.';
 
-  /// Shown when routing was meant to happen for this route and did not.
-  ///
-  /// `RouteGeometryEnricher` converts a `RoutePathKind.route` path into a
-  /// `track` when the routing engine answers, and leaves it a `route` when the
-  /// request fails. A surviving `route` path with no manoeuvres is therefore a
-  /// routing failure that outlived the import it happened during: the enricher
-  /// returns a warning, but nothing carried it onto the route, so by riding
-  /// time the sailor saw the same words as an imported track (#303).
-  ///
-  /// They are not the same. One is working as intended and can be followed; the
-  /// other can be made to work again, and only this wording tells a sailor which
-  /// they have.
-  static const routingUnfinishedMessage =
-      'Directions could not be built for this route — the line is the raw '
-      'import. Re-import it to try again.';
+  // `routingUnfinishedMessage` was here (#72). It read:
+  //
+  //   "Directions could not be built for this route — the line is the raw
+  //    import. Re-import it to try again."
+  //
+  // Both halves were false on every passage. A GPX carrying a `<rte>` element -
+  // how every plotter exports a passage - took this branch, and re-importing
+  // produced the identical message, because the absence it was reading is by
+  // design since #19. The advice could not succeed.
 
   NavigationGuidance? plan({
     required ImportedRoute? route,
@@ -367,18 +370,12 @@ class NavigationGuidancePlanner {
       );
     }
     if (route.maneuvers.isEmpty) {
-      // A path still marked `route` was never turned into road geometry, which
-      // only happens when the routing request for it failed.
-      final unrouted = route.paths.any(
-        (path) => path.kind == RoutePathKind.route && path.points.length >= 2,
-      );
-      return NavigationGuidanceAssessment(
-        state: unrouted
-            ? NavigationGuidanceState.routingUnfinished
-            : NavigationGuidanceState.noManeuvers,
-        message: unrouted
-            ? routingUnfinishedMessage
-            : noTurnInstructionsMessage,
+      // Always the normal case now. A passage has no manoeuvres, so there is
+      // nothing here to distinguish and nothing to report as a failure (#72).
+      // The path kind used to decide between two messages; it decides nothing.
+      return const NavigationGuidanceAssessment(
+        state: NavigationGuidanceState.noManeuvers,
+        message: noTurnInstructionsMessage,
       );
     }
     final path = _primaryPath(route.paths);

--- a/apps/mobile/lib/services/passage_guidance.dart
+++ b/apps/mobile/lib/services/passage_guidance.dart
@@ -1,0 +1,470 @@
+/// What the passage asks for, where the vessel actually is.
+///
+/// The piece that was missing (#63, #73). Everything it needs already existed
+/// and none of it was joined up: `PassagePlan` knew the legs, `PassageManeuverPlan`
+/// knew the alterations, `NavigationInstruments` knew where the vessel was and
+/// how stale that knowledge was — and the surface under way was still being fed
+/// by the road guidance planner, which had nothing to say about any of it.
+///
+/// So this reads all three and answers the four questions a navigator asks under
+/// way: which leg am I on, what is next, how far is it, and what does the plan
+/// ask for when I get there.
+///
+/// ## It reports the plan; it does not decide anything
+///
+/// `PLAN.md` requires that guidance "never issues helm commands". The
+/// distinction worth holding: "alter 22 degrees to port onto 074" is the course
+/// *the sailor themselves planned*, read back at the moment it becomes
+/// relevant — the same figures the leg table shows in writing. Nothing here
+/// chooses a course, avoids a hazard, or judges whether the plan is safe. It
+/// cannot: there is no chart under it (#17), no depth (#29) and no tide (#11).
+///
+/// ## Prompts are state, not events
+///
+/// [PassageGuidance.prompts] is what is *currently* worth saying, each with a
+/// stable [PassagePrompt.key]. Whoever speaks them keeps the set it has already
+/// said and skips those — which is what `active_voyage_shell` already does with
+/// its spoken-key set. Emitting events instead would mean this service owning a
+/// timeline, and a service that owns a timeline cannot be tested by handing it a
+/// position.
+library;
+
+import '../domain/distance_unit.dart';
+import 'measurement_formatter.dart';
+import 'navigation_instruments.dart';
+import 'passage_legs.dart';
+import 'passage_maneuvers.dart';
+
+/// Metres in a nautical mile.
+const _metresPerNauticalMile = 1852.0;
+
+/// Metres in a cable, a tenth of a nautical mile.
+const _metresPerCable = _metresPerNauticalMile / 10;
+
+/// Where the vessel is in the passage.
+enum PassagePhase {
+  /// Nothing planned. COG and SOG still work; there is simply no passage to
+  /// report progress against.
+  noPassage,
+
+  /// A passage, but no position yet — or one too old to use.
+  waitingForFix,
+
+  /// On a leg, with the next mark more than an approach away.
+  underWay,
+
+  /// Inside [PassageGuidancePolicy.approachMeters] of the next mark, which is
+  /// when the alteration waiting there stops being reference and becomes
+  /// something to prepare for.
+  approachingMark,
+
+  /// Off the planned track by more than the policy allows.
+  ///
+  /// Not a failure state and not exclusive of the others in reality — a vessel
+  /// can be off track *and* approaching a mark. Reported as the phase because it
+  /// is the more urgent of the two: a sailor a cable off the line wants to know
+  /// that before they want the next course.
+  offTrack,
+
+  /// The last mark is within an approach.
+  arriving,
+}
+
+/// Why something is worth saying aloud.
+enum PassagePromptKind {
+  /// The next mark is a mile off. Twelve minutes at five knots — time to get
+  /// the next course in mind, which is the point of prompting this early.
+  markAhead,
+
+  /// The next mark is two cables off. Time to steer it.
+  markImminent,
+
+  /// Off the planned track by more than the policy allows.
+  offTrack,
+
+  /// The fix is too old to trust, which makes every calculated reading suspect.
+  staleFix,
+
+  /// The last mark is an approach away.
+  arriving,
+}
+
+/// One thing worth saying, once.
+class PassagePrompt {
+  const PassagePrompt({
+    required this.kind,
+    required this.key,
+    required this.spoken,
+  });
+
+  final PassagePromptKind kind;
+
+  /// Stable for as long as this prompt means the same thing, so a speaker that
+  /// remembers what it has said does not repeat it. Includes the mark it is
+  /// about, so the same kind of prompt at the next mark is a different prompt.
+  final String key;
+
+  /// The words, written to be *heard*: three-figure courses digit by digit,
+  /// distances in cables inside a mile, no abbreviations a voice would spell out.
+  final String spoken;
+}
+
+/// Thresholds, stated rather than scattered.
+class PassageGuidancePolicy {
+  const PassageGuidancePolicy({
+    this.approachMeters = _metresPerNauticalMile,
+    this.imminentMeters = 2 * _metresPerCable,
+    this.offTrackMeters = _metresPerCable,
+  });
+
+  /// How far out a mark is "ahead".
+  ///
+  /// One nautical mile. A yacht at five knots covers that in twelve minutes,
+  /// which is the warning a navigator actually wants — road prompt distances of
+  /// a couple of hundred metres would fire nine seconds before the mark.
+  final double approachMeters;
+
+  /// How far out a mark is "imminent". Two cables, about 370 m: close enough to
+  /// be steering it, far enough to settle on the new course.
+  final double imminentMeters;
+
+  /// How far off the planned track is worth mentioning. One cable.
+  final double offTrackMeters;
+}
+
+/// The passage, as it stands right now.
+class PassageGuidance {
+  const PassageGuidance({
+    required this.phase,
+    required this.headline,
+    required this.instruments,
+    this.detail,
+    this.activeLeg,
+    this.legCount = 0,
+    this.alterationAhead,
+    this.prompts = const [],
+  });
+
+  final PassagePhase phase;
+
+  /// One line for the banner: where the vessel is in the passage.
+  final String headline;
+
+  /// A second line when there is more worth saying — the distance to run and
+  /// the alteration waiting at the mark. Null when the headline says it all.
+  final String? detail;
+
+  final NavigationInstruments instruments;
+
+  final PassageLeg? activeLeg;
+  final int legCount;
+
+  /// The alteration at the end of [activeLeg], when the plan asks for one there.
+  ///
+  /// Null both when the mark needs no alteration and when it is the last mark.
+  /// The list surface distinguishes those; under way the difference does not
+  /// change what a sailor does.
+  final PassageManeuver? alterationAhead;
+
+  /// What is worth saying now. Empty is the normal case.
+  final List<PassagePrompt> prompts;
+
+  bool get hasPassage => phase != PassagePhase.noPassage;
+
+  /// Whether the surface should draw attention to itself.
+  bool get needsAttention =>
+      phase == PassagePhase.offTrack ||
+      phase == PassagePhase.approachingMark ||
+      phase == PassagePhase.arriving;
+
+  /// Reads the passage against a fix.
+  ///
+  /// [maneuvers] is passed in rather than derived here so the caller can share
+  /// one `PassageManeuverPlan` with the list surface — deriving it twice would
+  /// let the two disagree about how many alterations a passage has.
+  static PassageGuidance of({
+    required PassagePlan plan,
+    required PassageManeuverPlan maneuvers,
+    required NavigationInstruments instruments,
+    PassageGuidancePolicy policy = const PassageGuidancePolicy(),
+    DistanceUnit distanceUnit = DistanceUnit.nauticalMiles,
+  }) {
+    final formatter = MeasurementFormatter(distanceUnit);
+
+    if (!plan.hasLegs) {
+      return PassageGuidance(
+        phase: PassagePhase.noPassage,
+        headline: 'No passage planned',
+        instruments: instruments,
+      );
+    }
+
+    final leg = instruments.activeLeg;
+    if (leg == null || instruments.fixIsStale) {
+      return PassageGuidance(
+        phase: PassagePhase.waitingForFix,
+        headline: instruments.fixIsStale
+            ? 'Position is stale'
+            : 'Waiting for a position',
+        detail: instruments.fixIsStale
+            // Said in the same breath as the reason, because the readings are
+            // still on screen and a sailor needs to know not to steer by them.
+            ? 'Last fix ${_spokenAge(instruments.fixAge)} ago. Readings below '
+                  'are from it.'
+            : 'The passage is ready. ${plan.legs.length} legs.',
+        instruments: instruments,
+        legCount: plan.legs.length,
+        prompts: instruments.fixIsStale
+            ? [
+                PassagePrompt(
+                  kind: PassagePromptKind.staleFix,
+                  key: 'stale-fix',
+                  spoken:
+                      'Position is stale. Last fix '
+                      '${_spokenAge(instruments.fixAge)} ago.',
+                ),
+              ]
+            : const [],
+      );
+    }
+
+    final distanceMeters = instruments.distanceToMark.value;
+    final isLastLeg = leg.number == plan.legs.length;
+    final alteration = maneuvers.maneuvers
+        .where((maneuver) => maneuver.markLabel == leg.toLabel)
+        .firstOrNull;
+
+    final crossTrack = instruments.crossTrackError.value;
+    final offTrack = crossTrack != null && crossTrack > policy.offTrackMeters;
+    final imminent =
+        distanceMeters != null && distanceMeters <= policy.imminentMeters;
+    final approaching =
+        distanceMeters != null && distanceMeters <= policy.approachMeters;
+
+    final phase = offTrack
+        ? PassagePhase.offTrack
+        : isLastLeg && approaching
+        ? PassagePhase.arriving
+        : approaching
+        ? PassagePhase.approachingMark
+        : PassagePhase.underWay;
+
+    return PassageGuidance(
+      phase: phase,
+      headline: switch (phase) {
+        PassagePhase.offTrack =>
+          '${formatter.distance(crossTrack!)} off track to '
+              '${instruments.offTrackSide?.label ?? 'one side'}',
+        PassagePhase.arriving => 'Arriving at ${leg.toLabel}',
+        PassagePhase.approachingMark => 'Approaching ${leg.toLabel}',
+        _ => 'Leg ${leg.number} of ${plan.legs.length} to ${leg.toLabel}',
+      },
+      detail: _detailFor(
+        phase: phase,
+        leg: leg,
+        legCount: plan.legs.length,
+        distanceMeters: distanceMeters,
+        alteration: alteration,
+        formatter: formatter,
+        offTrackSide: instruments.offTrackSide,
+      ),
+      instruments: instruments,
+      activeLeg: leg,
+      legCount: plan.legs.length,
+      alterationAhead: alteration,
+      prompts: _promptsFor(
+        leg: leg,
+        distanceMeters: distanceMeters,
+        alteration: alteration,
+        isLastLeg: isLastLeg,
+        imminent: imminent,
+        approaching: approaching,
+        offTrack: offTrack,
+        crossTrackMeters: crossTrack,
+        offTrackSide: instruments.offTrackSide,
+      ),
+    );
+  }
+
+  static String? _detailFor({
+    required PassagePhase phase,
+    required PassageLeg leg,
+    required int legCount,
+    required double? distanceMeters,
+    required PassageManeuver? alteration,
+    required MeasurementFormatter formatter,
+    required TrackSide? offTrackSide,
+  }) {
+    final parts = <String>[];
+
+    if (phase == PassagePhase.offTrack) {
+      // The course back is the leg's own course; steering toward the track is
+      // the sailor's decision and this only says which way that is.
+      parts.add(
+        'Track is to ${offTrackSide?.opposite.label ?? 'the other side'}. '
+        "Leg ${leg.number}'s course is ${_threeFigures(leg.courseDegreesTrue)}°T",
+      );
+    }
+
+    if (distanceMeters != null && phase != PassagePhase.offTrack) {
+      parts.add('${formatter.distance(distanceMeters)} to run');
+    }
+
+    if (alteration != null) {
+      parts.add(
+        'then alter ${alteration.alterationDegrees.round()}° to '
+        '${alteration.side.label} onto '
+        '${_threeFigures(alteration.outboundCourseDegreesTrue)}°T',
+      );
+    } else if (phase == PassagePhase.arriving) {
+      parts.add('last mark of the passage');
+    }
+
+    return parts.isEmpty ? null : parts.join(' · ');
+  }
+
+  static List<PassagePrompt> _promptsFor({
+    required PassageLeg leg,
+    required double? distanceMeters,
+    required PassageManeuver? alteration,
+    required bool isLastLeg,
+    required bool imminent,
+    required bool approaching,
+    required bool offTrack,
+    required double? crossTrackMeters,
+    required TrackSide? offTrackSide,
+  }) {
+    final prompts = <PassagePrompt>[];
+
+    if (offTrack && crossTrackMeters != null) {
+      prompts.add(
+        PassagePrompt(
+          kind: PassagePromptKind.offTrack,
+          // Keyed on the leg, so drifting off the same leg twice does not
+          // announce twice, but doing it on the next leg does.
+          key: 'off-track-leg-${leg.number}',
+          spoken:
+              '${_spokenDistance(crossTrackMeters)} off track to '
+              '${offTrackSide?.label ?? 'one side'}. '
+              "Leg ${leg.number}'s course is "
+              '${_spokenCourse(leg.courseDegreesTrue)}.',
+        ),
+      );
+    }
+
+    if (distanceMeters == null) return prompts;
+
+    if (isLastLeg && approaching) {
+      prompts.add(
+        PassagePrompt(
+          kind: PassagePromptKind.arriving,
+          key: 'arriving-${leg.toLabel}',
+          spoken:
+              '${_spokenDistance(distanceMeters)} to ${leg.toLabel}, '
+              'the last mark.',
+        ),
+      );
+      return prompts;
+    }
+
+    // Imminent supersedes ahead: two prompts about the same mark in the same
+    // breath is noise, and the nearer one is the one that matters.
+    if (imminent) {
+      prompts.add(
+        PassagePrompt(
+          kind: PassagePromptKind.markImminent,
+          key: 'mark-imminent-${leg.toLabel}',
+          spoken: _markPhrase(leg, distanceMeters, alteration),
+        ),
+      );
+    } else if (approaching) {
+      prompts.add(
+        PassagePrompt(
+          kind: PassagePromptKind.markAhead,
+          key: 'mark-ahead-${leg.toLabel}',
+          spoken: _markPhrase(leg, distanceMeters, alteration),
+        ),
+      );
+    }
+
+    return prompts;
+  }
+
+  static String _markPhrase(
+    PassageLeg leg,
+    double distanceMeters,
+    PassageManeuver? alteration,
+  ) {
+    final approach = '${_spokenDistance(distanceMeters)} to ${leg.toLabel}';
+    if (alteration == null) return '$approach.';
+    return '$approach, then alter '
+        '${alteration.alterationDegrees.round()} degrees to '
+        '${alteration.side.label} onto '
+        '${_spokenCourse(alteration.outboundCourseDegreesTrue)}.';
+  }
+}
+
+/// Three figures, rounded before normalising so 359.6 reads 000 rather than 360.
+String _threeFigures(double degreesTrue) {
+  final normalised = ((degreesTrue.round() % 360) + 360) % 360;
+  return normalised.toString().padLeft(3, '0');
+}
+
+/// A course as it is passed aloud: "zero seven four", not "seventy four".
+///
+/// Digit by digit is how a course is read over a radio or across a cockpit, and
+/// it is unambiguous through wind noise in a way "seventy four" is not — which
+/// could be 074 or 74 spoken carelessly for 274.
+String _spokenCourse(double degreesTrue) {
+  const names = [
+    'zero',
+    'one',
+    'two',
+    'three',
+    'four',
+    'five',
+    'six',
+    'seven',
+    'eight',
+    'nine',
+  ];
+  return _threeFigures(
+    degreesTrue,
+  ).split('').map((digit) => names[int.parse(digit)]).join(' ');
+}
+
+/// A distance as it is said at sea: cables inside a mile, miles beyond.
+///
+/// Deliberately not `MeasurementFormatter`, which writes for the eye: "2.5 NM"
+/// is right on screen and wrong in the ear, where it wants to be "two point five
+/// miles". Numerals a voice has to expand are a source of mis-hearing.
+String _spokenDistance(double meters) {
+  final cables = meters / _metresPerCable;
+  if (cables < 1) return 'less than a cable';
+  if (cables < 10) {
+    final rounded = cables.round();
+    return rounded == 1 ? 'one cable' : '$rounded cables';
+  }
+  final miles = meters / _metresPerNauticalMile;
+  if (miles < 10) {
+    final tenths = (miles * 10).round();
+    if (tenths % 10 == 0) {
+      final whole = tenths ~/ 10;
+      return whole == 1 ? 'one mile' : '$whole miles';
+    }
+    return '${tenths ~/ 10} point ${tenths % 10} miles';
+  }
+  return '${miles.round()} miles';
+}
+
+/// A fix age in words rather than a duration a voice would read as digits.
+String _spokenAge(Duration age) {
+  if (age.inSeconds < 60) {
+    final seconds = age.inSeconds;
+    return seconds <= 1 ? 'a second' : '$seconds seconds';
+  }
+  final minutes = age.inMinutes;
+  if (minutes < 60) return minutes == 1 ? 'a minute' : '$minutes minutes';
+  final hours = age.inHours;
+  return hours == 1 ? 'an hour' : '$hours hours';
+}

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.2+23
+version: 1.0.3+24
 
 environment:
   sdk: ^3.12.2

--- a/apps/mobile/test/features/map/passage_guidance_banner_test.dart
+++ b/apps/mobile/test/features/map/passage_guidance_banner_test.dart
@@ -1,0 +1,147 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tide_and_seek/domain/distance_unit.dart';
+import 'package:tide_and_seek/domain/imported_route.dart';
+import 'package:tide_and_seek/services/navigation_instruments.dart';
+import 'package:tide_and_seek/services/passage_guidance.dart';
+import 'package:tide_and_seek/services/passage_legs.dart';
+import 'package:tide_and_seek/services/passage_maneuvers.dart';
+
+/// #63 step 3. The banner under way was fed by the road guidance planner, which
+/// on a passage could only ever say "following the passage line" — true, and
+/// useless to somebody steering. These check what it says instead.
+///
+/// Driven through `PassageGuidance` and rendered into the same two-line shape
+/// the banner uses, rather than through the map widget, which needs a platform
+/// view. What is under test is the words a helm reads.
+void main() {
+  testWidgets('under way it names the leg and the mark', (tester) async {
+    await _pump(tester, const GeoPoint(latitude: 50.6975, longitude: -1.4450));
+
+    expect(find.textContaining('Leg 1 of 3'), findsOneWidget);
+    expect(find.textContaining('Hamstead'), findsWidgets);
+    expect(find.textContaining('to run'), findsOneWidget);
+  });
+
+  testWidgets('approaching a mark it shows the alteration waiting there', (
+    tester,
+  ) async {
+    await _pump(tester, const GeoPoint(latitude: 50.6958, longitude: -1.4145));
+
+    expect(find.textContaining('Approaching Hamstead'), findsOneWidget);
+    expect(find.textContaining('alter'), findsOneWidget);
+    // Three figures and true, the same as the leg table says in writing.
+    expect(find.textContaining('°T'), findsOneWidget);
+  });
+
+  testWidgets('arriving it says so instead of offering a next course', (
+    tester,
+  ) async {
+    await _pump(tester, const GeoPoint(latitude: 50.7420, longitude: -1.3060));
+
+    expect(find.textContaining('Arriving at Cowes'), findsOneWidget);
+    expect(find.textContaining('last mark'), findsOneWidget);
+  });
+
+  testWidgets('a stale fix says the readings below came from it', (
+    tester,
+  ) async {
+    await _pump(
+      tester,
+      const GeoPoint(latitude: 50.6958, longitude: -1.4145),
+      fixAge: const Duration(minutes: 4),
+    );
+
+    expect(find.textContaining('Position is stale'), findsOneWidget);
+    expect(find.textContaining('Readings below'), findsOneWidget);
+    // And not the mark it happens to be near, which would invite steering by a
+    // four-minute-old position.
+    expect(find.textContaining('Approaching'), findsNothing);
+  });
+
+  testWidgets('it never falls back to the road planner wording', (
+    tester,
+  ) async {
+    await _pump(tester, const GeoPoint(latitude: 50.6975, longitude: -1.4450));
+
+    expect(find.textContaining('Following the passage line'), findsNothing);
+    expect(find.textContaining('turn'), findsNothing);
+  });
+}
+
+Future<void> _pump(
+  WidgetTester tester,
+  GeoPoint point, {
+  Duration fixAge = Duration.zero,
+}) async {
+  final now = DateTime.utc(2026, 8, 20, 12);
+  final plan = PassagePlan.of(_passage());
+  final guidance = PassageGuidance.of(
+    plan: plan,
+    maneuvers: PassageManeuverPlan.of(plan),
+    instruments: NavigationInstruments.compute(
+      fix: NavigationFix(
+        point: point,
+        recordedAt: now.subtract(fixAge),
+        courseOverGroundDegrees: 80,
+        speedOverGroundMetersPerSecond: 2.6,
+        accuracyMeters: 5,
+      ),
+      plan: plan,
+      now: now,
+    ),
+    distanceUnit: DistanceUnit.nauticalMiles,
+  );
+
+  await tester.pumpWidget(
+    MaterialApp(
+      theme: ThemeData.dark(useMaterial3: true),
+      home: Scaffold(
+        body: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(guidance.headline),
+            if (guidance.detail case final detail?) Text(detail),
+          ],
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+ImportedRoute _passage() => ImportedRoute(
+  id: 'solent',
+  name: 'Lymington to Cowes',
+  importedAt: DateTime.utc(2026, 8, 20),
+  sourceFileName: 'solent.gpx',
+  paths: const [
+    RoutePath(
+      kind: RoutePathKind.route,
+      points: [
+        GeoPoint(latitude: 50.7000, longitude: -1.5000),
+        GeoPoint(latitude: 50.6950, longitude: -1.4000),
+        GeoPoint(latitude: 50.7100, longitude: -1.3400),
+        GeoPoint(latitude: 50.7500, longitude: -1.3000),
+      ],
+    ),
+  ],
+  waypoints: const [
+    RouteWaypoint(
+      name: 'Lymington',
+      point: GeoPoint(latitude: 50.7000, longitude: -1.5000),
+    ),
+    RouteWaypoint(
+      name: 'Hamstead',
+      point: GeoPoint(latitude: 50.6950, longitude: -1.4000),
+    ),
+    RouteWaypoint(
+      name: 'Salt Mead',
+      point: GeoPoint(latitude: 50.7100, longitude: -1.3400),
+    ),
+    RouteWaypoint(
+      name: 'Cowes',
+      point: GeoPoint(latitude: 50.7500, longitude: -1.3000),
+    ),
+  ],
+);

--- a/apps/mobile/test/services/navigation_guidance_test.dart
+++ b/apps/mobile/test/services/navigation_guidance_test.dart
@@ -173,7 +173,7 @@ void main() {
       ],
     );
 
-    test('a followable line without prompts says to follow the line', () {
+    test('a followable line points at what the passage does have', () {
       final assessment = planner.assess(
         route: routeWith(paths: const [followableLine]),
         position: const GeoPoint(latitude: 0, longitude: 0),
@@ -187,8 +187,10 @@ void main() {
       );
       expect(
         assessment.message,
-        contains('follow the line'),
-        reason: 'the route is usable; only the prompts are missing',
+        contains('leg table'),
+        reason:
+            'the passage is usable and its courses are one tap away; naming '
+            'the absence of turn prompts undersold that (#72)',
       );
     });
 
@@ -1023,9 +1025,11 @@ void _guidanceStateTests() {
       expect(assessment.state, NavigationGuidanceState.active);
     });
 
-    test('an imported track says the line is followable', () {
-      // A GPX track is a line without instructions. Nothing failed, and the
-      // sailor can voyage it.
+    // #72. These two used to give different answers, and one of them was a lie.
+    // A `route`-kind path with no manoeuvres meant "road routing failed" when a
+    // road router existed; since #19 it means "this is a passage". Both kinds
+    // are now reported the same way, because they are the same thing.
+    test('an imported track is followable, and says so', () {
       final assessment = assess(
         _routeWith(
           paths: const [RoutePath(kind: RoutePathKind.track, points: _line)],
@@ -1033,34 +1037,57 @@ void _guidanceStateTests() {
       );
 
       expect(assessment.state, NavigationGuidanceState.noManeuvers);
-      expect(assessment.message, contains('follow the line'));
+      expect(assessment.message, contains('leg table'));
     });
 
-    test('a route whose routing failed says so instead', () {
-      // `RouteGeometryEnricher` turns a `route` path into a `track` when the
-      // engine answers and leaves it a `route` when the request fails. The
-      // warning it returns is gone by riding time; this is what survives.
+    test('a rte-kind passage is not reported as a failure', () {
+      // The defect: every plotter exports a passage as `<rte>`, which imports as
+      // a `route` path, which took the failure branch. A sailor was told their
+      // good passage could not be routed and to re-import it - advice that
+      // produced the identical message every time.
       final assessment = assess(
         _routeWith(
           paths: const [RoutePath(kind: RoutePathKind.route, points: _line)],
         ),
       );
 
-      expect(assessment.state, NavigationGuidanceState.routingUnfinished);
-      expect(assessment.message, contains('could not be built'));
-      // Never the imported-track wording, which would tell a sailor nothing is
-      // wrong when something is.
-      expect(assessment.message, isNot(contains('follow the line')));
+      expect(assessment.state, NavigationGuidanceState.noManeuvers);
+      expect(assessment.message, contains('leg table'));
+      expect(assessment.message, isNot(contains('could not be built')));
+      expect(assessment.message, isNot(contains('Re-import')));
     });
 
-    test('the three states never share a message', () {
+    test('both path kinds are told exactly the same thing', () {
+      String messageFor(RoutePathKind kind) => assess(
+        _routeWith(
+          paths: [RoutePath(kind: kind, points: _line)],
+        ),
+      ).message;
+
+      expect(
+        messageFor(RoutePathKind.route),
+        messageFor(RoutePathKind.track),
+        reason: 'the path kind decides nothing about a passage now',
+      );
+    });
+
+    test('the remaining states never share a message', () {
       final messages = {
         NavigationGuidancePlanner.noTurnInstructionsMessage,
         NavigationGuidancePlanner.noRouteLineMessage,
-        NavigationGuidancePlanner.routingUnfinishedMessage,
       };
 
-      expect(messages, hasLength(3));
+      expect(messages, hasLength(2));
+    });
+
+    test('nothing tells a sailor to re-import a passage', () {
+      // The whole point. Re-importing could never have helped.
+      for (final message in [
+        NavigationGuidancePlanner.noTurnInstructionsMessage,
+        NavigationGuidancePlanner.noRouteLineMessage,
+      ]) {
+        expect(message.toLowerCase(), isNot(contains('re-import')));
+      }
     });
 
     test('a route with no line at all is a third thing again', () {

--- a/apps/mobile/test/services/passage_guidance_test.dart
+++ b/apps/mobile/test/services/passage_guidance_test.dart
@@ -1,0 +1,381 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tide_and_seek/domain/imported_route.dart';
+import 'package:tide_and_seek/services/navigation_instruments.dart';
+import 'package:tide_and_seek/services/passage_guidance.dart';
+import 'package:tide_and_seek/services/passage_legs.dart';
+import 'package:tide_and_seek/services/passage_maneuvers.dart';
+
+/// #63 and #73. The piece that joins a planned passage to where the vessel
+/// actually is — which nothing did, so the surface under way was fed by the road
+/// guidance planner and said nothing about legs, marks or alterations.
+///
+/// The prompts matter most here. They are the words a sailor hears while
+/// steering, so these tests read them as sentences rather than checking fields:
+/// a course spoken "seventy four" instead of "zero seven four" is a real hazard
+/// through wind noise, and "2.5 NM" is right on a screen and wrong in an ear.
+void main() {
+  // Lymington eastward: three legs, roughly 096, 074, then 059.
+  const lymington = GeoPoint(latitude: 50.7000, longitude: -1.5000);
+  // ignore: unused_local_variable
+  const hamstead = GeoPoint(latitude: 50.6950, longitude: -1.4000);
+  // ignore: unused_local_variable
+  const saltMead = GeoPoint(latitude: 50.7100, longitude: -1.3400);
+  // ignore: unused_local_variable
+  const cowes = GeoPoint(latitude: 50.7500, longitude: -1.3000);
+
+  group('with no passage', () {
+    test('says so, and still reports position instruments', () {
+      final guidance = _guidanceAt(lymington, plan: PassagePlan.empty);
+
+      expect(guidance.phase, PassagePhase.noPassage);
+      expect(guidance.headline, 'No passage planned');
+      expect(guidance.hasPassage, isFalse);
+      expect(guidance.prompts, isEmpty);
+      // A sailor with no passage still wants COG and SOG.
+      expect(guidance.instruments, isNotNull);
+    });
+  });
+
+  group('under way', () {
+    test('names the leg, its mark, and how many there are', () {
+      // Just off Lymington, so the first leg with a long way to run.
+      final guidance = _guidanceAt(
+        const GeoPoint(latitude: 50.6995, longitude: -1.4900),
+      );
+
+      expect(guidance.phase, PassagePhase.underWay);
+      expect(guidance.headline, 'Leg 1 of 3 to Hamstead');
+      expect(guidance.legCount, 3);
+      expect(guidance.activeLeg?.number, 1);
+    });
+
+    test('says nothing aloud when the mark is more than a mile off', () {
+      final guidance = _guidanceAt(
+        const GeoPoint(latitude: 50.6995, longitude: -1.4900),
+      );
+      // Silence is the normal state. A prompt every update would be unusable.
+      expect(guidance.prompts, isEmpty);
+    });
+
+    test('shows the distance to run', () {
+      final guidance = _guidanceAt(
+        const GeoPoint(latitude: 50.6995, longitude: -1.4900),
+      );
+      expect(guidance.detail, contains('to run'));
+    });
+  });
+
+  group('approaching a mark', () {
+    // A mile out from Hamstead, still on the first leg.
+    final approach = _guidanceAt(
+      const GeoPoint(latitude: 50.6960, longitude: -1.4150),
+    );
+
+    test('changes phase and headline', () {
+      expect(approach.phase, PassagePhase.approachingMark);
+      expect(approach.headline, 'Approaching Hamstead');
+      expect(approach.needsAttention, isTrue);
+    });
+
+    test('carries the alteration waiting there', () {
+      expect(approach.alterationAhead, isNotNull);
+      expect(approach.detail, contains('alter'));
+      expect(approach.detail, contains('°T'));
+    });
+
+    test('speaks the mark and the alteration in one prompt', () {
+      final prompt = approach.prompts.single;
+
+      expect(prompt.kind, PassagePromptKind.markAhead);
+      expect(prompt.spoken, contains('Hamstead'));
+      expect(prompt.spoken, contains('alter'));
+      expect(prompt.spoken, contains('degrees to'));
+    });
+
+    test('speaks the course digit by digit, not as a number', () {
+      final spoken = approach.prompts.single.spoken;
+
+      // "zero seven four", never "74" or "seventy four": digit by digit is how
+      // a course is passed aloud, and it survives wind noise.
+      expect(
+        spoken,
+        matches(
+          RegExp(
+            r'(zero|one|two|three|four|five|six|seven|eight|nine) '
+            r'(zero|one|two|three|four|five|six|seven|eight|nine) '
+            r'(zero|one|two|three|four|five|six|seven|eight|nine)',
+          ),
+        ),
+      );
+      expect(spoken, isNot(contains('°')));
+      expect(spoken, isNot(matches(RegExp(r'\bonto \d'))));
+    });
+
+    test('speaks distance in words a voice can say', () {
+      final spoken = approach.prompts.single.spoken;
+
+      expect(spoken, isNot(contains('NM')));
+      expect(spoken, anyOf(contains('cable'), contains('mile')));
+    });
+  });
+
+  group('with the mark imminent', () {
+    // Two cables off Hamstead.
+    final imminent = _guidanceAt(
+      const GeoPoint(latitude: 50.6952, longitude: -1.4030),
+    );
+
+    test('is a different prompt from the one a mile out', () {
+      final prompt = imminent.prompts.single;
+
+      expect(prompt.kind, PassagePromptKind.markImminent);
+      // A different key, so a speaker that already said the one-mile prompt
+      // still says this one.
+      expect(prompt.key, isNot('mark-ahead-Hamstead'));
+    });
+
+    test('never both prompts about the same mark at once', () {
+      // Two sentences about one mark in the same breath is noise.
+      expect(
+        imminent.prompts.where((p) => p.kind == PassagePromptKind.markAhead),
+        isEmpty,
+      );
+    });
+  });
+
+  group('off the track', () {
+    // A quarter-mile north of the first leg: well off a line running roughly
+    // east, and still nowhere near the mark.
+    final off = _guidanceAt(
+      const GeoPoint(latitude: 50.7040, longitude: -1.4600),
+    );
+
+    test('takes precedence over the leg, because it is more urgent', () {
+      expect(off.phase, PassagePhase.offTrack);
+      expect(off.headline, contains('off track'));
+      expect(off.needsAttention, isTrue);
+    });
+
+    test('names the side it is off, and the side the track is on', () {
+      expect(off.headline, anyOf(contains('port'), contains('starboard')));
+      // The detail says which way the track lies, which is the opposite side.
+      expect(off.detail, contains('Track is to'));
+    });
+
+    test('gives the leg course rather than a course to steer back', () {
+      // Deliberate: recovering a track is the sailor's decision, and a computed
+      // intercept would be this app choosing a course - which it must not do
+      // with no chart under it.
+      expect(off.detail, contains("Leg 1's course is"));
+      expect(off.detail, isNot(contains('steer')));
+    });
+
+    test('speaks it once per leg, not once per fix', () {
+      final prompt = off.prompts.first;
+      expect(prompt.kind, PassagePromptKind.offTrack);
+      expect(prompt.key, 'off-track-leg-1');
+    });
+  });
+
+  group('arriving', () {
+    // Approaching Cowes on the last leg.
+    final arriving = _guidanceAt(
+      const GeoPoint(latitude: 50.7420, longitude: -1.3060),
+    );
+
+    test('says it is the last mark rather than offering a next course', () {
+      expect(arriving.phase, PassagePhase.arriving);
+      expect(arriving.headline, 'Arriving at Cowes');
+      expect(arriving.detail, contains('last mark'));
+      expect(arriving.alterationAhead, isNull);
+    });
+
+    test('the prompt says the same', () {
+      final prompt = arriving.prompts.single;
+      expect(prompt.kind, PassagePromptKind.arriving);
+      expect(prompt.spoken, contains('last mark'));
+    });
+  });
+
+  group('when the fix goes stale', () {
+    test('the passage stops reporting progress and says why', () {
+      final guidance = _guidanceAt(
+        const GeoPoint(latitude: 50.6960, longitude: -1.4150),
+        fixAge: const Duration(minutes: 3),
+      );
+
+      expect(guidance.phase, PassagePhase.waitingForFix);
+      expect(guidance.headline, 'Position is stale');
+      // The readings are still on screen, so a sailor has to be told not to
+      // steer by them.
+      expect(guidance.detail, contains('Readings below'));
+    });
+
+    test('says it aloud, with the age in words', () {
+      final guidance = _guidanceAt(
+        const GeoPoint(latitude: 50.6960, longitude: -1.4150),
+        fixAge: const Duration(minutes: 3),
+      );
+      final prompt = guidance.prompts.single;
+
+      expect(prompt.kind, PassagePromptKind.staleFix);
+      expect(prompt.spoken, contains('stale'));
+      expect(prompt.spoken, contains('3 minutes'));
+    });
+
+    test('a stale fix outranks an approaching mark', () {
+      // Standing two cables from a mark on a three-minute-old fix, the mark is
+      // not the thing to say.
+      final guidance = _guidanceAt(
+        const GeoPoint(latitude: 50.6952, longitude: -1.4030),
+        fixAge: const Duration(minutes: 3),
+      );
+
+      expect(guidance.phase, PassagePhase.waitingForFix);
+      expect(guidance.prompts.map((p) => p.kind), [PassagePromptKind.staleFix]);
+    });
+  });
+
+  group('the thresholds are stated, not scattered', () {
+    test('an approach is a mile and imminent is two cables', () {
+      const policy = PassageGuidancePolicy();
+      expect(policy.approachMeters, 1852.0);
+      expect(policy.imminentMeters, closeTo(370.4, 0.1));
+      expect(policy.offTrackMeters, closeTo(185.2, 0.1));
+    });
+
+    test('a tighter policy changes when a mark is announced', () {
+      final position = const GeoPoint(latitude: 50.6960, longitude: -1.4150);
+
+      // Default: a mile out, so announced.
+      expect(_guidanceAt(position).prompts, hasLength(1));
+      // Halve the approach and the same position is not yet worth saying.
+      expect(
+        _guidanceAt(
+          position,
+          policy: const PassageGuidancePolicy(approachMeters: 900),
+        ).prompts,
+        isEmpty,
+      );
+    });
+  });
+
+  group('it never issues a helm command', () {
+    test('no prompt tells the sailor what to do with the wheel', () {
+      for (final position in [
+        const GeoPoint(latitude: 50.6960, longitude: -1.4150),
+        const GeoPoint(latitude: 50.6952, longitude: -1.4030),
+        const GeoPoint(latitude: 50.7040, longitude: -1.4600),
+        const GeoPoint(latitude: 50.7420, longitude: -1.3060),
+      ]) {
+        for (final prompt in _guidanceAt(position).prompts) {
+          // "Alter 22 degrees to port onto 074" reports the sailor's own plan.
+          // "Turn", "steer", "head for" would be the app choosing, which it
+          // cannot do with no chart, no depth and no tide under it.
+          for (final verb in ['turn ', 'steer ', 'head for', 'go to']) {
+            expect(
+              prompt.spoken.toLowerCase(),
+              isNot(contains(verb)),
+              reason: '"$verb" in: ${prompt.spoken}',
+            );
+          }
+        }
+      }
+    });
+  });
+
+  group('spoken distances read as speech', () {
+    test('across the range a passage actually uses', () {
+      // Driven through the public surface by placing the vessel at known
+      // distances off a mark, because the formatter is private on purpose.
+      final phrases = <String>[];
+      for (final latitude in [50.6952, 50.6955, 50.6960, 50.6975]) {
+        final guidance = _guidanceAt(
+          GeoPoint(latitude: latitude, longitude: -1.4100),
+        );
+        phrases.addAll(guidance.prompts.map((p) => p.spoken));
+      }
+
+      expect(phrases, isNotEmpty);
+      for (final phrase in phrases) {
+        // No unit abbreviation, and no decimal a voice would read as "four
+        // point three" when it means four and a bit cables. A bare "4" is fine:
+        // every engine says "four". The full stop ending the sentence is fine
+        // too, which an earlier version of this assertion tripped over.
+        expect(phrase, isNot(contains('NM')));
+        expect(
+          phrase,
+          isNot(matches(RegExp(r'\d\.\d'))),
+          reason: 'a decimal in the ear is a mis-heard distance',
+        );
+      }
+    });
+  });
+}
+
+PassagePlan _plan() => PassagePlan.of(
+  ImportedRoute(
+    id: 'solent',
+    name: 'Lymington to Cowes',
+    importedAt: DateTime.utc(2026, 8, 20),
+    sourceFileName: 'solent.gpx',
+    paths: const [
+      RoutePath(
+        kind: RoutePathKind.route,
+        points: [
+          GeoPoint(latitude: 50.7000, longitude: -1.5000),
+          GeoPoint(latitude: 50.6950, longitude: -1.4000),
+          GeoPoint(latitude: 50.7100, longitude: -1.3400),
+          GeoPoint(latitude: 50.7500, longitude: -1.3000),
+        ],
+      ),
+    ],
+    waypoints: const [
+      RouteWaypoint(
+        name: 'Lymington',
+        point: GeoPoint(latitude: 50.7000, longitude: -1.5000),
+      ),
+      RouteWaypoint(
+        name: 'Hamstead',
+        point: GeoPoint(latitude: 50.6950, longitude: -1.4000),
+      ),
+      RouteWaypoint(
+        name: 'Salt Mead',
+        point: GeoPoint(latitude: 50.7100, longitude: -1.3400),
+      ),
+      RouteWaypoint(
+        name: 'Cowes',
+        point: GeoPoint(latitude: 50.7500, longitude: -1.3000),
+      ),
+    ],
+  ),
+);
+
+/// Reads the guidance for a vessel at [point], making way on a fresh fix unless
+/// told otherwise.
+PassageGuidance _guidanceAt(
+  GeoPoint point, {
+  PassagePlan? plan,
+  Duration fixAge = Duration.zero,
+  PassageGuidancePolicy policy = const PassageGuidancePolicy(),
+}) {
+  final now = DateTime.utc(2026, 8, 20, 12);
+  final passage = plan ?? _plan();
+  final fix = NavigationFix(
+    point: point,
+    recordedAt: now.subtract(fixAge),
+    courseOverGroundDegrees: 90,
+    speedOverGroundMetersPerSecond: 2.6, // about 5 knots
+    accuracyMeters: 5,
+  );
+  return PassageGuidance.of(
+    plan: passage,
+    maneuvers: PassageManeuverPlan.of(passage),
+    instruments: NavigationInstruments.compute(
+      fix: fix,
+      plan: passage,
+      now: now,
+    ),
+    policy: policy,
+  );
+}

--- a/apps/mobile/test/services/passage_prompt_speech_test.dart
+++ b/apps/mobile/test/services/passage_prompt_speech_test.dart
@@ -1,0 +1,177 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tide_and_seek/domain/imported_route.dart';
+import 'package:tide_and_seek/services/navigation_instruments.dart';
+import 'package:tide_and_seek/services/passage_guidance.dart';
+import 'package:tide_and_seek/services/passage_legs.dart';
+import 'package:tide_and_seek/services/passage_maneuvers.dart';
+import 'package:tide_and_seek/services/spoken_audio_mode.dart';
+
+/// #73. What the voice would actually say, and how often.
+///
+/// The shell's `_speakPassage` is a loop over `prompts` filtered against the
+/// spoken-key set. These tests stand in for that loop rather than driving the
+/// whole shell, because what can go wrong is the *keys*: a prompt whose key
+/// changes on every fix would be said on every fix, and a sailor a mile from a
+/// mark would hear the same sentence twenty times.
+void main() {
+  group('a prompt is said once', () {
+    test('the same approach on twenty consecutive fixes speaks once', () {
+      final spoken = <String>{};
+      var utterances = 0;
+
+      // Closing the mark slowly, as a yacht does: twenty fixes over the last
+      // half mile, all of them inside the approach.
+      for (var step = 0; step < 20; step += 1) {
+        final guidance = _guidanceAt(
+          GeoPoint(latitude: 50.6958 - step * 0.0002, longitude: -1.4145),
+        );
+        for (final prompt in guidance.prompts) {
+          if (spoken.add(prompt.key)) utterances += 1;
+        }
+      }
+
+      expect(
+        utterances,
+        lessThanOrEqualTo(2),
+        reason:
+            'at most the one-mile prompt and the two-cable one; anything more '
+            'means a key is changing between fixes',
+      );
+    });
+
+    test('the next mark is a new prompt, not a repeat', () {
+      final spoken = <String>{};
+      final said = <String>[];
+
+      for (final point in [
+        // Approaching Hamstead.
+        const GeoPoint(latitude: 50.6958, longitude: -1.4145),
+        // Then approaching Salt Mead on the next leg.
+        const GeoPoint(latitude: 50.7060, longitude: -1.3540),
+      ]) {
+        for (final prompt in _guidanceAt(point).prompts) {
+          if (spoken.add(prompt.key)) said.add(prompt.spoken);
+        }
+      }
+
+      expect(said, hasLength(2));
+      expect(said.first, contains('Hamstead'));
+      expect(said.last, contains('Salt Mead'));
+    });
+  });
+
+  group('what the sailor hears', () {
+    test('the mile prompt names the mark and the alteration', () {
+      final spoken = _guidanceAt(
+        const GeoPoint(latitude: 50.6958, longitude: -1.4145),
+      ).prompts.single.spoken;
+
+      // The sentence, as a whole, because the parts have to hang together to be
+      // followable while steering.
+      expect(
+        spoken,
+        matches(
+          RegExp(
+            r'^\d+ (cable|cables|mile|miles|point) .*to Hamstead, then alter '
+            r'\d+ degrees to (port|starboard) onto '
+            r'(zero|one|two|three|four|five|six|seven|eight|nine) ',
+          ),
+        ),
+        reason:
+            'heard as: "6 cables to Hamstead, then alter 26 degrees to '
+            'port onto zero six eight." — got: $spoken',
+      );
+    });
+
+    test('a stale fix is safety, so alerts-only still says it', () {
+      final guidance = _guidanceAt(
+        const GeoPoint(latitude: 50.6958, longitude: -1.4145),
+        fixAge: const Duration(minutes: 3),
+      );
+      final prompt = guidance.prompts.single;
+
+      expect(prompt.kind, PassagePromptKind.staleFix);
+      // The shell classes this one as safety and the rest as navigation. A
+      // sailor who muted directions still wants to be told their position is
+      // three minutes old, because the readings on screen come from it.
+      expect(
+        spokenAudioAllows(SpokenAudioMode.alertsOnly, SpokenAudioClass.safety),
+        isTrue,
+      );
+      expect(
+        spokenAudioAllows(
+          SpokenAudioMode.alertsOnly,
+          SpokenAudioClass.navigation,
+        ),
+        isFalse,
+      );
+    });
+
+    test('nothing is said on a leg with a long way to run', () {
+      expect(
+        _guidanceAt(
+          const GeoPoint(latitude: 50.6990, longitude: -1.4800),
+        ).prompts,
+        isEmpty,
+      );
+    });
+  });
+}
+
+PassagePlan _plan() => PassagePlan.of(
+  ImportedRoute(
+    id: 'solent',
+    name: 'Lymington to Cowes',
+    importedAt: DateTime.utc(2026, 8, 20),
+    sourceFileName: 'solent.gpx',
+    paths: const [
+      RoutePath(
+        kind: RoutePathKind.route,
+        points: [
+          GeoPoint(latitude: 50.7000, longitude: -1.5000),
+          GeoPoint(latitude: 50.6950, longitude: -1.4000),
+          GeoPoint(latitude: 50.7100, longitude: -1.3400),
+          GeoPoint(latitude: 50.7500, longitude: -1.3000),
+        ],
+      ),
+    ],
+    waypoints: const [
+      RouteWaypoint(
+        name: 'Lymington',
+        point: GeoPoint(latitude: 50.7000, longitude: -1.5000),
+      ),
+      RouteWaypoint(
+        name: 'Hamstead',
+        point: GeoPoint(latitude: 50.6950, longitude: -1.4000),
+      ),
+      RouteWaypoint(
+        name: 'Salt Mead',
+        point: GeoPoint(latitude: 50.7100, longitude: -1.3400),
+      ),
+      RouteWaypoint(
+        name: 'Cowes',
+        point: GeoPoint(latitude: 50.7500, longitude: -1.3000),
+      ),
+    ],
+  ),
+);
+
+PassageGuidance _guidanceAt(GeoPoint point, {Duration fixAge = Duration.zero}) {
+  final now = DateTime.utc(2026, 8, 20, 12);
+  final plan = _plan();
+  return PassageGuidance.of(
+    plan: plan,
+    maneuvers: PassageManeuverPlan.of(plan),
+    instruments: NavigationInstruments.compute(
+      fix: NavigationFix(
+        point: point,
+        recordedAt: now.subtract(fixAge),
+        courseOverGroundDegrees: 85,
+        speedOverGroundMetersPerSecond: 2.6,
+        accuracyMeters: 5,
+      ),
+      plan: plan,
+      now: now,
+    ),
+  );
+}


### PR DESCRIPTION
Steps 1–3 of the plan in `PLAN.md`'s new **Phase 4b**, which is what the fitness review actually found: the app can plan a passage in detail and then not sail it, because the plan, the instruments and the voice all exist and none of them speak to each other.

## Step 1 — stop reporting a correct passage as broken (#72)

Import a passage as a GPX carrying a `<rte>` element — how essentially every plotter exports one:

```
STATE:   NavigationGuidanceState.routingUnfinished
MESSAGE: Directions could not be built for this route — the line is the raw
         import. Re-import it to try again.
```

Both halves false, and re-importing produced the identical message forever. `routingUnfinished` is removed: an empty manoeuvre list is now the normal state of every passage, and the path kind it branched on decides nothing. A `<rte>` and a `<trk>` are the same thing and are told the same thing — with a test asserting they are told *identical* things, and one asserting nothing anywhere tells a sailor to re-import.

The demo hid it: `demo_route.gpx` carries a `<trk>`, so every test and simulator run used the branch that looked fine.

## Step 2 — `PassageGuidance` (#63)

One service reading `PassagePlan`, `PassageManeuverPlan` and `NavigationInstruments`, answering the four questions a navigator asks under way: which leg, what next, how far, and what does the plan ask for there.

Written for the ear as well as the eye. A course is spoken **digit by digit** — "zero six eight", never "sixty eight", which through wind noise could be 068 or a careless 268. Distances are cables inside a mile and never carry a decimal. On screen the existing formatter is unchanged.

Thresholds in one place: a mark is *ahead* at one mile — twelve minutes at five knots, where road prompt distances would fire nine seconds out — *imminent* at two cables, off-track at one cable.

Three refusals, each tested:

- **Off-track gives the leg's own course and which side the track lies, never a course to steer back.** A computed intercept would be this app choosing a course, which it must not do with no chart, no depth and no tide under it.
- **A stale fix outranks an approaching mark.** Two cables off on a three-minute-old fix, the mark is not the thing to say.
- **No prompt contains "turn", "steer", "head for" or "go to".** "Alter 26 degrees to port onto zero six eight" reports the sailor's own plan at the moment it matters. The P0 requirement that guidance never issue helm commands is about who decides, and it is still the sailor.

Prompts are **state, not events** — what is currently worth saying, each with a stable key, for a speaker that remembers what it has said. That is what `active_voyage_shell` already does, and it keeps the service testable by handing it a position rather than a timeline.

## Step 3 — the banner reads it

Two lines instead of one:

```
Leg 1 of 3 to Hamstead
3.4 NM to run · then alter 26° to port onto 068°T

Approaching Hamstead
6 cables to run · then alter 26° to port onto 068°T

Arriving at Cowes
5 cables to run · last mark of the passage
```

The detail line may wrap to two on purpose: that is the sentence a helm steers by, and an ellipsis would eat the course. The border takes the phase colour only when the phase needs attention.

`_instrumentFix` is extracted rather than duplicated — the instrument sheet built the same `NavigationFix` from the same fields, and two constructions are two chances to disagree about what the receiver said.

## Verification

- `flutter analyze` clean; `flutter test` — **1,746 pass**, 24 skipped
- 24 service tests, 5 banner tests, 6 rewritten guidance tests
- Walked the Solent passage at six positions printing what the banner reads at each; the output above is that run
- **Not** photographed under way on the simulator. Starting a voyage there needs the location prompts answered and the run kept consuming taps without starting. The logic is covered; the photograph is not, and I have said so rather than implying otherwise.

## Found while trying — #75

Walking the solo start path for the first time turned up that a **solo** voyage is described as a group activity, including in the two `Info.plist` location strings Apple shows *before* permission is granted: *"share your position with your group"*. On solo, nothing is shared with anyone. Filed separately.

## Still to come in Phase 4b

Step 4: spoken prompts read `PassageGuidance` (#73) — the machinery is complete and has never had a phrase to say. Step 5: retire what that leaves dead — OSRM, the roundabout and lane machinery, `mini_roundabouts.geojson`, `tools/discovery` (#31).