### PR TITLE
fix: make planner forecasts resilient to rate limits

### DIFF
--- a/apps/website/forecast-cache.mjs
+++ b/apps/website/forecast-cache.mjs
@@ -1,0 +1,130 @@
+const memoryCache = new Map();
+const inFlightRequests = new Map();
+const cooldowns = new Map();
+const STORAGE_PREFIX = "tide-and-seek:forecast:";
+
+export class ForecastRateLimitError extends Error {
+  constructor(retryAfterSeconds) {
+    super(`forecast service rate limited; try again in ${retryAfterSeconds} s`);
+    this.name = "ForecastRateLimitError";
+    this.retryAfterSeconds = retryAfterSeconds;
+  }
+}
+
+export async function fetchForecastJson(
+  url,
+  {
+    ttlMs = 10 * 60 * 1000,
+    staleIfErrorMs = 60 * 60 * 1000,
+    persist = false,
+    fetcher = globalThis.fetch,
+    storage = defaultSessionStorage(),
+    now = Date.now,
+  } = {},
+) {
+  const cacheKey = String(url);
+  const cooldownKey = forecastOrigin(cacheKey);
+  const currentTime = now();
+  const cached = readCache(cacheKey, persist ? storage : null);
+  if (cached && currentTime - cached.savedAt <= ttlMs) {
+    return { data: cached.data, cacheStatus: "fresh-cache" };
+  }
+
+  const cooldownUntil = cooldowns.get(cooldownKey) || 0;
+  if (cooldownUntil > currentTime) {
+    if (isUsableStale(cached, currentTime, staleIfErrorMs)) {
+      return { data: cached.data, cacheStatus: "stale-cache" };
+    }
+    throw new ForecastRateLimitError(Math.max(1, Math.ceil((cooldownUntil - currentTime) / 1000)));
+  }
+
+  if (inFlightRequests.has(cacheKey)) return inFlightRequests.get(cacheKey);
+
+  const request = (async () => {
+    try {
+      const response = await fetcher(url, { headers: { Accept: "application/json" } });
+      if (response.status === 429) {
+        const retryAfterSeconds = parseRetryAfter(response.headers?.get?.("Retry-After"), now());
+        cooldowns.set(cooldownKey, now() + retryAfterSeconds * 1000);
+        if (isUsableStale(cached, now(), staleIfErrorMs)) {
+          return { data: cached.data, cacheStatus: "stale-cache" };
+        }
+        throw new ForecastRateLimitError(retryAfterSeconds);
+      }
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      const data = await response.json();
+      const record = { savedAt: now(), data };
+      memoryCache.set(cacheKey, record);
+      if (persist && storage) writeStoredCache(storage, cacheKey, record);
+      return { data, cacheStatus: "network" };
+    } catch (error) {
+      if (isUsableStale(cached, now(), staleIfErrorMs)) {
+        return { data: cached.data, cacheStatus: "stale-cache" };
+      }
+      throw error;
+    } finally {
+      inFlightRequests.delete(cacheKey);
+    }
+  })();
+
+  inFlightRequests.set(cacheKey, request);
+  return request;
+}
+
+export function clearForecastCache() {
+  memoryCache.clear();
+  inFlightRequests.clear();
+  cooldowns.clear();
+}
+
+function readCache(cacheKey, storage) {
+  const memoryRecord = memoryCache.get(cacheKey);
+  if (memoryRecord) return memoryRecord;
+  if (!storage) return null;
+  try {
+    const record = JSON.parse(storage.getItem(`${STORAGE_PREFIX}${cacheKey}`));
+    if (!Number.isFinite(record?.savedAt) || !("data" in record)) return null;
+    memoryCache.set(cacheKey, record);
+    return record;
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredCache(storage, cacheKey, record) {
+  try {
+    storage.setItem(`${STORAGE_PREFIX}${cacheKey}`, JSON.stringify(record));
+  } catch {
+    // The in-memory cache still protects the current planner session.
+  }
+}
+
+function isUsableStale(record, currentTime, staleIfErrorMs) {
+  return Boolean(record && currentTime - record.savedAt <= staleIfErrorMs);
+}
+
+function parseRetryAfter(value, currentTime) {
+  const seconds = Number(value);
+  if (Number.isFinite(seconds) && seconds > 0) return Math.ceil(seconds);
+  const retryDate = Date.parse(value || "");
+  if (Number.isFinite(retryDate) && retryDate > currentTime) {
+    return Math.ceil((retryDate - currentTime) / 1000);
+  }
+  return 60;
+}
+
+function forecastOrigin(url) {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return url;
+  }
+}
+
+function defaultSessionStorage() {
+  try {
+    return globalThis.sessionStorage || null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/website/map-data.test.mjs
+++ b/apps/website/map-data.test.mjs
@@ -23,9 +23,12 @@ import {
   routeSamplePlan,
   sampleMarineAt,
   tideEventsFromResponse,
+  tideLevelAt,
   tideRequestUrl,
+  tideSeriesFromResponse,
 } from "./tide-current.mjs";
 import { sunChartRows, sunRequestUrl } from "./sun-times.mjs";
+import { clearForecastCache, fetchForecastJson } from "./forecast-cache.mjs";
 
 test("builds a bounded EMODnet request across England", () => {
   const request = createContourRequest(
@@ -296,9 +299,68 @@ test("derives model high and low water events for the tide table", () => {
     },
   };
   const events = tideEventsFromResponse(response, start, end);
+  const series = tideSeriesFromResponse(response, start, end);
   assert.deepEqual(events.map((event) => event.kind), ["high", "low"]);
   assert.equal(events[0].time, "2026-08-21T02:00:00.000Z");
   assert.equal(events[1].heightMsl, -2);
+  assert.equal(series.length, 9);
+  assert.equal(tideLevelAt(series, new Date("2026-08-21T01:30:00Z")), 1.5);
+});
+
+test("deduplicates and reuses forecast requests", async () => {
+  clearForecastCache();
+  let requests = 0;
+  const fetcher = async () => {
+    requests += 1;
+    await Promise.resolve();
+    return { ok: true, status: 200, json: async () => ({ value: 42 }) };
+  };
+  const options = { fetcher, now: () => 1_000, ttlMs: 60_000 };
+  const [first, second] = await Promise.all([
+    fetchForecastJson("https://example.test/forecast", options),
+    fetchForecastJson("https://example.test/forecast", options),
+  ]);
+  const cached = await fetchForecastJson("https://example.test/forecast", options);
+  assert.equal(requests, 1);
+  assert.deepEqual(first.data, { value: 42 });
+  assert.deepEqual(second.data, first.data);
+  assert.equal(cached.cacheStatus, "fresh-cache");
+});
+
+test("uses stale forecast data during a 429 cooldown", async () => {
+  clearForecastCache();
+  let currentTime = 1_000;
+  const url = "https://example.test/rate-limited";
+  await fetchForecastJson(url, {
+    now: () => currentTime,
+    fetcher: async () => ({ ok: true, status: 200, json: async () => ({ height: 1.2 }) }),
+    ttlMs: 10,
+  });
+  currentTime = 2_000;
+  let rateLimitedRequests = 0;
+  const options = {
+    now: () => currentTime,
+    ttlMs: 10,
+    staleIfErrorMs: 60_000,
+    fetcher: async () => {
+      rateLimitedRequests += 1;
+      return {
+        ok: false,
+        status: 429,
+        headers: { get: () => "90" },
+        json: async () => ({}),
+      };
+    },
+  };
+  const fallback = await fetchForecastJson(url, options);
+  const cooldownFallback = await fetchForecastJson(url, options);
+  await assert.rejects(
+    fetchForecastJson("https://example.test/another-forecast", options),
+    /forecast service rate limited/,
+  );
+  assert.equal(fallback.cacheStatus, "stale-cache");
+  assert.equal(cooldownFallback.cacheStatus, "stale-cache");
+  assert.equal(rateLimitedRequests, 1);
 });
 
 test("builds a daylight chart and flags arrival after sunset", () => {
@@ -358,7 +420,7 @@ test("adjusts each leg estimate using the current expected at its midpoint", () 
   assert.equal(estimate.legs[0].samples.length, 4);
 });
 
-test("plots repeated course-to-steer arrows and an uncorrected drift track", () => {
+test("plots repeated course-to-steer arrows without an ambiguous drift track", () => {
   const summary = {
     legs: [{
       index: 1,
@@ -385,7 +447,6 @@ test("plots repeated course-to-steer arrows and an uncorrected drift track", () 
     samplePlan,
   );
   assert.ok(estimate.legs[0].samples.every((sample) => sample.headingDegrees > 101));
-  assert.ok(estimate.driftCoordinates.at(-1)[1] > summary.legs[0].to.latitude);
   const geojson = routeCurrentGeoJson(estimate);
   assert.equal(
     geojson.features.filter((feature) => feature.properties.kind === "course-to-steer-arrow").length,
@@ -393,6 +454,6 @@ test("plots repeated course-to-steer arrows and an uncorrected drift track", () 
   );
   assert.equal(
     geojson.features.filter((feature) => feature.properties.kind === "drift-line").length,
-    1,
+    0,
   );
 });

--- a/apps/website/planner.css
+++ b/apps/website/planner.css
@@ -200,11 +200,6 @@ input:focus, select:focus, textarea:focus { border-color: var(--sea); box-shadow
 .current-key .current-blend { background: #486fc0; }
 .current-key .current-route { height: 4px; background: #8a4faf; }
 .current-key .current-cts { height: 4px; background: #f09a35; }
-.current-key .current-drift {
-  height: 2px;
-  border-radius: 0;
-  background: repeating-linear-gradient(90deg, #c54e8f 0 5px, transparent 5px 8px);
-}
 .current-key .ground-track {
   height: 2px;
   border-radius: 0;
@@ -345,6 +340,27 @@ button:disabled { cursor: not-allowed; opacity: 0.5; }
 .environment-heading { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; }
 .environment-heading > strong { font-size: 0.68rem; }
 .environment-heading > small { color: var(--muted); font-size: 0.56rem; text-align: right; }
+.tide-height-chart {
+  margin-top: 8px;
+  padding: 5px 6px 4px;
+  border: 1px solid #ccd9d7;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.72);
+}
+.tide-height-svg { display: block; width: 100%; height: auto; overflow: visible; }
+.tide-grid-line { stroke: #cad8d9; stroke-width: 1; }
+.tide-time-tick { stroke: var(--muted); stroke-width: 1; }
+.tide-axis-label { fill: var(--muted); font-size: 8px; }
+.tide-height-path {
+  fill: none;
+  stroke: var(--sea);
+  stroke-width: 2.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+.tide-selected-line { stroke: var(--coral); stroke-width: 1.5; stroke-dasharray: 3 3; }
+.tide-selected-point { fill: var(--coral); stroke: #fffdf7; stroke-width: 1.5; }
+.tide-chart-caption { margin: -2px 3px 2px; color: var(--muted); font-size: 0.58rem; text-align: center; }
 .tide-table { margin-top: 8px; display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 5px; }
 .tide-event {
   padding: 7px 5px;
@@ -472,6 +488,9 @@ button:disabled { cursor: not-allowed; opacity: 0.5; }
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.34);
 }
 :root[data-theme="dark"] .tide-event { border-color: #3a5359; background: rgba(16, 33, 38, 0.82); }
+:root[data-theme="dark"] .tide-height-chart { border-color: #3a5359; background: rgba(16, 33, 38, 0.82); }
+:root[data-theme="dark"] .tide-grid-line { stroke: #314950; }
+:root[data-theme="dark"] .tide-selected-point { stroke: #102126; }
 :root[data-theme="dark"] .sun-track { background: #17243d; }
 :root[data-theme="dark"] .map-provenance strong { color: #ff9b7d; }
 :root[data-theme="dark"] .maplibregl-popup-content,

--- a/apps/website/planner.html
+++ b/apps/website/planner.html
@@ -17,7 +17,7 @@
       integrity="sha384-uTttxo/aOKbdE5RlD/SPzSDoDmNvGlUYPjONi2MN/b7c9HPSvW07OIuyP7uL6jxK"
       crossorigin="anonymous"
     />
-    <link rel="stylesheet" href="/planner.css?v=20260821-6" />
+    <link rel="stylesheet" href="/planner.css?v=20260821-7" />
     <script src="/theme.js?v=20260821-6" defer></script>
   </head>
   <body class="planner-page">
@@ -180,7 +180,6 @@
               <span><i class="current-blend"></i>Blended time</span>
               <span><i class="current-route"></i>Expected route time</span>
               <span><i class="current-cts"></i>Course to steer</span>
-              <span><i class="current-drift"></i>Uncorrected drift if CTS is ignored</span>
               <span><i class="ground-track"></i>Desired ground track</span>
               <span>Arrows point with the flow</span>
             </div>
@@ -238,7 +237,7 @@
             <thead><tr><th>Leg</th><th>Course</th><th>Distance</th><th>Model current</th><th>ETA</th></tr></thead>
             <tbody id="leg-table"></tbody>
           </table>
-          <p>The coral dashed line is the desired ground track. Amber arrows show the modelled course to steer to stay on it. The labelled magenta dashed line is the drift track if that correction is ignored. Current samples are taken about every 2.5 NM. These are planning estimates, not helm instructions.</p>
+          <p>The coral dashed line is the desired ground track. Amber arrows show the modelled course to steer to stay on it. Current samples are taken about every 2.5 NM. These are planning estimates, not helm instructions.</p>
         </div>
 
         <section class="planner-actions" aria-label="Passage actions">
@@ -266,6 +265,7 @@
               <strong id="tide-table-title">Model tide near departure</strong>
               <small id="tide-table-status">Loading…</small>
             </div>
+            <div class="tide-height-chart" id="tide-height-chart" aria-live="polite"></div>
             <div class="tide-table" id="tide-table" aria-live="polite"></div>
           </section>
           <section aria-labelledby="sun-chart-title">
@@ -290,6 +290,6 @@
       integrity="sha384-5+cfbwT0iiub6VsQAdn6yz16nr6sDiQoHx6tm4O8OVYXHYOxcffFmCJBL0dgdvGp"
       crossorigin="anonymous"
     ></script>
-    <script type="module" src="/planner.js?v=20260821-6"></script>
+    <script type="module" src="/planner.js?v=20260821-7"></script>
   </body>
 </html>

--- a/apps/website/planner.js
+++ b/apps/website/planner.js
@@ -34,9 +34,12 @@ import {
   routeCurrentGeoJson,
   sampleMarineAt,
   tideEventsFromResponse,
+  tideLevelAt,
   tideRequestUrl,
+  tideSeriesFromResponse,
 } from "./tide-current.mjs";
 import { sunChartRows, sunRequestUrl } from "./sun-times.mjs";
+import { fetchForecastJson } from "./forecast-cache.mjs";
 
 const MAP_STYLE_URLS = {
   light: "https://tiles.openfreemap.org/styles/liberty",
@@ -112,6 +115,7 @@ const elements = {
   startTime: document.querySelector("#start-time"),
   stillWaterDuration: document.querySelector("#still-water-duration"),
   tideDepthStatus: document.querySelector("#tide-depth-status"),
+  tideHeightChart: document.querySelector("#tide-height-chart"),
   tideTable: document.querySelector("#tide-table"),
   tideTableStatus: document.querySelector("#tide-table-status"),
   timeSlider: document.querySelector("#time-slider"),
@@ -135,20 +139,15 @@ let shallowContourData = EMPTY_FEATURE_COLLECTION;
 let shallowContourBounds = null;
 let shallowContourProvider = null;
 let shallowContourAbortController = null;
-let windAbortController = null;
 let windRequestSequence = 0;
-let currentFieldAbortController = null;
 let currentFieldRequestSequence = 0;
-let routeCurrentAbortController = null;
 let routeCurrentRequestSequence = 0;
 let routeCurrentEstimate = null;
 let currentDepthAdjustment = null;
 let marineDepthContext = null;
 let marineRefreshTimer = null;
 let marineRefreshPending = { field: false, route: false };
-let tideTableAbortController = null;
 let tideTableRequestSequence = 0;
-let sunAbortController = null;
 let sunRequestSequence = 0;
 let environmentRefreshTimer = null;
 
@@ -526,42 +525,6 @@ map.on("style.load", async () => {
 
   map.addSource("route-current", { type: "geojson", data: routeCurrentGeoJson(routeCurrentEstimate) });
   map.addLayer({
-    id: "route-drift-line",
-    type: "line",
-    source: "route-current",
-    filter: ["==", ["get", "kind"], "drift-line"],
-    minzoom: 4,
-    layout: {
-      visibility: elements.currentVisible.checked ? "visible" : "none",
-      "line-cap": "round",
-      "line-join": "round",
-    },
-    paint: {
-      "line-color": "#a82082",
-      "line-width": 2.8,
-      "line-dasharray": [1.5, 1.5],
-      "line-opacity": 0.9,
-    },
-  });
-  map.addLayer({
-    id: "route-drift-label",
-    type: "symbol",
-    source: "route-current",
-    filter: ["==", ["get", "kind"], "drift-label"],
-    minzoom: 5,
-    layout: {
-      visibility: elements.currentVisible.checked ? "visible" : "none",
-      "text-field": ["get", "label"],
-      "text-size": 10,
-      "text-offset": [0, -1],
-    },
-    paint: {
-      "text-color": currentTheme() === "dark" ? "#ffb6e4" : "#7d145f",
-      "text-halo-color": currentTheme() === "dark" ? "#0b1c22" : "#fffdf7",
-      "text-halo-width": 1.7,
-    },
-  });
-  map.addLayer({
     id: "route-current-arrows",
     type: "line",
     source: "route-current",
@@ -690,8 +653,6 @@ for (const layerId of [
   "wind-field-labels",
   "current-field-arrows",
   "current-field-labels",
-  "route-drift-line",
-  "route-drift-label",
   "route-current-arrows",
   "route-current-labels",
 ]) {
@@ -765,7 +726,7 @@ elements.windVisible.addEventListener("change", () => {
   if (elements.windVisible.checked) {
     updateWindField();
   } else {
-    windAbortController?.abort();
+    windRequestSequence += 1;
     elements.windStatus.textContent = "Wind field hidden. Turn it on to load model wind.";
   }
   scheduleDraftSave();
@@ -775,8 +736,8 @@ elements.currentVisible.addEventListener("change", () => {
   if (elements.currentVisible.checked) {
     scheduleMarineRefresh({ field: true, route: true }, 0);
   } else {
-    currentFieldAbortController?.abort();
-    routeCurrentAbortController?.abort();
+    currentFieldRequestSequence += 1;
+    routeCurrentRequestSequence += 1;
     elements.currentStatus.textContent = "Current field hidden.";
   }
   scheduleDraftSave();
@@ -800,8 +761,6 @@ function syncChartContextLayers() {
   setLayerVisibility("noaa-charts-layer", elements.noaaVisible.checked);
   setLayerVisibility("current-field-arrows", elements.currentVisible.checked);
   setLayerVisibility("current-field-labels", elements.currentVisible.checked);
-  setLayerVisibility("route-drift-line", elements.currentVisible.checked);
-  setLayerVisibility("route-drift-label", elements.currentVisible.checked);
   setLayerVisibility("route-current-arrows", elements.currentVisible.checked);
   setLayerVisibility("route-current-labels", elements.currentVisible.checked);
 }
@@ -1232,8 +1191,6 @@ async function importGpx() {
 
 async function updateWindField() {
   if (!mapReady || !elements.windVisible.checked) return;
-  windAbortController?.abort();
-  windAbortController = new AbortController();
   const requestSequence = ++windRequestSequence;
   const bounds = visibleMapBounds();
   const canvas = map.getCanvas();
@@ -1245,12 +1202,10 @@ async function updateWindField() {
   const rangeEnd = new Date(Math.max(...requestedTimes.map((date) => date.getTime())) + 3_600_000);
   elements.windStatus.textContent = "Loading zoom-adaptive wind at current and expected passage times…";
   try {
-    const response = await fetch(windRequestUrl(points, rangeStart, rangeEnd), {
-      headers: { Accept: "application/json" },
-      signal: windAbortController.signal,
+    const { data } = await fetchForecastJson(windRequestUrl(points, rangeStart, rangeEnd), {
+      ttlMs: 10 * 60 * 1000,
+      staleIfErrorMs: 60 * 60 * 1000,
     });
-    if (!response.ok) throw new Error(`HTTP ${response.status}`);
-    const data = await response.json();
     if (requestSequence !== windRequestSequence) return;
     const field = windFieldGeoJson(
       points,
@@ -1265,7 +1220,6 @@ async function updateWindField() {
     const routeTimed = timings.filter((timing) => timing.forecastWeight > 0.01).length;
     elements.windStatus.textContent = `${points.length} samples on a ${dimensions.columns}×${dimensions.rows} zoom-adaptive grid · ${routeTimed} near-route samples blend to their expected passage time and carry a purple halo. Labels show knots and UTC sample time; arrows point downwind.`;
   } catch (error) {
-    if (error.name === "AbortError") return;
     elements.windStatus.textContent = `Wind forecast unavailable (${error.message}).`;
   }
 }
@@ -1296,8 +1250,6 @@ async function updateCurrentField() {
     elements.currentStatus.textContent = "Choose a valid passage start time to load currents.";
     return;
   }
-  currentFieldAbortController?.abort();
-  currentFieldAbortController = new AbortController();
   const requestSequence = ++currentFieldRequestSequence;
   const bounds = visibleMapBounds();
   const canvas = map.getCanvas();
@@ -1315,15 +1267,10 @@ async function updateCurrentField() {
   const rangeEnd = new Date(Math.max(...requestedTimes.map((date) => date.getTime())) + 3_600_000);
   elements.currentStatus.textContent = "Loading the adaptive current field and route-time forecast…";
   try {
-    const response = await fetch(
-      marineRequestUrl(points, rangeStart, rangeEnd),
-      {
-        headers: { Accept: "application/json" },
-        signal: currentFieldAbortController.signal,
-      },
-    );
-    if (!response.ok) throw new Error(`HTTP ${response.status}`);
-    const data = await response.json();
+    const { data } = await fetchForecastJson(marineRequestUrl(points, rangeStart, rangeEnd), {
+      ttlMs: 10 * 60 * 1000,
+      staleIfErrorMs: 60 * 60 * 1000,
+    });
     if (requestSequence !== currentFieldRequestSequence) return;
     const field = currentFieldGeoJson(
       points,
@@ -1354,7 +1301,6 @@ async function updateCurrentField() {
     const omitted = candidates.length - points.length;
     elements.currentStatus.textContent = `${waterSamples.length} distinct model sea cells on a ${dimensions.columns}×${dimensions.rows} zoom-adaptive grid; ${omitted} land grid positions omitted · teal is current time; ${routeTimed} cells blend through blue to purple at the nearest expected route time within 8 NM. Arrows point with the flow; labels show knots.`;
   } catch (error) {
-    if (error.name === "AbortError") return;
     map.getSource("current-field")?.setData(EMPTY_FEATURE_COLLECTION);
     marineDepthContext = null;
     currentDepthAdjustment = null;
@@ -1381,8 +1327,6 @@ async function updateRouteCurrentEstimate() {
     return;
   }
 
-  routeCurrentAbortController?.abort();
-  routeCurrentAbortController = new AbortController();
   const requestSequence = ++routeCurrentRequestSequence;
   const samplePlan = routeSamplePlan(summary);
   const points = samplePlan.map((sample) => sample.point);
@@ -1392,15 +1336,13 @@ async function updateRouteCurrentEstimate() {
   );
   elements.stillWaterDuration.textContent = "Loading currents expected along the passage…";
   try {
-    const response = await fetch(
+    const { data } = await fetchForecastJson(
       marineRequestUrl(points, start, new Date(start.getTime() + rangeSeconds * 1000)),
       {
-        headers: { Accept: "application/json" },
-        signal: routeCurrentAbortController.signal,
+        ttlMs: 10 * 60 * 1000,
+        staleIfErrorMs: 60 * 60 * 1000,
       },
     );
-    if (!response.ok) throw new Error(`HTTP ${response.status}`);
-    const data = await response.json();
     if (requestSequence !== routeCurrentRequestSequence) return;
     routeCurrentEstimate = estimatePassageWithCurrents(
       summary,
@@ -1420,7 +1362,6 @@ async function updateRouteCurrentEstimate() {
       elements.stillWaterDuration.textContent = "Some leg currents were unavailable; showing still-water passage time.";
     }
   } catch (error) {
-    if (error.name === "AbortError") return;
     routeCurrentEstimate = null;
     map.getSource("route-current")?.setData(EMPTY_FEATURE_COLLECTION);
     renderSummary();
@@ -1485,31 +1426,106 @@ async function updateTideTable() {
   const start = selectedStartTime();
   if (!start) return;
   const point = environmentPoint("departure");
-  tideTableAbortController?.abort();
-  tideTableAbortController = new AbortController();
   const requestSequence = ++tideTableRequestSequence;
   elements.tideTableStatus.textContent = stops.length > 0 ? "near waypoint 1" : "at map centre";
   try {
-    const rangeStart = new Date(start.getTime() - 12 * 60 * 60 * 1000);
-    const rangeEnd = new Date(start.getTime() + 36 * 60 * 60 * 1000);
-    const response = await fetch(tideRequestUrl(point, rangeStart, rangeEnd), {
-      headers: { Accept: "application/json" },
-      signal: tideTableAbortController.signal,
+    const dayStart = new Date(Date.UTC(
+      start.getUTCFullYear(),
+      start.getUTCMonth(),
+      start.getUTCDate(),
+    ));
+    const rangeStart = new Date(dayStart.getTime() - 12 * 60 * 60 * 1000);
+    const rangeEnd = new Date(dayStart.getTime() + 60 * 60 * 60 * 1000);
+    const { data, cacheStatus } = await fetchForecastJson(tideRequestUrl(point, rangeStart, rangeEnd), {
+      ttlMs: 15 * 60 * 1000,
+      staleIfErrorMs: 24 * 60 * 60 * 1000,
+      persist: true,
     });
-    if (!response.ok) throw new Error(`HTTP ${response.status}`);
-    const data = await response.json();
     if (requestSequence !== tideTableRequestSequence) return;
     const events = tideEventsFromResponse(data, rangeStart, rangeEnd);
+    const chartStart = new Date(start.getTime() - 6 * 60 * 60 * 1000);
+    const chartEnd = new Date(start.getTime() + 30 * 60 * 60 * 1000);
+    const series = tideSeriesFromResponse(data, chartStart, chartEnd);
     const datum = depthAdjustmentFor({ provider: "emodnet", point, seaLevelMsl: 0 });
+    renderTideHeightChart(series, start, datum);
     renderTideTable(events, start, datum);
     elements.tideTableStatus.textContent = datum
-      ? `${datum.chartDatum} via ${datum.stationName} · device time`
-      : "MSL · device time";
+      ? `${datum.chartDatum} via ${datum.stationName} · device time${forecastCacheSuffix(cacheStatus)}`
+      : `MSL · device time${forecastCacheSuffix(cacheStatus)}`;
   } catch (error) {
-    if (error.name === "AbortError") return;
+    elements.tideHeightChart.replaceChildren(environmentEmpty("Model tide-height chart unavailable."));
     elements.tideTable.replaceChildren(environmentEmpty("Model tide table unavailable."));
     elements.tideTableStatus.textContent = error.message;
   }
+}
+
+function renderTideHeightChart(series, start, datum) {
+  elements.tideHeightChart.replaceChildren();
+  if (series.length < 2) {
+    elements.tideHeightChart.append(environmentEmpty("No tide-height series was resolved in this model window."));
+    return;
+  }
+  const offset = datum?.heightM || 0;
+  const samples = series.map((sample) => ({
+    time: Date.parse(sample.time),
+    height: sample.heightMsl + offset,
+  }));
+  const firstTime = samples[0].time;
+  const lastTime = samples.at(-1).time;
+  const heights = samples.map((sample) => sample.height);
+  const minimum = Math.min(...heights);
+  const maximum = Math.max(...heights);
+  const heightSpan = Math.max(0.2, maximum - minimum);
+  const chartMinimum = minimum - heightSpan * 0.08;
+  const chartMaximum = maximum + heightSpan * 0.08;
+  const width = 420;
+  const height = 126;
+  const plot = { left: 38, right: 10, top: 10, bottom: 25 };
+  const x = (time) => plot.left + ((time - firstTime) / (lastTime - firstTime)) *
+    (width - plot.left - plot.right);
+  const y = (value) => plot.top + ((chartMaximum - value) / (chartMaximum - chartMinimum)) *
+    (height - plot.top - plot.bottom);
+  const svg = svgNode("svg", {
+    class: "tide-height-svg",
+    viewBox: `0 0 ${width} ${height}`,
+    "aria-hidden": "true",
+  });
+
+  for (const value of [minimum, (minimum + maximum) / 2, maximum]) {
+    svg.append(
+      svgNode("line", { class: "tide-grid-line", x1: plot.left, x2: width - plot.right, y1: y(value), y2: y(value) }),
+      svgNode("text", { class: "tide-axis-label", x: plot.left - 5, y: y(value) + 3, "text-anchor": "end" }, value.toFixed(1)),
+    );
+  }
+  for (let index = 0; index < 4; index += 1) {
+    const time = firstTime + ((lastTime - firstTime) * index) / 3;
+    svg.append(
+      svgNode("line", { class: "tide-time-tick", x1: x(time), x2: x(time), y1: height - plot.bottom, y2: height - plot.bottom + 4 }),
+      svgNode("text", { class: "tide-axis-label", x: x(time), y: height - 7, "text-anchor": "middle" }, formatShortChartTime(new Date(time))),
+    );
+  }
+  const path = samples.map((sample, index) =>
+    `${index === 0 ? "M" : "L"}${x(sample.time).toFixed(1)},${y(sample.height).toFixed(1)}`
+  ).join(" ");
+  svg.append(svgNode("path", { class: "tide-height-path", d: path }));
+
+  const selectedHeightMsl = tideLevelAt(series, start);
+  if (selectedHeightMsl !== null && start.getTime() >= firstTime && start.getTime() <= lastTime) {
+    const selectedHeight = selectedHeightMsl + offset;
+    svg.append(
+      svgNode("line", { class: "tide-selected-line", x1: x(start), x2: x(start), y1: plot.top, y2: height - plot.bottom }),
+      svgNode("circle", { class: "tide-selected-point", cx: x(start), cy: y(selectedHeight), r: 4 }),
+    );
+  }
+
+  const caption = document.createElement("div");
+  caption.className = "tide-chart-caption";
+  const selectedHeight = tideLevelAt(series, start);
+  caption.textContent = selectedHeight === null
+    ? `Hourly model water height · m ${datum?.chartDatum || "MSL"}`
+    : `Passage start ${formatPassageTime(start)} · ${(selectedHeight + offset).toFixed(2)} m ${datum?.chartDatum || "MSL"}`;
+  elements.tideHeightChart.setAttribute("aria-label", caption.textContent);
+  elements.tideHeightChart.append(svg, caption);
 }
 
 function renderTideTable(events, start, datum) {
@@ -1519,10 +1535,11 @@ function renderTideTable(events, start, datum) {
     return;
   }
   const nextIndex = events.findIndex((event) => new Date(event.time) >= start);
-  events.slice(0, 8).forEach((event, index) => {
+  const firstVisibleIndex = Math.max(0, nextIndex - 2);
+  events.slice(firstVisibleIndex, firstVisibleIndex + 8).forEach((event, index) => {
     const date = new Date(event.time);
     const card = document.createElement("div");
-    card.className = `tide-event${index === nextIndex ? " next" : ""}`;
+    card.className = `tide-event${firstVisibleIndex + index === nextIndex ? " next" : ""}`;
     const kind = document.createElement("b");
     kind.textContent = event.kind === "high" ? "High" : "Low";
     const time = document.createElement("time");
@@ -1548,24 +1565,20 @@ async function updateSunChart() {
   const arrival = stops.length > 1 && Number.isFinite(duration)
     ? new Date(start.getTime() + duration * 1000)
     : null;
-  sunAbortController?.abort();
-  sunAbortController = new AbortController();
   const requestSequence = ++sunRequestSequence;
   elements.mapEnvironmentTime.textContent = formatPassageTime(start);
   elements.sunChartStatus.textContent = stops.length > 1 ? "at final waypoint" : "at map centre";
   try {
-    const response = await fetch(sunRequestUrl(point), {
-      headers: { Accept: "application/json" },
-      signal: sunAbortController.signal,
+    const { data, cacheStatus } = await fetchForecastJson(sunRequestUrl(point), {
+      ttlMs: 12 * 60 * 60 * 1000,
+      staleIfErrorMs: 7 * 24 * 60 * 60 * 1000,
+      persist: true,
     });
-    if (!response.ok) throw new Error(`HTTP ${response.status}`);
-    const data = await response.json();
     if (requestSequence !== sunRequestSequence) return;
     const chart = sunChartRows(data, start, arrival);
     renderSunChart(chart);
-    elements.sunChartStatus.textContent = `${stops.length > 1 ? "final waypoint" : "map centre"} · ${chart.timezoneAbbreviation}`;
+    elements.sunChartStatus.textContent = `${stops.length > 1 ? "final waypoint" : "map centre"} · ${chart.timezoneAbbreviation}${forecastCacheSuffix(cacheStatus)}`;
   } catch (error) {
-    if (error.name === "AbortError") return;
     elements.sunChart.replaceChildren(environmentEmpty("Sunrise and sunset unavailable."));
     elements.sunChartStatus.textContent = error.message;
   }
@@ -1634,6 +1647,27 @@ function environmentPoint(kind) {
   return { longitude: centre.lng, latitude: centre.lat };
 }
 
+function forecastCacheSuffix(cacheStatus) {
+  if (cacheStatus === "stale-cache") return " · cached fallback";
+  if (cacheStatus === "fresh-cache") return " · cached";
+  return "";
+}
+
+function formatShortChartTime(date) {
+  return date.toLocaleTimeString("en-GB", {
+    weekday: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function svgNode(name, attributes, textContent = null) {
+  const node = document.createElementNS("http://www.w3.org/2000/svg", name);
+  for (const [attribute, value] of Object.entries(attributes)) node.setAttribute(attribute, value);
+  if (textContent !== null) node.textContent = textContent;
+  return node;
+}
+
 function environmentEmpty(message) {
   const empty = document.createElement("p");
   empty.className = "environment-empty";
@@ -1642,7 +1676,6 @@ function environmentEmpty(message) {
 }
 
 function invalidateRouteCurrentEstimate() {
-  routeCurrentAbortController?.abort();
   routeCurrentRequestSequence += 1;
   routeCurrentEstimate = null;
   map.getSource("route-current")?.setData(EMPTY_FEATURE_COLLECTION);

--- a/apps/website/tide-current.mjs
+++ b/apps/website/tide-current.mjs
@@ -92,16 +92,46 @@ export function tideRequestUrl(point, start, end) {
   return `${MARINE_API_URL}?${parameters}`;
 }
 
-export function tideEventsFromResponse(response, start, end) {
+export function tideSeriesFromResponse(response, start, end) {
   const rangeStart = validDate(start).getTime();
   const rangeEnd = validDate(end).getTime();
   const hourly = response?.hourly;
-  const times = Array.isArray(hourly?.time)
-    ? hourly.time.map((value) => Date.parse(`${value}Z`))
-    : [];
+  const times = Array.isArray(hourly?.time) ? hourly.time : [];
   const levels = Array.isArray(hourly?.sea_level_height_msl)
-    ? hourly.sea_level_height_msl.map(Number)
+    ? hourly.sea_level_height_msl
     : [];
+  return times.slice(0, levels.length).flatMap((value, index) => {
+    const time = Date.parse(`${value}Z`);
+    const heightMsl = Number(levels[index]);
+    return Number.isFinite(time) && Number.isFinite(heightMsl) &&
+      time >= rangeStart && time <= rangeEnd
+      ? [{ time: new Date(time).toISOString(), heightMsl }]
+      : [];
+  });
+}
+
+export function tideLevelAt(series, at) {
+  const target = validDate(at).getTime();
+  if (!Array.isArray(series) || series.length === 0) return null;
+  const samples = series
+    .map((sample) => ({ time: Date.parse(sample.time), heightMsl: Number(sample.heightMsl) }))
+    .filter((sample) => Number.isFinite(sample.time) && Number.isFinite(sample.heightMsl))
+    .sort((first, second) => first.time - second.time);
+  if (samples.length === 0 || target < samples[0].time || target > samples.at(-1).time) return null;
+  const upper = samples.findIndex((sample) => sample.time >= target);
+  if (upper <= 0) return samples[0].heightMsl;
+  const first = samples[upper - 1];
+  const second = samples[upper];
+  const fraction = (target - first.time) / Math.max(1, second.time - first.time);
+  return first.heightMsl + (second.heightMsl - first.heightMsl) * fraction;
+}
+
+export function tideEventsFromResponse(response, start, end) {
+  const series = tideSeriesFromResponse(response, start, end);
+  const rangeStart = validDate(start).getTime();
+  const rangeEnd = validDate(end).getTime();
+  const times = series.map((sample) => Date.parse(sample.time));
+  const levels = series.map((sample) => sample.heightMsl);
   const weights = [1, 2, 3, 2, 1];
   const smoothed = levels.map((_, index) => {
     let total = 0;
@@ -333,12 +363,6 @@ export function estimatePassageWithCurrents(
   const legs = [];
   let elapsedSeconds = 0;
   let complete = true;
-  let driftPosition = summary.legs[0]?.from
-    ? { longitude: summary.legs[0].from.longitude, latitude: summary.legs[0].from.latitude }
-    : null;
-  const driftCoordinates = driftPosition
-    ? [[driftPosition.longitude, driftPosition.latitude]]
-    : [];
 
   summary.legs.forEach((leg) => {
     const legStartSeconds = elapsedSeconds;
@@ -384,21 +408,6 @@ export function estimatePassageWithCurrents(
           weightedSeaLevel += sample.seaLevelMsl * usedDuration;
           seaLevelWeight += usedDuration;
         }
-      }
-      if (sample && driftPosition) {
-        const delta = ((sample.directionTowards - leg.bearingDegrees) * Math.PI) / 180;
-        const alongSpeed = speed + sample.speedKnots * Math.cos(delta);
-        const driftHours = planned.distanceMetres / METRES_PER_NAUTICAL_MILE /
-          Math.max(0.1, alongSpeed);
-        driftPosition = displaceByVelocity(
-          driftPosition,
-          speed,
-          leg.bearingDegrees,
-          sample.speedKnots,
-          sample.directionTowards,
-          driftHours,
-        );
-        driftCoordinates.push([driftPosition.longitude, driftPosition.latitude]);
       }
       samples.push({
         ...planned,
@@ -449,36 +458,12 @@ export function estimatePassageWithCurrents(
     arrivalTime: new Date(startDate.getTime() + elapsedSeconds * 1000).toISOString(),
     durationSeconds: complete ? elapsedSeconds : null,
     legs,
-    driftCoordinates,
   };
 }
 
 export function routeCurrentGeoJson(estimate, arrowLength = 0.012) {
   if (!estimate?.legs) return { type: "FeatureCollection", features: [] };
   const features = [];
-  if (estimate.driftCoordinates?.length > 1) {
-    features.push({
-      type: "Feature",
-      properties: {
-        kind: "drift-line",
-        timing: "expected-route",
-        warning: "Modelled track if each planned ground-track bearing is held without correcting for current.",
-      },
-      geometry: { type: "LineString", coordinates: estimate.driftCoordinates },
-    });
-    features.push({
-      type: "Feature",
-      properties: {
-        kind: "drift-label",
-        label: "UNCORRECTED DRIFT",
-        timing: "expected-route",
-      },
-      geometry: {
-        type: "Point",
-        coordinates: estimate.driftCoordinates[Math.floor(estimate.driftCoordinates.length / 2)],
-      },
-    });
-  }
   estimate.legs.forEach((leg) => {
     leg.samples?.forEach((sample) => {
       if (!Number.isFinite(sample.headingDegrees)) return;
@@ -646,29 +631,6 @@ function nearestPointOnLeg(point, leg) {
     : 0;
   const nearest = interpolateCoordinate(leg.from, leg.to, fraction);
   return { leg, fraction, distanceNm: distanceKilometres(point, nearest) / 1.852 };
-}
-
-function displaceByVelocity(
-  point,
-  boatSpeedKnots,
-  boatBearingDegrees,
-  currentSpeedKnots,
-  currentBearingDegrees,
-  durationHours,
-) {
-  const boatRadians = (boatBearingDegrees * Math.PI) / 180;
-  const currentRadians = (currentBearingDegrees * Math.PI) / 180;
-  const eastNm =
-    (boatSpeedKnots * Math.sin(boatRadians) + currentSpeedKnots * Math.sin(currentRadians)) *
-    durationHours;
-  const northNm =
-    (boatSpeedKnots * Math.cos(boatRadians) + currentSpeedKnots * Math.cos(currentRadians)) *
-    durationHours;
-  return {
-    longitude: Number(point.longitude) + eastNm /
-      (60 * Math.max(0.2, Math.cos((Number(point.latitude) * Math.PI) / 180))),
-    latitude: Number(point.latitude) + northNm / 60,
-  };
 }
 
 function interpolateNullable(first, second, fraction) {


### PR DESCRIPTION
## Summary
- deduplicate and cache Open-Meteo wind, current, tide, and sun requests
- honour HTTP 429 cooldowns and reuse recent cached data when the provider is unavailable
- add a tide-height curve with passage-start height plus nearby high/low-water times
- remove the ambiguous uncorrected-drift track while retaining course-to-steer arrows

## Verification
- node syntax checks for planner forecast modules
- 24 website unit tests
- local browser QA in light and dark modes