### PR TITLE
feat: add temporal tide, wind and daylight planning

### DIFF
--- a/apps/website/README.md
+++ b/apps/website/README.md
@@ -19,9 +19,10 @@ motorcycle preferences or cafe discovery.
   throughout its North Atlantic and European coverage, a coarser GEBCO 2026
   fallback elsewhere in the world, and EMODnet's generalised 50 m-and-deeper
   European overlay;
-- a map-wide current wind field with downwind arrows, speed labels, valid time,
-  gust detail and explicit model—not observation—wording;
-- a locally entered passage start time and a zoom-adaptive model-current field:
+- a zoom-adaptive wind field with downwind arrows, speed/time labels, gust detail,
+  a purple passage-time halo near the route and explicit model—not observation—wording;
+- a locally entered passage start time, 15-minute time-of-day slider, hour/day
+  step controls and a zoom-adaptive model-current field filtered to basemap water:
   teal arrows use current time away from the route, then blend through blue to
   purple at the expected nearest-route time within 8 NM;
 - current samples about every 2.5 NM for a current-adjusted passage estimate,
@@ -31,6 +32,9 @@ motorcycle preferences or cafe discovery.
   reconciled: the Solent uses the bundled TICON-4 MSL/LAT offsets with the
   Open-Meteo model sea level, while unsupported datum combinations remain
   visibly unadjusted;
+- a map tide table derived from smoothed Open-Meteo sea-level extrema, plus a
+  destination daylight chart showing sunrise, sunset, departure, ETA and an
+  after-sunset/before-sunrise warning;
 - an obvious persistent Light/Dark selector that also chooses the matching
   OpenFreeMap basemap style;
 - alternative GEBCO 2026 global terrain context and NOAA's current US-only

--- a/apps/website/map-data.test.mjs
+++ b/apps/website/map-data.test.mjs
@@ -9,7 +9,7 @@ import {
   parseEmodnetGrid,
   parseGebcoGrid,
 } from "./emodnet-contours.mjs";
-import { windFieldGeoJson, windGrid, windRequestUrl } from "./wind-field.mjs";
+import { sampleWindAt, windFieldGeoJson, windGrid, windRequestUrl } from "./wind-field.mjs";
 import {
   currentEffect,
   currentFieldGeoJson,
@@ -22,7 +22,10 @@ import {
   routeCurrentGeoJson,
   routeSamplePlan,
   sampleMarineAt,
+  tideEventsFromResponse,
+  tideRequestUrl,
 } from "./tide-current.mjs";
+import { sunChartRows, sunRequestUrl } from "./sun-times.mjs";
 
 test("builds a bounded EMODnet request across England", () => {
   const request = createContourRequest(
@@ -114,21 +117,64 @@ test("builds a map-wide wind field with downwind arrows and labels", () => {
   const bounds = { west: -2, south: 50, east: 0, north: 52 };
   const points = windGrid(bounds, 2, 1);
   assert.equal(points.length, 2);
-  assert.match(windRequestUrl(points), /wind_speed_10m/);
+  const at = new Date("2026-08-21T14:30:00Z");
+  assert.match(windRequestUrl(points, at, at), /wind_speed_10m/);
   const response = points.map(() => ({
-    current: {
-      time: "2026-08-21T14:15",
-      wind_speed_10m: 12.4,
-      wind_direction_10m: 0,
-      wind_gusts_10m: 19.2,
+    hourly: {
+      time: ["2026-08-21T14:00", "2026-08-21T15:00"],
+      wind_speed_10m: [12.4, 12.4],
+      wind_direction_10m: [0, 0],
+      wind_gusts_10m: [19.2, 19.2],
     },
   }));
-  const field = windFieldGeoJson(points, response, bounds, 2, 1);
+  assert.equal(sampleWindAt(response[0], at).directionFrom, 0);
+  const field = windFieldGeoJson(points, response, bounds, at, 2, 1);
   assert.equal(field.geojson.features.length, 4);
   assert.equal(field.geojson.features[0].geometry.type, "MultiLineString");
-  assert.equal(field.geojson.features[1].properties.speedLabel, "12 kn");
+  assert.equal(field.geojson.features[1].properties.speedLabel, "12 kn · now");
   const [start, end] = field.geojson.features[0].geometry.coordinates[0];
   assert.ok(end[1] < start[1], "a north wind should point downwind to the south");
+});
+
+test("shrinks map arrows as the geographic viewport narrows", () => {
+  const at = new Date("2026-08-21T14:30:00Z");
+  const response = {
+    hourly: {
+      time: ["2026-08-21T14:00", "2026-08-21T15:00"],
+      wind_speed_10m: [12, 12],
+      wind_direction_10m: [90, 90],
+      wind_gusts_10m: [18, 18],
+    },
+  };
+  const wideBounds = { west: -2, south: 50, east: 0, north: 52 };
+  const closeBounds = { west: -1.41, south: 50.74, east: -1.39, north: 50.76 };
+  const wide = windFieldGeoJson(
+    [{ longitude: -1, latitude: 51 }], response, wideBounds, at, 6, 4,
+  );
+  const close = windFieldGeoJson(
+    [{ longitude: -1.4, latitude: 50.75 }], response, closeBounds, at, 10, 7,
+  );
+  const length = (field) => {
+    const [start, end] = field.geojson.features[0].geometry.coordinates[0];
+    return Math.hypot(end[0] - start[0], end[1] - start[1]);
+  };
+  assert.ok(length(close) < length(wide) / 20);
+
+  const marineResponse = {
+    hourly: {
+      time: ["2026-08-21T14:00", "2026-08-21T15:00"],
+      ocean_current_velocity: [1, 1],
+      ocean_current_direction: [90, 90],
+      sea_level_height_msl: [0, 0],
+    },
+  };
+  const wideCurrent = currentFieldGeoJson(
+    [{ longitude: -1, latitude: 51 }], marineResponse, wideBounds, at, 5, 3,
+  );
+  const closeCurrent = currentFieldGeoJson(
+    [{ longitude: -1.4, latitude: 50.75 }], marineResponse, closeBounds, at, 10, 7,
+  );
+  assert.ok(length(closeCurrent) < length(wideCurrent) / 20);
 });
 
 test("interpolates a map-wide current field at the selected passage start", () => {
@@ -155,6 +201,36 @@ test("interpolates a map-wide current field at the selected passage start", () =
   const field = currentFieldGeoJson(points, response, bounds, start, 2, 1);
   assert.equal(field.geojson.features.length, 4);
   assert.equal(field.geojson.features[0].properties.kind, "current-arrow");
+});
+
+test("renders deduplicated currents at the model's selected sea cells", () => {
+  const bounds = { west: -1.6, south: 50.7, east: -1.0, north: 50.9 };
+  const points = marineGrid(bounds, 2, 1);
+  const response = points.map(() => ({
+    latitude: 50.7917,
+    longitude: -1.375,
+    hourly: {
+      time: ["2026-08-21T14:00", "2026-08-21T15:00"],
+      ocean_current_velocity: [1, 1],
+      ocean_current_direction: [90, 90],
+      sea_level_height_msl: [0, 0],
+    },
+  }));
+  const field = currentFieldGeoJson(
+    points,
+    response,
+    bounds,
+    [
+      { sampleTime: new Date("2026-08-21T14:30:00Z"), forecastWeight: 0 },
+      { sampleTime: new Date("2026-08-21T14:30:00Z"), forecastWeight: 1 },
+    ],
+    2,
+    1,
+  );
+  assert.equal(field.samples.length, 1);
+  assert.equal(field.samples[0].forecastWeight, 1);
+  assert.equal(field.geojson.features.length, 2);
+  assert.deepEqual(field.geojson.features[1].geometry.coordinates, [-1.375, 50.7917]);
 });
 
 test("adapts current grid density to the map zoom", () => {
@@ -207,6 +283,45 @@ test("uses compatible datums for tide-adjusted depths", () => {
     }),
     null,
   );
+});
+
+test("derives model high and low water events for the tide table", () => {
+  const start = new Date("2026-08-21T00:00:00Z");
+  const end = new Date("2026-08-21T08:00:00Z");
+  assert.match(tideRequestUrl({ latitude: 50.75, longitude: -1.4 }, start, end), /sea_level_height_msl/);
+  const response = {
+    hourly: {
+      time: Array.from({ length: 9 }, (_, index) => `2026-08-21T${String(index).padStart(2, "0")}:00`),
+      sea_level_height_msl: [0, 1, 2, 1, 0, -1, -2, -1, 0],
+    },
+  };
+  const events = tideEventsFromResponse(response, start, end);
+  assert.deepEqual(events.map((event) => event.kind), ["high", "low"]);
+  assert.equal(events[0].time, "2026-08-21T02:00:00.000Z");
+  assert.equal(events[1].heightMsl, -2);
+});
+
+test("builds a daylight chart and flags arrival after sunset", () => {
+  assert.match(sunRequestUrl({ latitude: 50.75, longitude: -1.4 }), /daily=sunrise%2Csunset/);
+  const epoch = (value) => Date.parse(value) / 1000;
+  const chart = sunChartRows(
+    {
+      timezone: "Europe/London",
+      timezone_abbreviation: "BST",
+      utc_offset_seconds: 0,
+      daily: {
+        time: [epoch("2026-08-21T00:00:00Z"), epoch("2026-08-22T00:00:00Z")],
+        sunrise: [epoch("2026-08-21T06:00:00Z"), epoch("2026-08-22T06:01:00Z")],
+        sunset: [epoch("2026-08-21T18:00:00Z"), epoch("2026-08-22T17:58:00Z")],
+      },
+    },
+    new Date("2026-08-21T08:00:00Z"),
+    new Date("2026-08-21T19:00:00Z"),
+  );
+  assert.equal(chart.rows.length, 1);
+  assert.equal(chart.rows[0].sunriseLabel, "07:00");
+  assert.equal(chart.rows[0].arrivalAfterSunset, true);
+  assert.ok(Math.abs(chart.rows[0].startPercent - 100 / 3) < 1e-9);
 });
 
 test("adjusts each leg estimate using the current expected at its midpoint", () => {

--- a/apps/website/planner.css
+++ b/apps/website/planner.css
@@ -68,6 +68,23 @@
 .form-grid .wide-field { min-width: 0; }
 .form-grid .start-time-field { grid-column: 1 / -1; }
 .form-grid .start-time-field small { color: var(--muted); font-size: 0.63rem; font-weight: 500; }
+.passage-time-controls { grid-column: 1 / -1; display: grid; gap: 8px; }
+.time-step-buttons { display: grid; grid-template-columns: repeat(5, 1fr); gap: 5px; }
+.time-step-buttons button {
+  min-height: 32px;
+  padding: 4px;
+  border: 1px solid #b8c7c5;
+  border-radius: 7px;
+  color: var(--sea-dark);
+  background: #f7faf8;
+  font-size: 0.65rem;
+  font-weight: 800;
+}
+.time-step-buttons button:hover { border-color: var(--sea); background: #edf6f3; }
+.time-slider-field { display: grid; gap: 2px; }
+.time-slider-field > span { display: flex; justify-content: space-between; align-items: center; }
+.time-slider-field output { color: var(--sea); font-size: 0.68rem; }
+.time-slider-field input { min-height: 28px; padding: 0; border: 0; accent-color: var(--coral); box-shadow: none; }
 input, select, textarea {
   width: 100%;
   min-height: 42px;
@@ -168,6 +185,7 @@ input:focus, select:focus, textarea:focus { border-color: var(--sea); box-shadow
 .wind-key .wind-fresh { background: #2b9b78; }
 .wind-key .wind-strong { background: #d18a2d; }
 .wind-key .wind-gale { background: #d14c3a; }
+.wind-key .wind-future { height: 5px; border: 1px solid #8a4faf; background: transparent; }
 .current-card { background: #e9f5f6; }
 .current-key {
   margin-left: 24px;
@@ -186,6 +204,11 @@ input:focus, select:focus, textarea:focus { border-color: var(--sea); box-shadow
   height: 2px;
   border-radius: 0;
   background: repeating-linear-gradient(90deg, #c54e8f 0 5px, transparent 5px 8px);
+}
+.current-key .ground-track {
+  height: 2px;
+  border-radius: 0;
+  background: repeating-linear-gradient(90deg, #e15f3b 0 5px, transparent 5px 8px);
 }
 .wind-popup::before {
   content: "Arrows point downwind";
@@ -276,7 +299,7 @@ button:disabled { cursor: not-allowed; opacity: 0.5; }
 
 .map-shell { position: relative; min-width: 0; }
 #map { position: absolute; inset: 0; }
-.map-callout, .map-provenance {
+.map-callout, .map-provenance, .map-environment-panel {
   position: absolute;
   z-index: 1;
   border: 1px solid rgba(9, 47, 61, 0.16);
@@ -292,6 +315,70 @@ button:disabled { cursor: not-allowed; opacity: 0.5; }
 .map-provenance { right: 12px; bottom: 30px; padding: 8px 10px; display: grid; gap: 2px; text-align: right; }
 .map-provenance span { color: var(--muted); font-size: 0.62rem; }
 .map-provenance strong { color: #934d37; font-size: 0.68rem; }
+.map-environment-panel {
+  top: 18px;
+  right: 18px;
+  width: min(350px, calc(100% - 36px));
+  max-height: calc(100% - 100px);
+  overflow: auto;
+  padding: 0;
+}
+.map-environment-panel > summary {
+  padding: 11px 13px;
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  cursor: pointer;
+  list-style-position: inside;
+}
+.map-environment-panel > summary span { font-size: 0.76rem; font-weight: 850; }
+.map-environment-panel > summary strong { color: var(--sea); font-size: 0.67rem; font-weight: 800; }
+.map-environment-panel > section { padding: 10px 13px; border-top: 1px solid var(--line); }
+.map-environment-panel > p {
+  margin: 0;
+  padding: 8px 13px 11px;
+  border-top: 1px solid var(--line);
+  color: var(--muted);
+  font-size: 0.59rem;
+  line-height: 1.35;
+}
+.environment-heading { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; }
+.environment-heading > strong { font-size: 0.68rem; }
+.environment-heading > small { color: var(--muted); font-size: 0.56rem; text-align: right; }
+.tide-table { margin-top: 8px; display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 5px; }
+.tide-event {
+  padding: 7px 5px;
+  border: 1px solid #ccd9d7;
+  border-radius: 7px;
+  display: grid;
+  gap: 1px;
+  text-align: center;
+  background: rgba(255, 255, 255, 0.72);
+}
+.tide-event.next { border-color: var(--coral); box-shadow: 0 0 0 1px var(--coral); }
+.tide-event b { color: var(--sea); font-size: 0.58rem; text-transform: uppercase; }
+.tide-event time { font-size: 0.71rem; font-weight: 850; }
+.tide-event span { color: var(--muted); font-size: 0.57rem; }
+.environment-empty { grid-column: 1 / -1; margin: 8px 0 0; color: var(--muted); font-size: 0.63rem; }
+.sun-chart { margin-top: 8px; display: grid; gap: 9px; }
+.sun-row { display: grid; gap: 4px; }
+.sun-row-heading { display: flex; justify-content: space-between; color: var(--muted); font-size: 0.57rem; }
+.sun-row-heading strong { color: var(--ink); font-size: 0.62rem; }
+.sun-track {
+  position: relative;
+  height: 14px;
+  overflow: visible;
+  border-radius: 999px;
+  background: #233d55;
+  box-shadow: inset 0 0 0 1px rgba(9, 47, 61, 0.22);
+}
+.sun-daylight { position: absolute; top: 0; bottom: 0; border-radius: 999px; background: #f1c85b; }
+.sun-marker { position: absolute; top: -4px; width: 3px; height: 22px; border-radius: 2px; transform: translateX(-50%); }
+.sun-marker.start { background: var(--coral); }
+.sun-marker.arrival { background: #0c5f78; }
+.sun-row.night-arrival .sun-marker.arrival { background: #b63548; }
+.sun-row-note { color: var(--muted); font-size: 0.56rem; }
+.sun-row-note strong { color: #a73945; }
 .passage-marker {
   width: 30px;
   height: 30px;
@@ -337,6 +424,11 @@ button:disabled { cursor: not-allowed; opacity: 0.5; }
   color: var(--ink);
   background: #0d1d22;
 }
+:root[data-theme="dark"] .time-step-buttons button {
+  border-color: #3a5359;
+  color: #c6e6eb;
+  background: #11242a;
+}
 :root[data-theme="dark"] .poi-result { border-top-color: #2c4146; }
 :root[data-theme="dark"] .layer-options {
   border-left-color: #3b555b;
@@ -373,11 +465,14 @@ button:disabled { cursor: not-allowed; opacity: 0.5; }
   background: #11242a;
 }
 :root[data-theme="dark"] .map-callout,
-:root[data-theme="dark"] .map-provenance {
+:root[data-theme="dark"] .map-provenance,
+:root[data-theme="dark"] .map-environment-panel {
   border-color: rgba(192, 223, 225, 0.2);
   background: rgba(14, 31, 36, 0.92);
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.34);
 }
+:root[data-theme="dark"] .tide-event { border-color: #3a5359; background: rgba(16, 33, 38, 0.82); }
+:root[data-theme="dark"] .sun-track { background: #17243d; }
 :root[data-theme="dark"] .map-provenance strong { color: #ff9b7d; }
 :root[data-theme="dark"] .maplibregl-popup-content,
 :root[data-theme="dark"] .maplibregl-popup-tip { background: #132329; }
@@ -404,5 +499,7 @@ button:disabled { cursor: not-allowed; opacity: 0.5; }
   .form-grid { grid-template-columns: minmax(0, 1fr) 100px; }
   .filter-grid { grid-template-columns: 1fr; }
   .map-provenance { display: none; }
+  .map-environment-panel { top: 10px; right: 10px; width: calc(100% - 20px); max-height: 46%; }
+  .tide-table { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .planner-header-actions .header-link { display: none; }
 }

--- a/apps/website/planner.html
+++ b/apps/website/planner.html
@@ -10,15 +10,15 @@
     <meta name="theme-color" content="#092f3d" />
     <meta name="tide-and-seek-api" content="https://relay.tailendcharlie.app" />
     <title>Passage planner | Tide and Seek</title>
-    <link rel="stylesheet" href="/styles.css?v=20260821-5" />
+    <link rel="stylesheet" href="/styles.css?v=20260821-6" />
     <link
       rel="stylesheet"
       href="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.css"
       integrity="sha384-uTttxo/aOKbdE5RlD/SPzSDoDmNvGlUYPjONi2MN/b7c9HPSvW07OIuyP7uL6jxK"
       crossorigin="anonymous"
     />
-    <link rel="stylesheet" href="/planner.css?v=20260821-5" />
-    <script src="/theme.js?v=20260821-5" defer></script>
+    <link rel="stylesheet" href="/planner.css?v=20260821-6" />
+    <script src="/theme.js?v=20260821-6" defer></script>
   </head>
   <body class="planner-page">
     <header class="planner-header">
@@ -73,6 +73,19 @@
             <input id="start-time" type="datetime-local" step="900" />
             <small>Entered in this device’s local time zone.</small>
           </label>
+          <div class="passage-time-controls">
+            <div class="time-step-buttons" role="group" aria-label="Move passage start time">
+              <button type="button" data-shift-hours="-24">−1 day</button>
+              <button type="button" data-shift-hours="-1">−1 h</button>
+              <button type="button" id="start-time-now">Now</button>
+              <button type="button" data-shift-hours="1">+1 h</button>
+              <button type="button" data-shift-hours="24">+1 day</button>
+            </div>
+            <label class="time-slider-field" for="time-slider">
+              <span>Time of day <output id="time-slider-label" for="time-slider">—</output></span>
+              <input id="time-slider" type="range" min="0" max="1425" step="15" />
+            </label>
+          </div>
           <p class="local-note" id="draft-status">Saved on this device only.</p>
         </section>
 
@@ -144,14 +157,15 @@
           <div class="conditions-card">
             <label class="layer-toggle condition-toggle">
               <input id="wind-visible" type="checkbox" />
-              <span><strong>Current wind field</strong><small>Show map-wide arrows and speeds from the best available Open-Meteo model.</small></span>
+              <span><strong>Time-aware wind field</strong><small>Show map-wide arrows and speeds. Near the route, samples use the expected passage time.</small></span>
             </label>
-            <p id="wind-status">Wind field hidden. Turn it on to load current model wind.</p>
+            <p id="wind-status">Wind field hidden. Turn it on to load model wind.</p>
             <div class="wind-key" aria-label="Wind arrow colour key">
               <span><i class="wind-calm"></i>&lt;10 kn</span>
               <span><i class="wind-fresh"></i>10–17 kn</span>
               <span><i class="wind-strong"></i>18–27 kn</span>
               <span><i class="wind-gale"></i>28+ kn</span>
+              <span><i class="wind-future"></i>Purple halo: expected route time</span>
             </div>
           </div>
           <div class="conditions-card current-card">
@@ -166,7 +180,8 @@
               <span><i class="current-blend"></i>Blended time</span>
               <span><i class="current-route"></i>Expected route time</span>
               <span><i class="current-cts"></i>Course to steer</span>
-              <span><i class="current-drift"></i>Uncorrected drift</span>
+              <span><i class="current-drift"></i>Uncorrected drift if CTS is ignored</span>
+              <span><i class="ground-track"></i>Desired ground track</span>
               <span>Arrows point with the flow</span>
             </div>
           </div>
@@ -213,7 +228,7 @@
 
         <section class="passage-summary" aria-label="Passage summary">
           <div><span>Distance</span><strong id="passage-distance">—</strong></div>
-          <div><span>Model-adjusted time</span><strong id="passage-duration">—</strong><small id="still-water-duration"></small></div>
+          <div><span>Current-adjusted time</span><strong id="passage-duration">—</strong><small id="still-water-duration"></small></div>
           <div><span>Expected arrival</span><strong id="passage-arrival">—</strong></div>
           <div><span>Legs</span><strong id="passage-leg-count">0</strong></div>
         </section>
@@ -223,7 +238,7 @@
             <thead><tr><th>Leg</th><th>Course</th><th>Distance</th><th>Model current</th><th>ETA</th></tr></thead>
             <tbody id="leg-table"></tbody>
           </table>
-          <p>Courses are rhumb-line degrees true. Model-adjusted times and amber course-to-steer arrows use current samples about every 2.5 NM. The magenta dashed line shows modelled drift if the planned ground-track bearings are held without correction. These are planning estimates, not helm instructions.</p>
+          <p>The coral dashed line is the desired ground track. Amber arrows show the modelled course to steer to stay on it. The labelled magenta dashed line is the drift track if that correction is ignored. Current samples are taken about every 2.5 NM. These are planning estimates, not helm instructions.</p>
         </div>
 
         <section class="planner-actions" aria-label="Passage actions">
@@ -244,6 +259,24 @@
           <strong>Tap water to add a waypoint</strong>
           <span>Drag waypoint markers to refine the passage.</span>
         </div>
+        <details class="map-environment-panel" open>
+          <summary><span>Tide &amp; daylight</span><strong id="map-environment-time">Passage time</strong></summary>
+          <section aria-labelledby="tide-table-title">
+            <div class="environment-heading">
+              <strong id="tide-table-title">Model tide near departure</strong>
+              <small id="tide-table-status">Loading…</small>
+            </div>
+            <div class="tide-table" id="tide-table" aria-live="polite"></div>
+          </section>
+          <section aria-labelledby="sun-chart-title">
+            <div class="environment-heading">
+              <strong id="sun-chart-title">Sun at destination</strong>
+              <small id="sun-chart-status">Loading…</small>
+            </div>
+            <div class="sun-chart" id="sun-chart" aria-live="polite"></div>
+          </section>
+          <p>Model guidance only. Tide heights are not official predictions; check a nautical almanac and local sources.</p>
+        </details>
         <div class="map-provenance">
           <span>Modelled depth shading and contours + general basemap + crowd-sourced seamarks</span>
           <strong>Not a nautical chart</strong>
@@ -257,6 +290,6 @@
       integrity="sha384-5+cfbwT0iiub6VsQAdn6yz16nr6sDiQoHx6tm4O8OVYXHYOxcffFmCJBL0dgdvGp"
       crossorigin="anonymous"
     ></script>
-    <script type="module" src="/planner.js?v=20260821-5"></script>
+    <script type="module" src="/planner.js?v=20260821-6"></script>
   </body>
 </html>

--- a/apps/website/planner.js
+++ b/apps/website/planner.js
@@ -33,7 +33,10 @@ import {
   routeSamplePlan,
   routeCurrentGeoJson,
   sampleMarineAt,
+  tideEventsFromResponse,
+  tideRequestUrl,
 } from "./tide-current.mjs";
+import { sunChartRows, sunRequestUrl } from "./sun-times.mjs";
 
 const MAP_STYLE_URLS = {
   light: "https://tiles.openfreemap.org/styles/liberty",
@@ -91,6 +94,7 @@ const elements = {
   legTable: document.querySelector("#leg-table"),
   legTableWrap: document.querySelector("#leg-table-wrap"),
   mapCallout: document.querySelector("#map-callout"),
+  mapEnvironmentTime: document.querySelector("#map-environment-time"),
   noaaVisible: document.querySelector("#noaa-visible"),
   offshoreContoursVisible: document.querySelector("#offshore-contours-visible"),
   passageName: document.querySelector("#passage-name"),
@@ -104,13 +108,20 @@ const elements = {
   shallowContourStatus: document.querySelector("#shallow-contour-status"),
   shallowContoursVisible: document.querySelector("#shallow-contours-visible"),
   speedKnots: document.querySelector("#speed-knots"),
+  startTimeNow: document.querySelector("#start-time-now"),
   startTime: document.querySelector("#start-time"),
   stillWaterDuration: document.querySelector("#still-water-duration"),
   tideDepthStatus: document.querySelector("#tide-depth-status"),
+  tideTable: document.querySelector("#tide-table"),
+  tideTableStatus: document.querySelector("#tide-table-status"),
+  timeSlider: document.querySelector("#time-slider"),
+  timeSliderLabel: document.querySelector("#time-slider-label"),
   duration: document.querySelector("#passage-duration"),
   waypointList: document.querySelector("#waypoint-list"),
   windStatus: document.querySelector("#wind-status"),
   windVisible: document.querySelector("#wind-visible"),
+  sunChart: document.querySelector("#sun-chart"),
+  sunChartStatus: document.querySelector("#sun-chart-status"),
 };
 
 let stops = [];
@@ -135,8 +146,14 @@ let currentDepthAdjustment = null;
 let marineDepthContext = null;
 let marineRefreshTimer = null;
 let marineRefreshPending = { field: false, route: false };
+let tideTableAbortController = null;
+let tideTableRequestSequence = 0;
+let sunAbortController = null;
+let sunRequestSequence = 0;
+let environmentRefreshTimer = null;
 
 restoreDraft();
+syncTimeSliderFromStart();
 elements.depthPalette.disabled = !elements.bathymetryVisible.checked;
 
 const map = new maplibregl.Map({
@@ -295,6 +312,26 @@ map.on("style.load", async () => {
 
   map.addSource("wind-field", { type: "geojson", data: EMPTY_FEATURE_COLLECTION });
   map.addLayer({
+    id: "wind-field-time-halo",
+    type: "line",
+    source: "wind-field",
+    filter: ["==", ["get", "kind"], "arrow"],
+    minzoom: 3,
+    layout: {
+      visibility: elements.windVisible.checked ? "visible" : "none",
+      "line-cap": "round",
+      "line-join": "round",
+    },
+    paint: {
+      "line-color": "#8a4faf",
+      "line-width": ["interpolate", ["linear"], ["get", "speedKnots"], 0, 5, 35, 7.5],
+      "line-opacity": [
+        "interpolate", ["linear"], ["coalesce", ["get", "forecastWeight"], 0],
+        0, 0, 0.15, 0.38, 1, 0.82,
+      ],
+    },
+  });
+  map.addLayer({
     id: "wind-field-arrows",
     type: "line",
     source: "wind-field",
@@ -323,7 +360,7 @@ map.on("style.load", async () => {
     layout: {
       visibility: elements.windVisible.checked ? "visible" : "none",
       "text-field": ["get", "speedLabel"],
-      "text-size": 10,
+      "text-size": 11.5,
       "text-offset": [0, 1.35],
       "text-allow-overlap": false,
     },
@@ -356,11 +393,7 @@ map.on("style.load", async () => {
         "interpolate", ["linear"], ["coalesce", ["get", "forecastWeight"], 0],
         0, "#078c9b", 0.5, "#486fc0", 1, "#8a4faf",
       ],
-      "line-width": [
-        "interpolate", ["linear"], ["zoom"],
-        3, ["interpolate", ["linear"], ["get", "speedKnots"], 0, 2.2, 4, 4.6],
-        14, ["interpolate", ["linear"], ["get", "speedKnots"], 0, 3.2, 4, 6.2],
-      ],
+      "line-width": ["interpolate", ["linear"], ["get", "speedKnots"], 0, 2.2, 4, 4.8],
       "line-opacity": 0.92,
     },
   });
@@ -373,7 +406,7 @@ map.on("style.load", async () => {
     layout: {
       visibility: elements.currentVisible.checked ? "visible" : "none",
       "text-field": ["get", "speedLabel"],
-      "text-size": ["interpolate", ["linear"], ["zoom"], 4, 11.5, 10, 13, 14, 14.5],
+      "text-size": 13,
       "text-offset": [0, -1.35],
       "text-allow-overlap": false,
     },
@@ -472,6 +505,24 @@ map.on("style.load", async () => {
     layout: { "line-cap": "round", "line-join": "round" },
     paint: { "line-color": "#e15f3b", "line-width": 4, "line-dasharray": [2.2, 1.2] },
   });
+  map.addLayer({
+    id: "passage-route-label",
+    type: "symbol",
+    source: "passage-route",
+    minzoom: 7,
+    layout: {
+      "symbol-placement": "line",
+      "symbol-spacing": 450,
+      "text-field": ["get", "label"],
+      "text-size": 10,
+      "text-letter-spacing": 0.08,
+    },
+    paint: {
+      "text-color": currentTheme() === "dark" ? "#ffc8b7" : "#8c321b",
+      "text-halo-color": currentTheme() === "dark" ? "#0b1c22" : "#fffdf7",
+      "text-halo-width": 1.6,
+    },
+  });
 
   map.addSource("route-current", { type: "geojson", data: routeCurrentGeoJson(routeCurrentEstimate) });
   map.addLayer({
@@ -486,10 +537,28 @@ map.on("style.load", async () => {
       "line-join": "round",
     },
     paint: {
-      "line-color": "#c54e8f",
-      "line-width": ["interpolate", ["linear"], ["zoom"], 4, 2, 13, 3.5],
+      "line-color": "#a82082",
+      "line-width": 2.8,
       "line-dasharray": [1.5, 1.5],
       "line-opacity": 0.9,
+    },
+  });
+  map.addLayer({
+    id: "route-drift-label",
+    type: "symbol",
+    source: "route-current",
+    filter: ["==", ["get", "kind"], "drift-label"],
+    minzoom: 5,
+    layout: {
+      visibility: elements.currentVisible.checked ? "visible" : "none",
+      "text-field": ["get", "label"],
+      "text-size": 10,
+      "text-offset": [0, -1],
+    },
+    paint: {
+      "text-color": currentTheme() === "dark" ? "#ffb6e4" : "#7d145f",
+      "text-halo-color": currentTheme() === "dark" ? "#0b1c22" : "#fffdf7",
+      "text-halo-width": 1.7,
     },
   });
   map.addLayer({
@@ -505,7 +574,7 @@ map.on("style.load", async () => {
     },
     paint: {
       "line-color": "#f09a35",
-      "line-width": ["interpolate", ["linear"], ["zoom"], 4, 3.4, 13, 5],
+      "line-width": 3.8,
       "line-opacity": 0.98,
     },
   });
@@ -518,7 +587,7 @@ map.on("style.load", async () => {
     layout: {
       visibility: elements.currentVisible.checked ? "visible" : "none",
       "text-field": ["get", "speedLabel"],
-      "text-size": ["interpolate", ["linear"], ["zoom"], 5, 11.5, 12, 13.5],
+      "text-size": 12.5,
       "text-offset": [0, 1.5],
       "text-allow-overlap": false,
     },
@@ -539,6 +608,7 @@ map.on("style.load", async () => {
     updateCurrentField();
     updateRouteCurrentEstimate();
   }
+  scheduleEnvironmentRefresh(0);
   if (!catalogueRequested) {
     catalogueRequested = true;
     await loadPoiCatalogue();
@@ -556,6 +626,7 @@ map.on("moveend", () => {
   updateShallowContours();
   if (elements.windVisible.checked) updateWindField();
   if (elements.currentVisible.checked) updateCurrentField();
+  scheduleEnvironmentRefresh();
 });
 
 map.on("click", async (event) => {
@@ -614,11 +685,13 @@ map.on("click", async (event) => {
 for (const layerId of [
   "marine-poi-clusters",
   "marine-poi-points",
+  "wind-field-time-halo",
   "wind-field-arrows",
   "wind-field-labels",
   "current-field-arrows",
   "current-field-labels",
   "route-drift-line",
+  "route-drift-label",
   "route-current-arrows",
   "route-current-labels",
 ]) {
@@ -631,15 +704,23 @@ elements.speedKnots.addEventListener("input", () => {
   invalidateRouteCurrentEstimate();
   renderSummary();
   scheduleMarineRefresh({ field: true, route: true });
+  scheduleEnvironmentRefresh();
   scheduleDraftSave();
 });
 elements.startTime.addEventListener("change", () => {
-  invalidateRouteCurrentEstimate();
-  currentDepthAdjustment = null;
-  renderSummary();
-  syncAdjustedContourData();
-  scheduleMarineRefresh({ field: true, route: true }, 0);
-  scheduleDraftSave();
+  passageStartChanged(0);
+});
+for (const button of document.querySelectorAll("[data-shift-hours]")) {
+  button.addEventListener("click", () => shiftPassageStart(Number(button.dataset.shiftHours)));
+}
+elements.startTimeNow.addEventListener("click", () => {
+  setPassageStart(new Date(Math.ceil(Date.now() / 900_000) * 900_000));
+});
+elements.timeSlider.addEventListener("input", () => {
+  const start = selectedStartTime() || new Date();
+  const minutes = Number(elements.timeSlider.value);
+  start.setHours(Math.floor(minutes / 60), minutes % 60, 0, 0);
+  setPassageStart(start, 450);
 });
 elements.poiSearch.addEventListener("input", renderPoiResults);
 elements.poiFilters.addEventListener("change", () => {
@@ -679,12 +760,13 @@ elements.noaaVisible.addEventListener("change", () => {
 elements.poisVisible.addEventListener("change", updatePoiLayer);
 elements.windVisible.addEventListener("change", () => {
   setLayerVisibility("wind-field-arrows", elements.windVisible.checked);
+  setLayerVisibility("wind-field-time-halo", elements.windVisible.checked);
   setLayerVisibility("wind-field-labels", elements.windVisible.checked);
   if (elements.windVisible.checked) {
     updateWindField();
   } else {
     windAbortController?.abort();
-    elements.windStatus.textContent = "Wind field hidden. Turn it on to load current model wind.";
+    elements.windStatus.textContent = "Wind field hidden. Turn it on to load model wind.";
   }
   scheduleDraftSave();
 });
@@ -719,6 +801,7 @@ function syncChartContextLayers() {
   setLayerVisibility("current-field-arrows", elements.currentVisible.checked);
   setLayerVisibility("current-field-labels", elements.currentVisible.checked);
   setLayerVisibility("route-drift-line", elements.currentVisible.checked);
+  setLayerVisibility("route-drift-label", elements.currentVisible.checked);
   setLayerVisibility("route-current-arrows", elements.currentVisible.checked);
   setLayerVisibility("route-current-labels", elements.currentVisible.checked);
 }
@@ -747,14 +830,17 @@ elements.clearLocal.addEventListener("click", () => {
   elements.windVisible.checked = false;
   elements.currentVisible.checked = true;
   elements.startTime.value = defaultStartTimeValue();
+  syncTimeSliderFromStart();
   invalidateRouteCurrentEstimate();
   currentDepthAdjustment = null;
   syncChartContextLayers();
   setLayerVisibility("seamarks-layer", true);
   setLayerVisibility("wind-field-arrows", false);
+  setLayerVisibility("wind-field-time-halo", false);
   setLayerVisibility("wind-field-labels", false);
   renderPassage();
   scheduleMarineRefresh({ field: true, route: true }, 0);
+  scheduleEnvironmentRefresh(0);
   clearTimeout(draftSaveTimer);
   localStorage.removeItem(PLANNER_DRAFT_KEY);
   elements.draftStatus.textContent = "Saved planner data cleared from this device.";
@@ -789,6 +875,7 @@ function renderPassage() {
   elements.download.disabled = stops.length < 2;
   elements.publish.disabled = stops.length < 2;
   scheduleMarineRefresh({ field: true, route: true });
+  scheduleEnvironmentRefresh();
   scheduleDraftSave();
 }
 
@@ -908,7 +995,7 @@ function routeGeoJson() {
   }
   return {
     type: "Feature",
-    properties: {},
+    properties: { label: "DESIRED GROUND TRACK" },
     geometry: {
       type: "LineString",
       coordinates: stops.map((stop) => [stop.longitude, stop.latitude]),
@@ -1149,20 +1236,34 @@ async function updateWindField() {
   windAbortController = new AbortController();
   const requestSequence = ++windRequestSequence;
   const bounds = visibleMapBounds();
-  const points = windGrid(bounds);
-  elements.windStatus.textContent = "Loading current model wind across this map…";
+  const canvas = map.getCanvas();
+  const dimensions = currentGridDimensions(canvas.clientWidth, canvas.clientHeight, map.getZoom());
+  const points = windGrid(bounds, dimensions.columns, dimensions.rows);
+  const timings = currentSampleTimings(points, new Date(), routeCurrentEstimate);
+  const requestedTimes = timings.map((timing) => new Date(timing.sampleTime));
+  const rangeStart = new Date(Math.min(...requestedTimes.map((date) => date.getTime())) - 3_600_000);
+  const rangeEnd = new Date(Math.max(...requestedTimes.map((date) => date.getTime())) + 3_600_000);
+  elements.windStatus.textContent = "Loading zoom-adaptive wind at current and expected passage times…";
   try {
-    const response = await fetch(windRequestUrl(points), {
+    const response = await fetch(windRequestUrl(points, rangeStart, rangeEnd), {
       headers: { Accept: "application/json" },
       signal: windAbortController.signal,
     });
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
     const data = await response.json();
     if (requestSequence !== windRequestSequence) return;
-    const field = windFieldGeoJson(points, data, bounds);
+    const field = windFieldGeoJson(
+      points,
+      data,
+      bounds,
+      timings,
+      dimensions.columns,
+      dimensions.rows,
+    );
     if (field.geojson.features.length === 0) throw new Error("unreadable forecast values");
     map.getSource("wind-field")?.setData(field.geojson);
-    elements.windStatus.textContent = `${points.length} model samples · valid ${field.validTime} UTC · arrows point downwind; labels show knots. Tap an arrow for direction and gusts.`;
+    const routeTimed = timings.filter((timing) => timing.forecastWeight > 0.01).length;
+    elements.windStatus.textContent = `${points.length} samples on a ${dimensions.columns}×${dimensions.rows} zoom-adaptive grid · ${routeTimed} near-route samples blend to their expected passage time and carry a purple halo. Labels show knots and UTC sample time; arrows point downwind.`;
   } catch (error) {
     if (error.name === "AbortError") return;
     elements.windStatus.textContent = `Wind forecast unavailable (${error.message}).`;
@@ -1178,7 +1279,7 @@ function showWindPopup(position, properties) {
   const heading = document.createElement("h3");
   heading.textContent = `${speed} kn from ${String(direction).padStart(3, "0")}°T`;
   const detail = document.createElement("p");
-  detail.textContent = `Gusting ${gust} kn · valid ${properties.validTime} UTC`;
+  detail.textContent = `Gusting ${gust} kn · ${properties.timing === "current" ? "current-time" : "route-time"} model valid ${formatPassageTime(new Date(properties.validTime))}`;
   const warning = document.createElement("p");
   warning.textContent = "Open-Meteo model forecast, not an observation.";
   container.append(heading, detail, warning);
@@ -1201,7 +1302,13 @@ async function updateCurrentField() {
   const bounds = visibleMapBounds();
   const canvas = map.getCanvas();
   const dimensions = currentGridDimensions(canvas.clientWidth, canvas.clientHeight, map.getZoom());
-  const points = marineGrid(bounds, dimensions.columns, dimensions.rows);
+  const candidates = marineGrid(bounds, dimensions.columns, dimensions.rows);
+  const points = waterOnlyModelPoints(candidates);
+  if (points.length === 0) {
+    map.getSource("current-field")?.setData(EMPTY_FEATURE_COLLECTION);
+    elements.currentStatus.textContent = "No basemap water cells are visible for the current field.";
+    return;
+  }
   const timings = currentSampleTimings(points, new Date(), routeCurrentEstimate);
   const requestedTimes = [start, ...timings.map((timing) => new Date(timing.sampleTime))];
   const rangeStart = new Date(Math.min(...requestedTimes.map((date) => date.getTime())) - 3_600_000);
@@ -1226,8 +1333,10 @@ async function updateCurrentField() {
       dimensions.columns,
       dimensions.rows,
     );
-    if (field.geojson.features.length === 0) throw new Error("unreadable model values");
-    map.getSource("current-field")?.setData(field.geojson);
+    const waterSamples = field.samples.filter((sample) => basemapShowsWater(sample.point));
+    const visibleField = currentFeaturesOverWater(field.geojson);
+    if (visibleField.features.length === 0) throw new Error("no visible model sea cells");
+    map.getSource("current-field")?.setData(visibleField);
     const centre = {
       longitude: (bounds.west + bounds.east) / 2,
       latitude: (bounds.south + bounds.north) / 2,
@@ -1238,11 +1347,12 @@ async function updateCurrentField() {
     }, { index: 0, distance: Infinity }).index;
     const centreSample = sampleMarineAt(Array.isArray(data) ? data[centreIndex] : data, start);
     marineDepthContext = Number.isFinite(centreSample?.seaLevelMsl)
-      ? { point: centre, seaLevelMsl: centreSample.seaLevelMsl, validTime: centreSample.validTime }
+      ? { point: points[centreIndex], seaLevelMsl: centreSample.seaLevelMsl, validTime: centreSample.validTime }
       : null;
     refreshDepthAdjustment();
-    const routeTimed = field.samples.filter((sample) => sample.forecastWeight > 0.01).length;
-    elements.currentStatus.textContent = `${field.samples.length} model samples on a ${dimensions.columns}×${dimensions.rows} zoom-adaptive grid · teal is current time; ${routeTimed} samples blend through blue to purple at the nearest expected route time within 8 NM. Arrows point with the flow; labels show knots.`;
+    const routeTimed = waterSamples.filter((sample) => sample.forecastWeight > 0.01).length;
+    const omitted = candidates.length - points.length;
+    elements.currentStatus.textContent = `${waterSamples.length} distinct model sea cells on a ${dimensions.columns}×${dimensions.rows} zoom-adaptive grid; ${omitted} land grid positions omitted · teal is current time; ${routeTimed} cells blend through blue to purple at the nearest expected route time within 8 NM. Arrows point with the flow; labels show knots.`;
   } catch (error) {
     if (error.name === "AbortError") return;
     map.getSource("current-field")?.setData(EMPTY_FEATURE_COLLECTION);
@@ -1299,11 +1409,13 @@ async function updateRouteCurrentEstimate() {
       boatSpeed,
       samplePlan,
     );
-    map.getSource("route-current")?.setData(
+    map.getSource("route-current")?.setData(currentFeaturesOverWater(
       routeCurrentGeoJson(routeCurrentEstimate, currentRouteArrowLength()),
-    );
+    ));
     renderSummary();
     updateCurrentField();
+    if (elements.windVisible.checked) updateWindField();
+    scheduleEnvironmentRefresh();
     if (!routeCurrentEstimate?.complete) {
       elements.stillWaterDuration.textContent = "Some leg currents were unavailable; showing still-water passage time.";
     }
@@ -1360,6 +1472,175 @@ function scheduleMarineRefresh({ field = false, route = false } = {}, delay = 35
   }, delay);
 }
 
+function scheduleEnvironmentRefresh(delay = 350) {
+  clearTimeout(environmentRefreshTimer);
+  environmentRefreshTimer = setTimeout(() => {
+    updateTideTable();
+    updateSunChart();
+  }, delay);
+}
+
+async function updateTideTable() {
+  if (!mapReady) return;
+  const start = selectedStartTime();
+  if (!start) return;
+  const point = environmentPoint("departure");
+  tideTableAbortController?.abort();
+  tideTableAbortController = new AbortController();
+  const requestSequence = ++tideTableRequestSequence;
+  elements.tideTableStatus.textContent = stops.length > 0 ? "near waypoint 1" : "at map centre";
+  try {
+    const rangeStart = new Date(start.getTime() - 12 * 60 * 60 * 1000);
+    const rangeEnd = new Date(start.getTime() + 36 * 60 * 60 * 1000);
+    const response = await fetch(tideRequestUrl(point, rangeStart, rangeEnd), {
+      headers: { Accept: "application/json" },
+      signal: tideTableAbortController.signal,
+    });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const data = await response.json();
+    if (requestSequence !== tideTableRequestSequence) return;
+    const events = tideEventsFromResponse(data, rangeStart, rangeEnd);
+    const datum = depthAdjustmentFor({ provider: "emodnet", point, seaLevelMsl: 0 });
+    renderTideTable(events, start, datum);
+    elements.tideTableStatus.textContent = datum
+      ? `${datum.chartDatum} via ${datum.stationName} · device time`
+      : "MSL · device time";
+  } catch (error) {
+    if (error.name === "AbortError") return;
+    elements.tideTable.replaceChildren(environmentEmpty("Model tide table unavailable."));
+    elements.tideTableStatus.textContent = error.message;
+  }
+}
+
+function renderTideTable(events, start, datum) {
+  elements.tideTable.replaceChildren();
+  if (events.length === 0) {
+    elements.tideTable.append(environmentEmpty("No high or low water extrema were resolved in this model window."));
+    return;
+  }
+  const nextIndex = events.findIndex((event) => new Date(event.time) >= start);
+  events.slice(0, 8).forEach((event, index) => {
+    const date = new Date(event.time);
+    const card = document.createElement("div");
+    card.className = `tide-event${index === nextIndex ? " next" : ""}`;
+    const kind = document.createElement("b");
+    kind.textContent = event.kind === "high" ? "High" : "Low";
+    const time = document.createElement("time");
+    time.dateTime = event.time;
+    time.textContent = date.toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit" });
+    const detail = document.createElement("span");
+    const height = event.heightMsl + (datum?.heightM || 0);
+    detail.textContent = `${date.toLocaleDateString("en-GB", { weekday: "short" })} · ${height.toFixed(2)} m ${datum?.chartDatum || "MSL"}`;
+    card.append(kind, time, detail);
+    elements.tideTable.append(card);
+  });
+}
+
+async function updateSunChart() {
+  if (!mapReady) return;
+  const start = selectedStartTime();
+  if (!start) return;
+  const point = environmentPoint("destination");
+  const summary = passageSummary(stops, Number(elements.speedKnots.value));
+  const duration = routeCurrentEstimate?.complete
+    ? routeCurrentEstimate.durationSeconds
+    : summary.durationSeconds;
+  const arrival = stops.length > 1 && Number.isFinite(duration)
+    ? new Date(start.getTime() + duration * 1000)
+    : null;
+  sunAbortController?.abort();
+  sunAbortController = new AbortController();
+  const requestSequence = ++sunRequestSequence;
+  elements.mapEnvironmentTime.textContent = formatPassageTime(start);
+  elements.sunChartStatus.textContent = stops.length > 1 ? "at final waypoint" : "at map centre";
+  try {
+    const response = await fetch(sunRequestUrl(point), {
+      headers: { Accept: "application/json" },
+      signal: sunAbortController.signal,
+    });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const data = await response.json();
+    if (requestSequence !== sunRequestSequence) return;
+    const chart = sunChartRows(data, start, arrival);
+    renderSunChart(chart);
+    elements.sunChartStatus.textContent = `${stops.length > 1 ? "final waypoint" : "map centre"} · ${chart.timezoneAbbreviation}`;
+  } catch (error) {
+    if (error.name === "AbortError") return;
+    elements.sunChart.replaceChildren(environmentEmpty("Sunrise and sunset unavailable."));
+    elements.sunChartStatus.textContent = error.message;
+  }
+}
+
+function renderSunChart(chart) {
+  elements.sunChart.replaceChildren();
+  if (chart.rows.length === 0) {
+    elements.sunChart.append(environmentEmpty("Selected time is outside the 16-day daylight window."));
+    return;
+  }
+  chart.rows.forEach((row) => {
+    const container = document.createElement("div");
+    const nightArrival = row.arrivalAfterSunset || row.arrivalBeforeSunrise;
+    container.className = `sun-row${nightArrival ? " night-arrival" : ""}`;
+    const heading = document.createElement("div");
+    heading.className = "sun-row-heading";
+    const date = document.createElement("strong");
+    date.textContent = new Intl.DateTimeFormat("en-GB", {
+      weekday: "short",
+      day: "2-digit",
+      month: "short",
+      timeZone: "UTC",
+    }).format(new Date(`${row.date}T12:00:00Z`));
+    const sunTimes = document.createElement("span");
+    sunTimes.textContent = `☀ ${row.sunriseLabel}–${row.sunsetLabel}`;
+    heading.append(date, sunTimes);
+    const track = document.createElement("div");
+    track.className = "sun-track";
+    track.setAttribute("aria-label", `Sunrise ${row.sunriseLabel}; sunset ${row.sunsetLabel}`);
+    const daylight = document.createElement("span");
+    daylight.className = "sun-daylight";
+    daylight.style.left = `${row.daylightStartPercent}%`;
+    daylight.style.width = `${row.daylightWidthPercent}%`;
+    track.append(daylight);
+    if (row.startPercent !== null) track.append(sunMarker("start", row.startPercent, `Start ${row.startLabel}`));
+    if (row.arrivalPercent !== null) track.append(sunMarker("arrival", row.arrivalPercent, `ETA ${row.arrivalLabel}`));
+    const note = document.createElement("div");
+    note.className = "sun-row-note";
+    const parts = [];
+    if (row.startLabel) parts.push(`Coral: start ${row.startLabel}`);
+    if (row.arrivalLabel) parts.push(`Blue: ETA ${row.arrivalLabel}`);
+    note.textContent = parts.join(" · ");
+    if (nightArrival) {
+      const warning = document.createElement("strong");
+      warning.textContent = row.arrivalAfterSunset ? " · ETA after sunset" : " · ETA before sunrise";
+      note.append(warning);
+    }
+    container.append(heading, track, note);
+    elements.sunChart.append(container);
+  });
+}
+
+function sunMarker(kind, position, label) {
+  const marker = document.createElement("span");
+  marker.className = `sun-marker ${kind}`;
+  marker.style.left = `${position}%`;
+  marker.title = label;
+  return marker;
+}
+
+function environmentPoint(kind) {
+  const stop = kind === "destination" ? stops.at(-1) : stops[0];
+  if (stop) return { longitude: stop.longitude, latitude: stop.latitude };
+  const centre = map.getCenter();
+  return { longitude: centre.lng, latitude: centre.lat };
+}
+
+function environmentEmpty(message) {
+  const empty = document.createElement("p");
+  empty.className = "environment-empty";
+  empty.textContent = message;
+  return empty;
+}
+
 function invalidateRouteCurrentEstimate() {
   routeCurrentAbortController?.abort();
   routeCurrentRequestSequence += 1;
@@ -1372,11 +1653,11 @@ function currentRouteArrowLength() {
   const canvas = map.getCanvas();
   const dimensions = currentGridDimensions(canvas.clientWidth, canvas.clientHeight, map.getZoom());
   return Math.max(
-    0.00008,
+    0.00002,
     Math.min(
       (bounds.north - bounds.south) / dimensions.rows,
       (bounds.east - bounds.west) / dimensions.columns,
-    ) * 0.34,
+    ) * 0.26,
   );
 }
 
@@ -1499,6 +1780,35 @@ function visibleMapBounds() {
   };
 }
 
+function waterOnlyModelPoints(points) {
+  if (!mapReady || !map.getLayer("water")) return points;
+  return points.filter(basemapShowsWater);
+}
+
+function currentFeaturesOverWater(geojson) {
+  if (!mapReady || !map.getLayer("water")) return geojson;
+  return {
+    ...geojson,
+    features: geojson.features.filter((feature) => {
+      const longitude = Number(feature.properties?.anchorLongitude);
+      const latitude = Number(feature.properties?.anchorLatitude);
+      return !Number.isFinite(longitude) || !Number.isFinite(latitude) ||
+        basemapShowsWater({ longitude, latitude });
+    }),
+  };
+}
+
+function basemapShowsWater(point) {
+  try {
+    return map.queryRenderedFeatures(
+      map.project([point.longitude, point.latitude]),
+      { layers: ["water"] },
+    ).length > 0;
+  } catch {
+    return true;
+  }
+}
+
 function fitPassage() {
   if (!mapReady || stops.length === 0) return;
   if (stops.length === 1) {
@@ -1591,6 +1901,41 @@ function currentTheme() {
 function selectedStartTime() {
   const date = new Date(elements.startTime.value);
   return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function setPassageStart(date, refreshDelay = 0) {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) return;
+  elements.startTime.value = localDateTimeValue(date);
+  passageStartChanged(refreshDelay);
+}
+
+function shiftPassageStart(hours) {
+  const start = selectedStartTime() || new Date();
+  start.setTime(start.getTime() + hours * 60 * 60 * 1000);
+  setPassageStart(start);
+}
+
+function passageStartChanged(refreshDelay = 0) {
+  syncTimeSliderFromStart();
+  invalidateRouteCurrentEstimate();
+  currentDepthAdjustment = null;
+  renderSummary();
+  syncAdjustedContourData();
+  scheduleMarineRefresh({ field: true, route: true }, refreshDelay);
+  if (elements.windVisible.checked) updateWindField();
+  scheduleEnvironmentRefresh(refreshDelay);
+  scheduleDraftSave();
+}
+
+function syncTimeSliderFromStart() {
+  const start = selectedStartTime();
+  if (!start) {
+    elements.timeSliderLabel.textContent = "Choose a valid time";
+    return;
+  }
+  elements.timeSlider.value = String(start.getHours() * 60 + start.getMinutes());
+  elements.timeSliderLabel.textContent = formatPassageTime(start);
+  elements.mapEnvironmentTime.textContent = formatPassageTime(start);
 }
 
 function defaultStartTimeValue(now = new Date()) {

--- a/apps/website/sun-times.mjs
+++ b/apps/website/sun-times.mjs
@@ -1,0 +1,102 @@
+const FORECAST_API_URL = "https://api.open-meteo.com/v1/forecast";
+
+export function sunRequestUrl(point) {
+  if (!point) throw new Error("A daylight position is required.");
+  const parameters = new URLSearchParams({
+    latitude: Number(point.latitude).toFixed(4),
+    longitude: Number(point.longitude).toFixed(4),
+    daily: "sunrise,sunset",
+    timezone: "auto",
+    timeformat: "unixtime",
+    forecast_days: "16",
+  });
+  return `${FORECAST_API_URL}?${parameters}`;
+}
+
+export function sunChartRows(response, start, arrival = null) {
+  const startTime = validDate(start).getTime();
+  const arrivalTime = arrival ? validDate(arrival).getTime() : null;
+  const daily = response?.daily;
+  const offsetSeconds = Number(response?.utc_offset_seconds) || 0;
+  const timezone = response?.timezone || "UTC";
+  const starts = Array.isArray(daily?.time) ? daily.time.map(unixMilliseconds) : [];
+  const sunrises = Array.isArray(daily?.sunrise)
+    ? daily.sunrise.map(unixMilliseconds)
+    : [];
+  const sunsets = Array.isArray(daily?.sunset)
+    ? daily.sunset.map(unixMilliseconds)
+    : [];
+  const rows = [];
+  starts.forEach((dayStart, index) => {
+    const dayEnd = starts[index + 1] ?? dayStart + 24 * 60 * 60 * 1000;
+    const sunrise = sunrises[index];
+    const sunset = sunsets[index];
+    if (![dayStart, dayEnd, sunrise, sunset].every(Number.isFinite)) return;
+    const hasStart = startTime >= dayStart && startTime < dayEnd;
+    const hasArrival = Number.isFinite(arrivalTime) && arrivalTime >= dayStart && arrivalTime < dayEnd;
+    if (!hasStart && !hasArrival) return;
+    const duration = dayEnd - dayStart;
+    rows.push({
+      date: localDateLabel(dayStart, timezone, offsetSeconds),
+      sunrise: new Date(sunrise).toISOString(),
+      sunset: new Date(sunset).toISOString(),
+      sunriseLabel: localClockLabel(sunrise, timezone, offsetSeconds),
+      sunsetLabel: localClockLabel(sunset, timezone, offsetSeconds),
+      daylightStartPercent: percentage(sunrise - dayStart, duration),
+      daylightWidthPercent: percentage(sunset - sunrise, duration),
+      startPercent: hasStart ? percentage(startTime - dayStart, duration) : null,
+      arrivalPercent: hasArrival ? percentage(arrivalTime - dayStart, duration) : null,
+      startLabel: hasStart ? localClockLabel(startTime, timezone, offsetSeconds) : null,
+      arrivalLabel: hasArrival ? localClockLabel(arrivalTime, timezone, offsetSeconds) : null,
+      arrivalAfterSunset: hasArrival && arrivalTime > sunset,
+      arrivalBeforeSunrise: hasArrival && arrivalTime < sunrise,
+    });
+  });
+  return {
+    rows,
+    timezone,
+    timezoneAbbreviation: response?.timezone_abbreviation || "UTC",
+  };
+}
+
+function percentage(value, total) {
+  return Math.max(0, Math.min(100, (value / total) * 100));
+}
+
+function unixMilliseconds(value) {
+  return value === null || value === undefined ? Number.NaN : Number(value) * 1000;
+}
+
+function localClockLabel(timestamp, timezone, offsetSeconds) {
+  try {
+    return new Intl.DateTimeFormat("en-GB", {
+      timeZone: timezone,
+      hour: "2-digit",
+      minute: "2-digit",
+      hourCycle: "h23",
+    }).format(new Date(timestamp));
+  } catch {
+    return new Date(timestamp + offsetSeconds * 1000).toISOString().slice(11, 16);
+  }
+}
+
+function localDateLabel(timestamp, timezone, offsetSeconds) {
+  try {
+    const parts = new Intl.DateTimeFormat("en-CA", {
+      timeZone: timezone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).formatToParts(new Date(timestamp));
+    const value = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+    return `${value.year}-${value.month}-${value.day}`;
+  } catch {
+    return new Date(timestamp + offsetSeconds * 1000).toISOString().slice(0, 10);
+  }
+}
+
+function validDate(value) {
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) throw new Error("Choose a valid passage time.");
+  return date;
+}

--- a/apps/website/tide-current.mjs
+++ b/apps/website/tide-current.mjs
@@ -75,6 +75,79 @@ export function marineRequestUrl(points, start, end) {
   return `${MARINE_API_URL}?${parameters}`;
 }
 
+export function tideRequestUrl(point, start, end) {
+  if (!point) throw new Error("A tide-model position is required.");
+  const startDate = validDate(start);
+  const endDate = validDate(end);
+  if (endDate < startDate) throw new Error("The tide-model time range is invalid.");
+  const parameters = new URLSearchParams({
+    latitude: Number(point.latitude).toFixed(4),
+    longitude: Number(point.longitude).toFixed(4),
+    hourly: "sea_level_height_msl",
+    start_hour: formatUtcHour(new Date(Math.floor(startDate.getTime() / 3_600_000) * 3_600_000)),
+    end_hour: formatUtcHour(new Date(Math.ceil(endDate.getTime() / 3_600_000) * 3_600_000)),
+    timezone: "UTC",
+    cell_selection: "sea",
+  });
+  return `${MARINE_API_URL}?${parameters}`;
+}
+
+export function tideEventsFromResponse(response, start, end) {
+  const rangeStart = validDate(start).getTime();
+  const rangeEnd = validDate(end).getTime();
+  const hourly = response?.hourly;
+  const times = Array.isArray(hourly?.time)
+    ? hourly.time.map((value) => Date.parse(`${value}Z`))
+    : [];
+  const levels = Array.isArray(hourly?.sea_level_height_msl)
+    ? hourly.sea_level_height_msl.map(Number)
+    : [];
+  const weights = [1, 2, 3, 2, 1];
+  const smoothed = levels.map((_, index) => {
+    let total = 0;
+    let weight = 0;
+    weights.forEach((value, offset) => {
+      const sample = levels[index + offset - 2];
+      if (!Number.isFinite(sample)) return;
+      total += sample * value;
+      weight += value;
+    });
+    return weight > 0 ? total / weight : Number.NaN;
+  });
+  const events = [];
+  const usedIndices = new Set();
+  for (let index = 2; index < Math.min(times.length, levels.length) - 2; index += 1) {
+    const previous = smoothed[index - 1];
+    const level = smoothed[index];
+    const next = smoothed[index + 1];
+    if (![times[index], previous, level, next].every(Number.isFinite)) continue;
+    const high = level > previous && level >= next;
+    const low = level < previous && level <= next;
+    if (!high && !low) continue;
+    const nearby = Array.from({ length: 5 }, (_, offset) => index + offset - 2)
+      .filter((candidate) => Number.isFinite(levels[candidate]))
+      .sort((first, second) => {
+        const levelOrder = high
+          ? levels[second] - levels[first]
+          : levels[first] - levels[second];
+        return Math.abs(levelOrder) > 1e-9
+          ? levelOrder
+          : Math.abs(first - index) - Math.abs(second - index);
+      });
+    const eventIndex = nearby[0];
+    if (usedIndices.has(eventIndex)) continue;
+    usedIndices.add(eventIndex);
+    const eventTime = times[eventIndex];
+    if (eventTime < rangeStart || eventTime > rangeEnd) continue;
+    events.push({
+      kind: high ? "high" : "low",
+      time: new Date(eventTime).toISOString(),
+      heightMsl: levels[eventIndex],
+    });
+  }
+  return events;
+}
+
 export function sampleMarineAt(response, at) {
   const target = validDate(at).getTime();
   const hourly = response?.hourly;
@@ -114,19 +187,36 @@ export function currentFieldGeoJson(
 ) {
   const values = Array.isArray(response) ? response : [response];
   const arrowLength = Math.max(
-    0.00008,
-    Math.min((bounds.north - bounds.south) / rows, (bounds.east - bounds.west) / columns) * 0.32,
+    0.00002,
+    Math.min((bounds.north - bounds.south) / rows, (bounds.east - bounds.west) / columns) * 0.24,
   );
   const features = [];
   const samples = [];
+  const renderedModelCells = new Map();
   values.slice(0, points.length).forEach((value, index) => {
     const requestedTiming = Array.isArray(atOrTimings)
       ? atOrTimings[index]
       : { sampleTime: atOrTimings, forecastWeight: 0, timing: "passage-start" };
     const sample = sampleMarineAt(value, requestedTiming?.sampleTime);
     if (!sample) return;
+    const modelPoint = [value?.longitude, value?.latitude].every(Number.isFinite)
+      ? { longitude: Number(value.longitude), latitude: Number(value.latitude) }
+      : points[index];
+    const modelCell = `${modelPoint.longitude.toFixed(4)},${modelPoint.latitude.toFixed(4)}`;
     const forecastWeight = Math.max(0, Math.min(1, Number(requestedTiming.forecastWeight) || 0));
-    samples.push({ ...sample, point: points[index], index, ...requestedTiming, forecastWeight });
+    const existingIndex = renderedModelCells.get(modelCell);
+    if (
+      Number.isInteger(existingIndex) &&
+      samples[existingIndex].forecastWeight >= forecastWeight
+    ) return;
+    const sampleEntry = {
+      ...sample,
+      point: modelPoint,
+      requestedPoint: points[index],
+      index,
+      ...requestedTiming,
+      forecastWeight,
+    };
     const properties = {
       kind: "current-arrow",
       speedKnots: sample.speedKnots,
@@ -138,13 +228,24 @@ export function currentFieldGeoJson(
       forecastWeight,
       routeDistanceNm: requestedTiming?.routeDistanceNm ?? null,
       routeTime: requestedTiming?.routeTime ?? null,
+      anchorLongitude: modelPoint.longitude,
+      anchorLatitude: modelPoint.latitude,
     };
-    features.push(arrowFeature(points[index], sample.directionTowards, arrowLength, properties));
-    features.push({
+    const arrow = arrowFeature(modelPoint, sample.directionTowards, arrowLength, properties);
+    const label = {
       type: "Feature",
       properties: { ...properties, kind: "current-label" },
-      geometry: { type: "Point", coordinates: [points[index].longitude, points[index].latitude] },
-    });
+      geometry: { type: "Point", coordinates: [modelPoint.longitude, modelPoint.latitude] },
+    };
+    if (Number.isInteger(existingIndex)) {
+      samples[existingIndex] = sampleEntry;
+      features[existingIndex * 2] = arrow;
+      features[existingIndex * 2 + 1] = label;
+    } else {
+      renderedModelCells.set(modelCell, samples.length);
+      samples.push(sampleEntry);
+      features.push(arrow, label);
+    }
   });
   return { geojson: { type: "FeatureCollection", features }, samples };
 }
@@ -365,6 +466,18 @@ export function routeCurrentGeoJson(estimate, arrowLength = 0.012) {
       },
       geometry: { type: "LineString", coordinates: estimate.driftCoordinates },
     });
+    features.push({
+      type: "Feature",
+      properties: {
+        kind: "drift-label",
+        label: "UNCORRECTED DRIFT",
+        timing: "expected-route",
+      },
+      geometry: {
+        type: "Point",
+        coordinates: estimate.driftCoordinates[Math.floor(estimate.driftCoordinates.length / 2)],
+      },
+    });
   }
   estimate.legs.forEach((leg) => {
     leg.samples?.forEach((sample) => {
@@ -383,6 +496,8 @@ export function routeCurrentGeoJson(estimate, arrowLength = 0.012) {
         alongKnots: sample.alongKnots,
         crossKnots: sample.crossKnots,
         seaLevelMsl: sample.seaLevelMsl,
+        anchorLongitude: sample.point.longitude,
+        anchorLatitude: sample.point.latitude,
       };
       features.push(arrowFeature(sample.point, sample.headingDegrees, arrowLength, properties));
       features.push({

--- a/apps/website/wind-field.mjs
+++ b/apps/website/wind-field.mjs
@@ -14,11 +14,19 @@ export function windGrid(bounds, columns = 6, rows = 4) {
   return points;
 }
 
-export function windRequestUrl(points) {
+export function windRequestUrl(points, start = new Date(), end = start) {
+  if (!Array.isArray(points) || points.length === 0) {
+    throw new Error("At least one wind-model position is required.");
+  }
+  const startDate = validDate(start);
+  const endDate = validDate(end);
+  if (endDate < startDate) throw new Error("The wind-model time range is invalid.");
   const parameters = new URLSearchParams({
     latitude: points.map((point) => point.latitude.toFixed(4)).join(","),
     longitude: points.map((point) => point.longitude.toFixed(4)).join(","),
-    current: "wind_speed_10m,wind_direction_10m,wind_gusts_10m",
+    hourly: "wind_speed_10m,wind_direction_10m,wind_gusts_10m",
+    start_hour: formatUtcHour(new Date(Math.floor(startDate.getTime() / 3_600_000) * 3_600_000)),
+    end_hour: formatUtcHour(new Date(Math.ceil(endDate.getTime() / 3_600_000) * 3_600_000)),
     wind_speed_unit: "kn",
     timezone: "UTC",
   });
@@ -35,23 +43,54 @@ function offsetPoint(point, bearingDegrees, distanceLatitudeDegrees) {
   return [longitude, latitude];
 }
 
-export function windFieldGeoJson(points, response, bounds, columns = 6, rows = 4) {
+export function sampleWindAt(response, at) {
+  const target = validDate(at).getTime();
+  const hourly = response?.hourly;
+  const times = Array.isArray(hourly?.time)
+    ? hourly.time.map((value) => Date.parse(`${value}Z`))
+    : [];
+  if (times.length === 0 || times.some((value) => !Number.isFinite(value))) return null;
+  let upper = times.findIndex((value) => value >= target);
+  if (upper < 0) upper = times.length - 1;
+  const lower = Math.max(0, upper - (times[upper] > target ? 1 : 0));
+  const span = times[upper] - times[lower];
+  const fraction = span > 0 ? Math.max(0, Math.min(1, (target - times[lower]) / span)) : 0;
+  const first = windVector(hourly, lower);
+  const second = windVector(hourly, upper);
+  if (!first || !second) return null;
+  const eastFrom = first.eastFrom + (second.eastFrom - first.eastFrom) * fraction;
+  const northFrom = first.northFrom + (second.northFrom - first.northFrom) * fraction;
+  return {
+    speedKnots: Math.hypot(eastFrom, northFrom),
+    directionFrom: normalizeBearing((Math.atan2(eastFrom, northFrom) * 180) / Math.PI),
+    gustKnots: first.gustKnots + (second.gustKnots - first.gustKnots) * fraction,
+    validTime: new Date(target).toISOString(),
+  };
+}
+
+export function windFieldGeoJson(
+  points,
+  response,
+  bounds,
+  atOrTimings = new Date(),
+  columns = 6,
+  rows = 4,
+) {
   const values = Array.isArray(response) ? response : [response];
   const arrowLength = Math.max(
-    0.004,
-    Math.min((bounds.north - bounds.south) / rows, (bounds.east - bounds.west) / columns) * 0.28,
+    0.00002,
+    Math.min((bounds.north - bounds.south) / rows, (bounds.east - bounds.west) / columns) * 0.24,
   );
   const features = [];
   let validTime = null;
   values.slice(0, points.length).forEach((value, index) => {
-    const current = value?.current;
-    if (
-      ![current?.wind_speed_10m, current?.wind_direction_10m, current?.wind_gusts_10m].every(
-        Number.isFinite,
-      )
-    ) return;
+    const requestedTiming = Array.isArray(atOrTimings)
+      ? atOrTimings[index]
+      : { sampleTime: atOrTimings, forecastWeight: 0, timing: "current" };
+    const sample = sampleWindAt(value, requestedTiming?.sampleTime);
+    if (!sample) return;
     const point = points[index];
-    const downwind = (current.wind_direction_10m + 180) % 360;
+    const downwind = (sample.directionFrom + 180) % 360;
     const start = offsetPoint(point, (downwind + 180) % 360, arrowLength * 0.48);
     const end = offsetPoint(point, downwind, arrowLength * 0.48);
     const leftHead = offsetPoint(
@@ -64,14 +103,20 @@ export function windFieldGeoJson(points, response, bounds, columns = 6, rows = 4
       (downwind + 210) % 360,
       arrowLength * 0.32,
     );
+    const forecastWeight = Math.max(0, Math.min(1, Number(requestedTiming.forecastWeight) || 0));
+    const timeLabel = forecastWeight < 0.01
+      ? "now"
+      : new Date(sample.validTime).toISOString().slice(11, 16) + "Z";
     const properties = {
-      speedKnots: current.wind_speed_10m,
-      speedLabel: `${Math.round(current.wind_speed_10m)} kn`,
-      directionFrom: current.wind_direction_10m,
-      gustKnots: current.wind_gusts_10m,
-      validTime: current.time,
+      speedKnots: sample.speedKnots,
+      speedLabel: `${Math.round(sample.speedKnots)} kn · ${timeLabel}`,
+      directionFrom: sample.directionFrom,
+      gustKnots: sample.gustKnots,
+      validTime: sample.validTime,
+      forecastWeight,
+      timing: requestedTiming?.timing || "current",
     };
-    validTime ||= current.time;
+    validTime ||= sample.validTime;
     features.push({
       type: "Feature",
       properties: { ...properties, kind: "arrow" },
@@ -87,4 +132,31 @@ export function windFieldGeoJson(points, response, bounds, columns = 6, rows = 4
     });
   });
   return { geojson: { type: "FeatureCollection", features }, validTime };
+}
+
+function windVector(hourly, index) {
+  const speedKnots = Number(hourly?.wind_speed_10m?.[index]);
+  const directionFrom = Number(hourly?.wind_direction_10m?.[index]);
+  const gustKnots = Number(hourly?.wind_gusts_10m?.[index]);
+  if (![speedKnots, directionFrom, gustKnots].every(Number.isFinite)) return null;
+  const radians = (directionFrom * Math.PI) / 180;
+  return {
+    eastFrom: speedKnots * Math.sin(radians),
+    northFrom: speedKnots * Math.cos(radians),
+    gustKnots,
+  };
+}
+
+function formatUtcHour(date) {
+  return date.toISOString().slice(0, 13) + ":00";
+}
+
+function validDate(value) {
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) throw new Error("Choose a valid forecast time.");
+  return date;
+}
+
+function normalizeBearing(value) {
+  return ((value % 360) + 360) % 360;
 }


### PR DESCRIPTION
## Summary
- make wind and current vectors shrink with close zoom and keep current cells over charted water
- make wind/current samples route-time aware and clearly label desired track, CTS and uncorrected drift
- add tide extrema, sunrise/sunset, start/ETA daylight chart and fast passage-time controls

## Safety
- retains model-resolution and coastal-navigation warnings
- presents tide heights as model guidance, not official predictions
- keeps calculated CTS as a planning estimate, not a helm instruction

## Verification
- node --check apps/website/planner.js
- node --test apps/website/planner-core.test.mjs apps/website/map-data.test.mjs
- python3 -m unittest tools/places/test_generate_sailing_pois.py
- python3 -m unittest tools/contours/test_generate_emodnet_shallow_contours.py
- ./tools/build_website.sh
- visual QA at wide/close zoom, dark theme, route-time wind/current, tide table, and after-sunset warning