### PR TITLE
fix: trace shallow contours from depth shading

### DIFF
--- a/apps/website/README.md
+++ b/apps/website/README.md
@@ -15,10 +15,10 @@ motorcycle preferences or cafe discovery.
 - optional short plan-code publishing through `/api/v1/plans`;
 - OpenFreeMap general context and a toggleable OpenSeaMap seamark overlay;
 - toggleable EMODnet Bathymetry DTM 2024 depth shading with three transparent
-  water-only palettes, on-demand 2/5/10/20/30 m contours for the current view
-  throughout its North Atlantic and European coverage, a coarser GEBCO 2026
-  fallback elsewhere in the world, and EMODnet's generalised 50 m-and-deeper
-  European overlay;
+  water-only palettes, on-demand 2/5/10/20/30 m contours dynamically traced at
+  screen resolution from the same official multicolour shading surface throughout
+  its North Atlantic and European coverage, a coarser GEBCO 2026 fallback elsewhere
+  in the world, and EMODnet's generalised 50 m-and-deeper European overlay;
 - a zoom-adaptive wind field with downwind arrows, speed/time labels, gust detail,
   a purple passage-time halo near the route and explicit model—not observation—wording;
 - a locally entered passage start time, 15-minute time-of-day slider, hour/day
@@ -48,10 +48,11 @@ Straight route legs do not imply land, depth or hazard avoidance. OpenStreetMap,
 OpenSeaMap, EMODnet, tide and weather data remain visibly attributed and carry
 their source limitations.
 
-Derived depth contours omit any interpolation cell containing non-negative land
-or shoreline elevation. This avoids drawing a seabed contour through a mixed land/sea cell,
-but the source grid is still about 115 m in EMODnet coverage and its coastline
-can differ from the general-purpose basemap.
+The EMODnet shallow contours are decoded from its official styled-raster colour
+ramp and retraced when the map zooms in. They are clipped to water polygons from
+the visible basemap. The smoother screen-resolution trace does not add survey
+precision: the source grid is still about 115 m in EMODnet coverage and its
+coastline can differ from the general-purpose basemap.
 
 Run locally from the repository root:
 

--- a/apps/website/emodnet-contours.mjs
+++ b/apps/website/emodnet-contours.mjs
@@ -7,16 +7,18 @@ export const EMODNET_COVERAGE = Object.freeze({
 export const SHALLOW_CONTOUR_LEVELS = Object.freeze([2, 5, 10, 20, 30]);
 
 const WCS_URL = "https://ows.emodnet-bathymetry.eu/wcs";
+const WMS_URL = "https://ows.emodnet-bathymetry.eu/wms";
 const GEBCO_DAP_URL =
   "https://dap.ceda.ac.uk/thredds/dodsC/bodc/gebco/global/gebco_2026/ice_surface_elevation/netcdf/GEBCO_2026.nc";
 const NATIVE_STEP_DEGREES = 1 / 960;
 const GEBCO_CELLS_PER_DEGREE = 240;
 const MAX_GRID_WIDTH = 512;
 const MAX_GRID_HEIGHT = 384;
+const MAX_SHADING_WIDTH = 1024;
+const MAX_SHADING_HEIGHT = 768;
 const NUMBER_PATTERN = /[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[Ee][-+]?\d+)?/g;
 
-export function createContourRequest(bounds, zoom) {
-  if (!bounds || zoom < 8 || bounds.east <= bounds.west) return null;
+function paddedEmodnetBounds(bounds) {
   const width = bounds.east - bounds.west;
   const height = bounds.north - bounds.south;
   const requested = {
@@ -25,7 +27,15 @@ export function createContourRequest(bounds, zoom) {
     east: Math.min(EMODNET_COVERAGE.east, bounds.east + width * 0.16),
     north: Math.min(EMODNET_COVERAGE.north, bounds.north + height * 0.16),
   };
-  if (requested.east <= requested.west || requested.north <= requested.south) return null;
+  return requested.east > requested.west && requested.north > requested.south
+    ? requested
+    : null;
+}
+
+export function createContourRequest(bounds, zoom) {
+  if (!bounds || zoom < 8 || bounds.east <= bounds.west) return null;
+  const requested = paddedEmodnetBounds(bounds);
+  if (!requested) return null;
 
   const nativeWidth = Math.max(2, Math.ceil((requested.east - requested.west) / NATIVE_STEP_DEGREES));
   const nativeHeight = Math.max(2, Math.ceil((requested.north - requested.south) / NATIVE_STEP_DEGREES));
@@ -48,6 +58,47 @@ export function createContourRequest(bounds, zoom) {
     gridHeight,
     resolutionLimited: scale < 0.999,
     url: `${WCS_URL}?${parameters}`,
+  };
+}
+
+export function createShadingContourRequest(bounds, zoom, viewport = {}) {
+  if (!bounds || zoom < 8 || bounds.east <= bounds.west) return null;
+  const requested = paddedEmodnetBounds(bounds);
+  if (!requested) return null;
+
+  const viewportWidth = Math.max(256, Number(viewport.width) || 768);
+  const viewportHeight = Math.max(192, Number(viewport.height) || 576);
+  const width = Math.min(MAX_SHADING_WIDTH, Math.round(viewportWidth * 1.32));
+  const height = Math.min(MAX_SHADING_HEIGHT, Math.round(viewportHeight * 1.32));
+  const parameters = new URLSearchParams({
+    service: "WMS",
+    version: "1.1.1",
+    request: "GetMap",
+    layers: "emodnet:mean",
+    styles: "multicolour",
+    format: "image/png",
+    transparent: "true",
+    srs: "EPSG:4326",
+    bbox: [requested.west, requested.south, requested.east, requested.north]
+      .map((value) => value.toFixed(6))
+      .join(","),
+    width: String(width),
+    height: String(height),
+  });
+  const legendParameters = new URLSearchParams({
+    service: "WMS",
+    version: "1.1.1",
+    request: "GetLegendGraphic",
+    layer: "emodnet:mean",
+    style: "multicolour",
+    format: "application/json",
+  });
+  return {
+    bounds: requested,
+    gridWidth: width,
+    gridHeight: height,
+    legendUrl: `${WMS_URL}?${legendParameters}`,
+    url: `${WMS_URL}?${parameters}`,
   };
 }
 
@@ -116,6 +167,14 @@ export function boundsContain(outer, inner) {
       outer.south <= inner.south &&
       outer.east >= inner.east &&
       outer.north >= inner.north,
+  );
+}
+
+export function contourSampleSupportsZoom(sampleZoom, visibleZoom) {
+  return Boolean(
+    Number.isFinite(sampleZoom) &&
+      Number.isFinite(visibleZoom) &&
+      visibleZoom <= sampleZoom + 0.35,
   );
 }
 
@@ -198,6 +257,112 @@ export function parseGebcoGrid(text) {
   };
 }
 
+function parseHexColour(value) {
+  const match = String(value || "").match(/^#([0-9a-f]{6})$/i);
+  if (!match) return null;
+  const colour = Number.parseInt(match[1], 16);
+  return [(colour >> 16) & 255, (colour >> 8) & 255, colour & 255];
+}
+
+export function parseEmodnetColourScale(payload) {
+  const document = typeof payload === "string" ? JSON.parse(payload) : payload;
+  const entries = document?.Legend
+    ?.flatMap((legend) => legend.rules || [])
+    .flatMap((rule) => rule.symbolizers || [])
+    .map((symbolizer) => symbolizer.Raster?.colormap?.entries)
+    .find(Array.isArray);
+  if (!entries) throw new Error("The depth shading service returned no colour scale.");
+
+  const scale = entries
+    .map((entry) => ({ elevation: Number(entry.quantity), colour: parseHexColour(entry.color) }))
+    .filter((entry) => Number.isFinite(entry.elevation) && entry.colour)
+    .sort((first, second) => first.elevation - second.elevation);
+  if (scale.length < 2) throw new Error("The depth shading colour scale was incomplete.");
+  return scale;
+}
+
+function elevationFromColour(colour, scale) {
+  let closest = { distanceSquared: Number.POSITIVE_INFINITY, elevation: 0 };
+  for (let index = 1; index < scale.length; index += 1) {
+    const first = scale[index - 1];
+    const second = scale[index];
+    const vector = second.colour.map((value, channel) => value - first.colour[channel]);
+    const lengthSquared = vector.reduce((sum, value) => sum + value * value, 0);
+    const offset = colour.map((value, channel) => value - first.colour[channel]);
+    const ratio = lengthSquared === 0
+      ? 0
+      : Math.max(0, Math.min(1,
+        offset.reduce((sum, value, channel) => sum + value * vector[channel], 0) /
+          lengthSquared));
+    const distanceSquared = colour.reduce((sum, value, channel) => {
+      const rendered = first.colour[channel] + vector[channel] * ratio;
+      return sum + (value - rendered) ** 2;
+    }, 0);
+    if (distanceSquared < closest.distanceSquared) {
+      closest = {
+        distanceSquared,
+        elevation: first.elevation + (second.elevation - first.elevation) * ratio,
+      };
+    }
+  }
+  return closest.elevation;
+}
+
+export function parseEmodnetShadingGrid(imageData, colourScale, bounds) {
+  const width = Number(imageData?.width);
+  const height = Number(imageData?.height);
+  const pixels = imageData?.data;
+  if (
+    !Number.isInteger(width) ||
+    !Number.isInteger(height) ||
+    width < 2 ||
+    height < 2 ||
+    pixels?.length !== width * height * 4 ||
+    !bounds ||
+    bounds.east <= bounds.west ||
+    bounds.north <= bounds.south ||
+    !Array.isArray(colourScale) ||
+    colourScale.length < 2
+  ) {
+    throw new Error("The depth shading image was incomplete.");
+  }
+
+  const colourCache = new Map();
+  const rows = Array.from({ length: height }, () => Array(width));
+  for (let row = 0; row < height; row += 1) {
+    for (let column = 0; column < width; column += 1) {
+      const offset = (row * width + column) * 4;
+      if (pixels[offset + 3] < 128) {
+        rows[row][column] = Number.NaN;
+        continue;
+      }
+      const key = (pixels[offset] << 16) | (pixels[offset + 1] << 8) | pixels[offset + 2];
+      if (!colourCache.has(key)) {
+        colourCache.set(
+          key,
+          elevationFromColour(
+            [pixels[offset], pixels[offset + 1], pixels[offset + 2]],
+            colourScale,
+          ),
+        );
+      }
+      rows[row][column] = colourCache.get(key);
+    }
+  }
+
+  const longitudeStep = (bounds.east - bounds.west) / width;
+  const latitudeStep = -(bounds.north - bounds.south) / height;
+  return {
+    rows,
+    transform: {
+      longitudeStep,
+      longitudeOrigin: bounds.west + longitudeStep / 2,
+      latitudeStep,
+      latitudeOrigin: bounds.north + latitudeStep / 2,
+    },
+  };
+}
+
 function interpolate(first, second, level) {
   if (first === second) return 0.5;
   return Math.max(0, Math.min(1, (level - first) / (second - first)));
@@ -235,6 +400,7 @@ function contourSegments(grid, level) {
         grid[row + 1][column + 1],
         grid[row + 1][column],
       ];
+      if (corners.some((corner) => !Number.isFinite(corner))) continue;
       const contourCase = corners.reduce(
         (value, corner, index) => value + (corner >= level ? 1 << index : 0),
         0,

--- a/apps/website/map-data.test.mjs
+++ b/apps/website/map-data.test.mjs
@@ -4,11 +4,15 @@ import assert from "node:assert/strict";
 import {
   boundsContain,
   clipContoursToWater,
+  contourSampleSupportsZoom,
   createContourRequest,
   createGebcoContourRequest,
+  createShadingContourRequest,
   deriveShallowContours,
   geometryContainsCoordinate,
+  parseEmodnetColourScale,
   parseEmodnetGrid,
+  parseEmodnetShadingGrid,
   parseGebcoGrid,
 } from "./emodnet-contours.mjs";
 import { sampleWindAt, windFieldGeoJson, windGrid, windRequestUrl } from "./wind-field.mjs";
@@ -44,6 +48,83 @@ test("builds a bounded EMODnet request across England", () => {
   assert.ok(request.gridHeight <= 384);
   assert.equal(createContourRequest({ west: 120, south: -40, east: 130, north: -30 }, 9), null);
   assert.ok(boundsContain(request.bounds, { west: -5, south: 50, east: 1, north: 55 }));
+});
+
+test("builds a screen-resolution request for the EMODnet depth shading colours", () => {
+  const request = createShadingContourRequest(
+    { west: -5.2, south: 50.05, east: -4.95, north: 50.25 },
+    12,
+    { width: 900, height: 700 },
+  );
+  assert.match(request.url, /request=GetMap/i);
+  assert.match(request.url, /layers=emodnet%3Amean/i);
+  assert.match(request.url, /styles=multicolour/i);
+  assert.match(request.legendUrl, /GetLegendGraphic/i);
+  assert.equal(request.gridWidth, 1024);
+  assert.equal(request.gridHeight, 768);
+  assert.ok(boundsContain(request.bounds, { west: -5.2, south: 50.05, east: -4.95, north: 50.25 }));
+});
+
+test("refreshes a cached colour trace as the map zooms in", () => {
+  assert.equal(contourSampleSupportsZoom(10, 10.3), true);
+  assert.equal(contourSampleSupportsZoom(10, 10.5), false);
+  assert.equal(contourSampleSupportsZoom(10, 9), true);
+  assert.equal(contourSampleSupportsZoom(null, 10), false);
+});
+
+test("recovers shallow depths from the official shading colour ramp", () => {
+  const colourScale = parseEmodnetColourScale({
+    Legend: [{
+      rules: [{
+        symbolizers: [{
+          Raster: {
+            colormap: {
+              entries: [
+                { quantity: "-50", color: "#FFFF0D" },
+                { quantity: "-10", color: "#F90018" },
+                { quantity: "0", color: "#FF666A" },
+              ],
+            },
+          },
+        }],
+      }],
+    }],
+  });
+  const colours = {
+    land: [255, 102, 106, 255],
+    fiveMetres: [252, 51, 65, 255],
+    tenMetres: [249, 0, 24, 255],
+  };
+  const pixels = new Uint8ClampedArray([
+    ...colours.land, ...colours.land, ...colours.land, ...colours.land,
+    ...colours.land, ...colours.tenMetres, ...colours.tenMetres, ...colours.land,
+    ...colours.land, ...colours.tenMetres, ...colours.tenMetres, ...colours.land,
+    ...colours.land, ...colours.land, ...colours.land, ...colours.land,
+  ]);
+  const parsed = parseEmodnetShadingGrid(
+    { width: 4, height: 4, data: pixels },
+    colourScale,
+    { west: -5.2, south: 50.05, east: -4.95, north: 50.25 },
+  );
+  assert.ok(Math.abs(parsed.rows[0][0]) < 0.01);
+  assert.ok(Math.abs(parsed.rows[1][1] + 10) < 0.01);
+
+  const fiveMetrePixel = new Uint8ClampedArray([
+    ...colours.fiveMetres, ...colours.fiveMetres,
+    ...colours.fiveMetres, ...colours.fiveMetres,
+  ]);
+  const fiveMetreGrid = parseEmodnetShadingGrid(
+    { width: 2, height: 2, data: fiveMetrePixel },
+    colourScale,
+    { west: 0, south: 0, east: 1, north: 1 },
+  );
+  assert.ok(Math.abs(fiveMetreGrid.rows[0][0] + 5) < 0.2);
+
+  const contours = deriveShallowContours(parsed, [5], {
+    sourceName: "EMODnet multicolour depth shading",
+  });
+  assert.equal(contours.features.length, 1);
+  assert.equal(contours.features[0].properties.label, "5 m");
 });
 
 test("parses negative seabed elevations into shallow contours", () => {

--- a/apps/website/planner.html
+++ b/apps/website/planner.html
@@ -130,9 +130,9 @@
             </label>
             <label class="layer-toggle compact-toggle">
               <input id="shallow-contours-visible" type="checkbox" checked />
-              <span><strong>Worldwide shallow contours</strong><small>Model-derived 2, 5, 10, 20 and 30 m lines. Higher-resolution EMODnet data covers all English coasts; GEBCO provides a coarser worldwide fallback.</small></span>
+              <span><strong>Shallow depth contours</strong><small>2, 5, 10, 20 and 30 m lines traced dynamically from the EMODnet depth-shading colours. GEBCO provides a coarser worldwide fallback.</small></span>
             </label>
-            <p class="layer-status" id="shallow-contour-status">Contours load for the visible area at zoom level 8 or closer.</p>
+            <p class="layer-status" id="shallow-contour-status">Depth-shading contours load for the visible area at zoom level 8 or closer.</p>
             <label class="layer-toggle compact-toggle">
               <input id="offshore-contours-visible" type="checkbox" />
               <span><strong>European offshore contours</strong><small>EMODnet's generalised 50 m and deeper model lines. Mostly outside this starter area.</small></span>
@@ -290,6 +290,6 @@
       integrity="sha384-5+cfbwT0iiub6VsQAdn6yz16nr6sDiQoHx6tm4O8OVYXHYOxcffFmCJBL0dgdvGp"
       crossorigin="anonymous"
     ></script>
-    <script type="module" src="/planner.js?v=20260821-8"></script>
+    <script type="module" src="/planner.js?v=20260821-9"></script>
   </body>
 </html>

--- a/apps/website/planner.js
+++ b/apps/website/planner.js
@@ -15,12 +15,14 @@ import {
 import {
   boundsContain,
   clipContoursToWater,
-  createContourRequest,
+  contourSampleSupportsZoom,
   createGebcoContourRequest,
+  createShadingContourRequest,
   deriveShallowContours,
   EMODNET_COVERAGE,
   geometryContainsCoordinate,
-  parseEmodnetGrid,
+  parseEmodnetColourScale,
+  parseEmodnetShadingGrid,
   parseGebcoGrid,
 } from "./emodnet-contours.mjs";
 import { windFieldGeoJson, windGrid, windRequestUrl } from "./wind-field.mjs";
@@ -140,7 +142,9 @@ let catalogueRequested = false;
 let shallowContourData = EMPTY_FEATURE_COLLECTION;
 let shallowContourBounds = null;
 let shallowContourProvider = null;
+let shallowContourSampleZoom = null;
 let shallowContourAbortController = null;
+let emodnetColourScalePromise = null;
 let windRequestSequence = 0;
 let currentFieldRequestSequence = 0;
 let routeCurrentRequestSequence = 0;
@@ -1741,20 +1745,68 @@ function syncAdjustedContourData() {
   return data;
 }
 
+async function responseImageData(response) {
+  const blob = await response.blob();
+  let objectUrl = null;
+  const bitmap = typeof createImageBitmap === "function"
+    ? await createImageBitmap(blob)
+    : await new Promise((resolve, reject) => {
+        objectUrl = URL.createObjectURL(blob);
+        const image = new Image();
+        image.onload = () => resolve(image);
+        image.onerror = () => reject(new Error("This browser could not decode the depth shading image."));
+        image.src = objectUrl;
+      });
+  try {
+    const canvas = document.createElement("canvas");
+    canvas.width = bitmap.width;
+    canvas.height = bitmap.height;
+    const context = canvas.getContext("2d", { willReadFrequently: true });
+    if (!context) throw new Error("This browser could not read the depth shading image.");
+    context.drawImage(bitmap, 0, 0);
+    return context.getImageData(0, 0, bitmap.width, bitmap.height);
+  } finally {
+    bitmap.close?.();
+    if (objectUrl) URL.revokeObjectURL(objectUrl);
+  }
+}
+
+function loadEmodnetColourScale(url) {
+  if (!emodnetColourScalePromise) {
+    emodnetColourScalePromise = fetch(url, { headers: { Accept: "application/json" } })
+      .then((response) => {
+        if (!response.ok) throw new Error(`colour scale HTTP ${response.status}`);
+        return response.json();
+      })
+      .then(parseEmodnetColourScale)
+      .catch((error) => {
+        emodnetColourScalePromise = null;
+        throw error;
+      });
+  }
+  return emodnetColourScalePromise;
+}
+
 async function updateShallowContours(force = false) {
   if (!mapReady || !elements.shallowContoursVisible.checked) return;
   const visibleBounds = visibleMapBounds();
   const useEmodnet = boundsContain(EMODNET_COVERAGE, visibleBounds);
   const provider = useEmodnet ? "emodnet" : "gebco";
+  const canvas = map.getCanvas();
+  const zoom = map.getZoom();
   const request = useEmodnet
-    ? createContourRequest(visibleBounds, map.getZoom())
-    : createGebcoContourRequest(visibleBounds, map.getZoom());
+    ? createShadingContourRequest(visibleBounds, zoom, {
+        width: canvas.clientWidth,
+        height: canvas.clientHeight,
+      })
+    : createGebcoContourRequest(visibleBounds, zoom);
   if (!request) {
-    elements.shallowContourStatus.textContent = map.getZoom() < 8
+    elements.shallowContourStatus.textContent = zoom < 8
       ? "Zoom in to level 8 or closer to derive shallow contours for the visible coast."
       : "Global contours cannot be sampled while this view crosses the 180° meridian.";
     shallowContourBounds = null;
     shallowContourProvider = null;
+    shallowContourSampleZoom = null;
     shallowContourData = EMPTY_FEATURE_COLLECTION;
     refreshDepthAdjustment();
     return;
@@ -1762,7 +1814,8 @@ async function updateShallowContours(force = false) {
   if (
     !force &&
     shallowContourProvider === provider &&
-    boundsContain(shallowContourBounds, visibleBounds)
+    boundsContain(shallowContourBounds, visibleBounds) &&
+    contourSampleSupportsZoom(shallowContourSampleZoom, zoom)
   ) {
     syncAdjustedContourData();
     return;
@@ -1772,24 +1825,35 @@ async function updateShallowContours(force = false) {
   shallowContourAbortController = new AbortController();
   const controller = shallowContourAbortController;
   elements.shallowContourStatus.textContent = provider === "emodnet"
-    ? "Loading higher-resolution EMODnet depths for this map area…"
+    ? "Tracing shallow contours from the visible EMODnet depth colours…"
     : "Loading the global GEBCO grid and deriving contours for this map area…";
   try {
     const response = await fetch(request.url, {
-      headers: { Accept: "text/plain" },
+      headers: { Accept: provider === "emodnet" ? "image/png" : "text/plain" },
       signal: controller.signal,
     });
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
-    const responseText = await response.text();
-    const parsed = provider === "emodnet"
-      ? parseEmodnetGrid(responseText)
-      : parseGebcoGrid(responseText);
+    let parsed;
+    if (provider === "emodnet") {
+      const [imageData, colourScale] = await Promise.all([
+        responseImageData(response),
+        loadEmodnetColourScale(request.legendUrl),
+      ]);
+      parsed = parseEmodnetShadingGrid(imageData, colourScale, request.bounds);
+    } else {
+      parsed = parseGebcoGrid(await response.text());
+    }
     if (controller !== shallowContourAbortController) return;
     shallowContourData = deriveShallowContours(
       parsed,
       undefined,
       provider === "emodnet"
-        ? {}
+        ? {
+            featurePrefix: "emodnet-shading",
+            sourceName: "EMODnet DTM 2024 multicolour depth shading",
+            warning:
+              "Dynamically traced from modelled depth-shading colours; not a charted sounding or safe clearance.",
+          }
         : {
             featurePrefix: "gebco-live",
             sourceName: "GEBCO 2026 Grid",
@@ -1799,14 +1863,16 @@ async function updateShallowContours(force = false) {
     );
     shallowContourBounds = request.bounds;
     shallowContourProvider = provider;
+    shallowContourSampleZoom = zoom;
     refreshDepthAdjustment();
-    const resolution = request.resolutionLimited
-      ? "high-detail view sampling; zoom closer for the native grid"
-      : provider === "emodnet"
-        ? "native 115 m model grid"
+    if (provider === "emodnet") {
+      elements.shallowContourStatus.textContent = `${shallowContourData.features.length.toLocaleString("en-GB")} lines dynamically traced from the ${request.gridWidth}×${request.gridHeight} EMODnet colour surface · underlying model cells remain about 115 m · clipped to visible basemap water.`;
+    } else {
+      const resolution = request.resolutionLimited
+        ? "high-detail view sampling; zoom closer for the native grid"
         : "native 15 arc-second model grid";
-    const source = provider === "emodnet" ? "EMODnet" : "GEBCO global fallback";
-    elements.shallowContourStatus.textContent = `${shallowContourData.features.length.toLocaleString("en-GB")} connected ${source} lines for this area · ${resolution} · clipped to visible basemap water.`;
+      elements.shallowContourStatus.textContent = `${shallowContourData.features.length.toLocaleString("en-GB")} connected GEBCO global fallback lines for this area · ${resolution} · clipped to visible basemap water.`;
+    }
   } catch (error) {
     if (error.name === "AbortError") return;
     elements.shallowContourStatus.textContent = `Contours unavailable for this area (${error.message}).`;


### PR DESCRIPTION
## Summary
- dynamically decode shallow contours from EMODnet's official multicolour depth-shading ramp
- resample at screen resolution and refresh traces as the map zooms in
- retain basemap-water clipping, tide-adjusted labels, GEBCO fallback, and explicit model-resolution warnings

## Verification
- node --check apps/website/planner.js
- node --check apps/website/emodnet-contours.mjs
- node --test apps/website/planner-core.test.mjs apps/website/map-data.test.mjs
- python3 -m unittest tools/contours/test_generate_emodnet_shallow_contours.py
- ./tools/build_website.sh
- live Falmouth EMODnet WMS/legend integration: 75 connected features, 15,036 vertices, ~172 ms

## Safety
- no provider keys, database migrations, feature flags, or restricted chart datasets
- UI continues to identify the contours as model-derived planning context, not charted soundings or safe clearance