### PR TITLE
fix: improve coastal depth contour continuity

### DIFF
--- a/apps/website/emodnet-contours.mjs
+++ b/apps/website/emodnet-contours.mjs
@@ -11,6 +11,8 @@ const GEBCO_DAP_URL =
   "https://dap.ceda.ac.uk/thredds/dodsC/bodc/gebco/global/gebco_2026/ice_surface_elevation/netcdf/GEBCO_2026.nc";
 const NATIVE_STEP_DEGREES = 1 / 960;
 const GEBCO_CELLS_PER_DEGREE = 240;
+const MAX_GRID_WIDTH = 512;
+const MAX_GRID_HEIGHT = 384;
 const NUMBER_PATTERN = /[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[Ee][-+]?\d+)?/g;
 
 export function createContourRequest(bounds, zoom) {
@@ -27,7 +29,7 @@ export function createContourRequest(bounds, zoom) {
 
   const nativeWidth = Math.max(2, Math.ceil((requested.east - requested.west) / NATIVE_STEP_DEGREES));
   const nativeHeight = Math.max(2, Math.ceil((requested.north - requested.south) / NATIVE_STEP_DEGREES));
-  const scale = Math.min(1, 320 / nativeWidth, 240 / nativeHeight);
+  const scale = Math.min(1, MAX_GRID_WIDTH / nativeWidth, MAX_GRID_HEIGHT / nativeHeight);
   const gridWidth = Math.max(2, Math.floor(nativeWidth * scale));
   const gridHeight = Math.max(2, Math.floor(nativeHeight * scale));
   const parameters = new URLSearchParams({
@@ -87,7 +89,11 @@ export function createGebcoContourRequest(bounds, zoom) {
   );
   const longitudeCount = longitudeEnd - longitudeStart + 1;
   const latitudeCount = latitudeEnd - latitudeStart + 1;
-  const stride = Math.max(1, Math.ceil(longitudeCount / 320), Math.ceil(latitudeCount / 240));
+  const stride = Math.max(
+    1,
+    Math.ceil(longitudeCount / MAX_GRID_WIDTH),
+    Math.ceil(latitudeCount / MAX_GRID_HEIGHT),
+  );
   const longitudeSamples = Math.floor((longitudeEnd - longitudeStart) / stride) + 1;
   const latitudeSamples = Math.floor((latitudeEnd - latitudeStart) / stride) + 1;
   const query =
@@ -114,7 +120,9 @@ export function boundsContain(outer, inner) {
 }
 
 export function parseEmodnetGrid(text) {
-  const range = text.match(/Grid range: GridEnvelope2D\[0\.\.(\d+), 0\.\.(\d+)\]/);
+  const range = text.match(
+    /Grid range: GridEnvelope2D\[(-?\d+)\.\.(-?\d+), (-?\d+)\.\.(-?\d+)\]/,
+  );
   const transform = Object.fromEntries(
     [...text.matchAll(/PARAMETER\["elt_(0_0|0_2|1_1|1_2)",\s*([-+0-9.eE]+)\]/g)].map(
       (match) => [match[1], Number(match[2])],
@@ -125,8 +133,12 @@ export function parseEmodnetGrid(text) {
   if (!range || Object.keys(transform).length !== 4 || markerIndex < 0) {
     throw new Error("The depth service returned an unrecognised grid.");
   }
-  const width = Number(range[1]) + 1;
-  const height = Number(range[2]) + 1;
+  const columnStart = Number(range[1]);
+  const columnEnd = Number(range[2]);
+  const rowStart = Number(range[3]);
+  const rowEnd = Number(range[4]);
+  const width = columnEnd - columnStart + 1;
+  const height = rowEnd - rowStart + 1;
   const values = (text.slice(markerIndex + marker.length).match(NUMBER_PATTERN) || []).map(Number);
   if (values.length !== width * height || values.some((value) => !Number.isFinite(value))) {
     throw new Error("The depth service returned an incomplete grid.");
@@ -138,9 +150,9 @@ export function parseEmodnetGrid(text) {
     rows,
     transform: {
       longitudeStep: transform["0_0"],
-      longitudeOrigin: transform["0_2"],
+      longitudeOrigin: transform["0_2"] + columnStart * transform["0_0"],
       latitudeStep: transform["1_1"],
-      latitudeOrigin: transform["1_2"],
+      latitudeOrigin: transform["1_2"] + rowStart * transform["1_1"],
     },
   };
 }
@@ -199,7 +211,7 @@ function edgePoint(row, column, edge, corners, level) {
   return [row + interpolate(topLeft, bottomLeft, level), column];
 }
 
-function contourSegments(grid, level, wetGrid = null) {
+function contourSegments(grid, level) {
   const cases = {
     1: [[3, 0]],
     2: [[0, 1]],
@@ -217,14 +229,6 @@ function contourSegments(grid, level, wetGrid = null) {
   const segments = [];
   for (let row = 0; row < grid.length - 1; row += 1) {
     for (let column = 0; column < grid[0].length - 1; column += 1) {
-      if (wetGrid && ![
-        wetGrid[row][column],
-        wetGrid[row][column + 1],
-        wetGrid[row + 1][column + 1],
-        wetGrid[row + 1][column],
-      ].every(Boolean)) {
-        continue;
-      }
       const corners = [
         grid[row][column],
         grid[row][column + 1],
@@ -313,10 +317,9 @@ export function deriveShallowContours(
   } = {},
 ) {
   const depthGrid = parsed.rows.map((row) => row.map((elevation) => -elevation));
-  const wetGrid = parsed.rows.map((row) => row.map((elevation) => elevation < 0));
   const features = [];
   for (const level of levels) {
-    const lines = stitchSegments(contourSegments(depthGrid, level, wetGrid));
+    const lines = stitchSegments(contourSegments(depthGrid, level));
     lines.forEach((line, index) => {
       if (line.length < 3) return;
       const coordinates = line.map(([row, column]) => [
@@ -339,4 +342,107 @@ export function deriveShallowContours(
     });
   }
   return { type: "FeatureCollection", features };
+}
+
+function coordinateInsideBounds([longitude, latitude], bounds) {
+  return Boolean(
+    bounds &&
+      longitude >= bounds.west &&
+      longitude <= bounds.east &&
+      latitude >= bounds.south &&
+      latitude <= bounds.north,
+  );
+}
+
+function sameCoordinate(first, second) {
+  return first[0] === second[0] && first[1] === second[1];
+}
+
+function pointOnSegment([longitude, latitude], first, second) {
+  const cross = (latitude - first[1]) * (second[0] - first[0]) -
+    (longitude - first[0]) * (second[1] - first[1]);
+  if (Math.abs(cross) > 1e-10) return false;
+  return longitude >= Math.min(first[0], second[0]) &&
+    longitude <= Math.max(first[0], second[0]) &&
+    latitude >= Math.min(first[1], second[1]) &&
+    latitude <= Math.max(first[1], second[1]);
+}
+
+function ringContainsCoordinate(ring, coordinate) {
+  let inside = false;
+  for (let index = 0, previous = ring.length - 1; index < ring.length; previous = index++) {
+    const first = ring[previous];
+    const second = ring[index];
+    if (pointOnSegment(coordinate, first, second)) return true;
+    const crossesLatitude = (first[1] > coordinate[1]) !== (second[1] > coordinate[1]);
+    if (
+      crossesLatitude &&
+      coordinate[0] <
+        ((second[0] - first[0]) * (coordinate[1] - first[1])) /
+          (second[1] - first[1]) + first[0]
+    ) {
+      inside = !inside;
+    }
+  }
+  return inside;
+}
+
+function polygonContainsCoordinate(rings, coordinate) {
+  return Boolean(
+    rings?.length &&
+      ringContainsCoordinate(rings[0], coordinate) &&
+      !rings.slice(1).some((ring) => ringContainsCoordinate(ring, coordinate)),
+  );
+}
+
+export function geometryContainsCoordinate(geometry, coordinate) {
+  if (geometry?.type === "Polygon") {
+    return polygonContainsCoordinate(geometry.coordinates, coordinate);
+  }
+  if (geometry?.type === "MultiPolygon") {
+    return geometry.coordinates.some((polygon) =>
+      polygonContainsCoordinate(polygon, coordinate));
+  }
+  return false;
+}
+
+export function clipContoursToWater(contours, isWater, bounds = null) {
+  if (!contours || typeof isWater !== "function") return contours;
+  const waterAt = (coordinate) =>
+    !bounds || !coordinateInsideBounds(coordinate, bounds) || isWater(coordinate);
+  const features = [];
+
+  for (const feature of contours.features || []) {
+    if (feature.geometry?.type !== "LineString") {
+      features.push(feature);
+      continue;
+    }
+    const coordinates = feature.geometry.coordinates;
+    const parts = [];
+    let part = [];
+    const flush = () => {
+      if (part.length >= 2) parts.push(part);
+      part = [];
+    };
+    for (let index = 1; index < coordinates.length; index += 1) {
+      const first = coordinates[index - 1];
+      const second = coordinates[index];
+      const midpoint = [(first[0] + second[0]) / 2, (first[1] + second[1]) / 2];
+      if (waterAt(first) && waterAt(midpoint) && waterAt(second)) {
+        if (!part.length) part.push(first);
+        if (!sameCoordinate(part.at(-1), second)) part.push(second);
+      } else {
+        flush();
+      }
+    }
+    flush();
+    parts.forEach((coordinatesPart, index) => {
+      features.push({
+        ...feature,
+        id: `${feature.id || "contour"}-water-${index}`,
+        geometry: { ...feature.geometry, coordinates: coordinatesPart },
+      });
+    });
+  }
+  return { ...contours, features };
 }

--- a/apps/website/map-data.test.mjs
+++ b/apps/website/map-data.test.mjs
@@ -3,9 +3,11 @@ import assert from "node:assert/strict";
 
 import {
   boundsContain,
+  clipContoursToWater,
   createContourRequest,
   createGebcoContourRequest,
   deriveShallowContours,
+  geometryContainsCoordinate,
   parseEmodnetGrid,
   parseGebcoGrid,
 } from "./emodnet-contours.mjs";
@@ -37,8 +39,9 @@ test("builds a bounded EMODnet request across England", () => {
   );
   assert.ok(request.url.includes("coverageId=emodnet__mean"));
   assert.ok(request.url.includes("scaleSize=i%28"));
-  assert.ok(request.gridWidth <= 320);
-  assert.ok(request.gridHeight <= 240);
+  assert.ok(request.gridWidth > 320);
+  assert.ok(request.gridWidth <= 512);
+  assert.ok(request.gridHeight <= 384);
   assert.equal(createContourRequest({ west: 120, south: -40, east: 130, north: -30 }, 9), null);
   assert.ok(boundsContain(request.bounds, { west: -5, south: 50, east: 1, north: 55 }));
 });
@@ -64,7 +67,24 @@ Band 0:
   assert.ok(contours.features[0].geometry.coordinates.every(([longitude]) => longitude < -1.47));
 });
 
-test("omits contour interpolation through cells containing positive land", () => {
+test("normalises scaled EMODnet grids whose row numbering does not begin at zero", () => {
+  const text = `Grid range: GridEnvelope2D[0..1, 1..2]
+Grid to world: PARAM_MT["Affine",
+  PARAMETER["elt_0_0", 0.02],
+  PARAMETER["elt_0_2", -5.1],
+  PARAMETER["elt_1_1", -0.02],
+  PARAMETER["elt_1_2", 50.2]]
+Contents:
+Band 0:
+-1 -2
+-3 -4`;
+  const parsed = parseEmodnetGrid(text);
+  assert.deepEqual(parsed.rows, [[-1, -2], [-3, -4]]);
+  assert.equal(parsed.transform.longitudeOrigin, -5.1);
+  assert.equal(parsed.transform.latitudeOrigin, 50.18);
+});
+
+test("keeps coastal contour cells connected until the display water mask is applied", () => {
   const text = `Grid range: GridEnvelope2D[0..3, 0..3]
 Grid to world: PARAM_MT["Affine",
   PARAMETER["elt_0_0", 0.01],
@@ -78,7 +98,51 @@ Band 0:
 3 -10 -10 3
 3 3 3 3`;
   const contours = deriveShallowContours(parseEmodnetGrid(text), [5]);
-  assert.equal(contours.features.length, 0);
+  assert.equal(contours.features.length, 1);
+  assert.equal(contours.features[0].geometry.coordinates.length, 9);
+  const clipped = clipContoursToWater(
+    contours,
+    () => false,
+    { west: -5.1, south: 50.1, east: -5, north: 50.2 },
+  );
+  assert.equal(clipped.features.length, 0);
+});
+
+test("clips only the on-land pieces of a connected contour", () => {
+  const contours = {
+    type: "FeatureCollection",
+    features: [{
+      type: "Feature",
+      id: "5m",
+      properties: { depthM: 5 },
+      geometry: {
+        type: "LineString",
+        coordinates: [[0, 0], [1, 0], [2, 0], [3, 0], [4, 0]],
+      },
+    }],
+  };
+  const clipped = clipContoursToWater(
+    contours,
+    ([longitude]) => longitude < 1.5 || longitude > 2.5,
+    { west: 0, south: -1, east: 4, north: 1 },
+  );
+  assert.deepEqual(
+    clipped.features.map((feature) => feature.geometry.coordinates),
+    [[[0, 0], [1, 0]], [[3, 0], [4, 0]]],
+  );
+});
+
+test("recognises rendered water polygons while respecting islands", () => {
+  const water = {
+    type: "Polygon",
+    coordinates: [
+      [[0, 0], [5, 0], [5, 5], [0, 5], [0, 0]],
+      [[2, 2], [3, 2], [3, 3], [2, 3], [2, 2]],
+    ],
+  };
+  assert.equal(geometryContainsCoordinate(water, [1, 1]), true);
+  assert.equal(geometryContainsCoordinate(water, [2.5, 2.5]), false);
+  assert.equal(geometryContainsCoordinate(water, [6, 1]), false);
 });
 
 test("builds and parses a bounded GEBCO global fallback request", () => {
@@ -87,8 +151,8 @@ test("builds and parses a bounded GEBCO global fallback request", () => {
     10,
   );
   assert.match(request.url, /GEBCO_2026\.nc\.ascii\?elevation\[/);
-  assert.ok(request.gridWidth <= 320);
-  assert.ok(request.gridHeight <= 240);
+  assert.ok(request.gridWidth <= 512);
+  assert.ok(request.gridHeight <= 384);
   assert.equal(
     createGebcoContourRequest({ west: 179, south: -20, east: 181, north: -19 }, 9),
     null,

--- a/apps/website/planner.html
+++ b/apps/website/planner.html
@@ -290,6 +290,6 @@
       integrity="sha384-5+cfbwT0iiub6VsQAdn6yz16nr6sDiQoHx6tm4O8OVYXHYOxcffFmCJBL0dgdvGp"
       crossorigin="anonymous"
     ></script>
-    <script type="module" src="/planner.js?v=20260821-7"></script>
+    <script type="module" src="/planner.js?v=20260821-8"></script>
   </body>
 </html>

--- a/apps/website/planner.js
+++ b/apps/website/planner.js
@@ -14,10 +14,12 @@ import {
 } from "./planner-storage.mjs";
 import {
   boundsContain,
+  clipContoursToWater,
   createContourRequest,
   createGebcoContourRequest,
   deriveShallowContours,
   EMODNET_COVERAGE,
+  geometryContainsCoordinate,
   parseEmodnetGrid,
   parseGebcoGrid,
 } from "./emodnet-contours.mjs";
@@ -1712,11 +1714,15 @@ function refreshDepthAdjustment() {
 }
 
 function syncAdjustedContourData() {
-  if (!mapReady) return;
+  if (!mapReady) return shallowContourData;
+  const waterPredicate = renderedWaterPredicate();
+  const waterClippedData = waterPredicate
+    ? clipContoursToWater(shallowContourData, waterPredicate, visibleMapBounds())
+    : shallowContourData;
   const data = currentDepthAdjustment
     ? {
-        ...shallowContourData,
-        features: shallowContourData.features.map((feature) => {
+        ...waterClippedData,
+        features: waterClippedData.features.map((feature) => {
           const adjustedDepth = Number(feature.properties?.depthM) + currentDepthAdjustment.heightM;
           return {
             ...feature,
@@ -1730,8 +1736,9 @@ function syncAdjustedContourData() {
           };
         }),
       }
-    : shallowContourData;
+    : waterClippedData;
   map.getSource("shallow-contours")?.setData(data);
+  return data;
 }
 
 async function updateShallowContours(force = false) {
@@ -1757,6 +1764,7 @@ async function updateShallowContours(force = false) {
     shallowContourProvider === provider &&
     boundsContain(shallowContourBounds, visibleBounds)
   ) {
+    syncAdjustedContourData();
     return;
   }
 
@@ -1793,10 +1801,12 @@ async function updateShallowContours(force = false) {
     shallowContourProvider = provider;
     refreshDepthAdjustment();
     const resolution = request.resolutionLimited
-      ? "regional preview resolution; zoom closer for more detail"
-      : "native model resolution";
+      ? "high-detail view sampling; zoom closer for the native grid"
+      : provider === "emodnet"
+        ? "native 115 m model grid"
+        : "native 15 arc-second model grid";
     const source = provider === "emodnet" ? "EMODnet" : "GEBCO global fallback";
-    elements.shallowContourStatus.textContent = `${shallowContourData.features.length.toLocaleString("en-GB")} ${source} lines for this area · ${resolution} · coastal land/sea transition cells omitted.`;
+    elements.shallowContourStatus.textContent = `${shallowContourData.features.length.toLocaleString("en-GB")} connected ${source} lines for this area · ${resolution} · clipped to visible basemap water.`;
   } catch (error) {
     if (error.name === "AbortError") return;
     elements.shallowContourStatus.textContent = `Contours unavailable for this area (${error.message}).`;
@@ -1840,6 +1850,25 @@ function basemapShowsWater(point) {
   } catch {
     return true;
   }
+}
+
+function renderedWaterPredicate() {
+  if (!mapReady || !map.getLayer("water")) return null;
+  let geometries;
+  try {
+    const canvas = map.getCanvas();
+    geometries = map.queryRenderedFeatures(
+      [[0, 0], [canvas.clientWidth, canvas.clientHeight]],
+      { layers: ["water"] },
+    )
+      .map((feature) => feature.geometry)
+      .filter(Boolean);
+  } catch {
+    return null;
+  }
+  if (!geometries.length) return null;
+  return (coordinate) => geometries.some((geometry) =>
+    geometryContainsCoordinate(geometry, coordinate));
 }
 
 function fitPassage() {

--- a/tools/places/README.md
+++ b/tools/places/README.md
@@ -63,7 +63,9 @@ and derives 2, 5, 10, 20 and 30 m linework with marching squares. The web
 planner now performs the same bounded derivation on demand for its current map
 view across EMODnet's coverage, so it is not limited to a committed Solent
 file. Outside that coverage it derives the same levels from a bounded GEBCO
-2026 OPeNDAP subset as a coarser worldwide fallback. Generated linework is model
+2026 OPeNDAP subset as a coarser worldwide fallback. The browser keeps coastal
+cells connected during derivation, then clips the displayed line segments to
+the currently rendered basemap water polygons. Generated linework is model
 context, not surveyed marina depth, a charted sounding or an under-keel-clearance
 source.
 


### PR DESCRIPTION
## Summary
- increase EMODnet and GEBCO contour sampling from 320×240 to 512×384
- keep coastal marching-square cells connected, then clip displayed segments against rendered basemap water
- accept scaled EMODnet grids whose row/column ranges do not start at zero
- document and test the coastal clipping pipeline

## Verification
- node --check apps/website/planner.js
- node --check apps/website/emodnet-contours.mjs
- node --test apps/website/planner-core.test.mjs apps/website/map-data.test.mjs
- python3 -m unittest tools/contours/test_generate_emodnet_shallow_contours.py
- ./tools/build_website.sh
- parsed a live 426×384 EMODnet WCS sample covering Falmouth