### PR TITLE
fix: keep contour rendering responsive

### DIFF
--- a/apps/website/Caddyfile
+++ b/apps/website/Caddyfile
@@ -12,7 +12,7 @@
 		X-Content-Type-Options "nosniff"
 		X-Frame-Options "DENY"
 		Permissions-Policy "geolocation=(), camera=(), microphone=()"
-		Content-Security-Policy "default-src 'self'; script-src 'self' https://unpkg.com; style-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' data: blob: https://tiles.openfreemap.org https://tiles.openseamap.org https://tiles.emodnet-bathymetry.eu https://ows.emodnet-bathymetry.eu https://wms.gebco.net https://gis.charttools.noaa.gov; connect-src 'self' https://relay.tailendcharlie.app https://tiles.openfreemap.org https://tiles.openseamap.org https://tiles.emodnet-bathymetry.eu https://ows.emodnet-bathymetry.eu https://wms.gebco.net https://gis.charttools.noaa.gov https://api.open-meteo.com; worker-src blob:; child-src blob:; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; object-src 'none'"
+		Content-Security-Policy "default-src 'self'; script-src 'self' https://unpkg.com; style-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' data: blob: https://tiles.openfreemap.org https://tiles.openseamap.org https://tiles.emodnet-bathymetry.eu https://ows.emodnet-bathymetry.eu https://wms.gebco.net https://gis.charttools.noaa.gov; connect-src 'self' https://relay.tailendcharlie.app https://tiles.openfreemap.org https://tiles.openseamap.org https://tiles.emodnet-bathymetry.eu https://ows.emodnet-bathymetry.eu https://wms.gebco.net https://gis.charttools.noaa.gov https://api.open-meteo.com; worker-src 'self' blob:; child-src blob:; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; object-src 'none'"
 	}
 
 	@planner path /planner.html

--- a/apps/website/README.md
+++ b/apps/website/README.md
@@ -49,10 +49,12 @@ OpenSeaMap, EMODnet, tide and weather data remain visibly attributed and carry
 their source limitations.
 
 The EMODnet shallow contours are decoded from its official styled-raster colour
-ramp and retraced when the map zooms in. They are clipped to water polygons from
-the visible basemap. The smoother screen-resolution trace does not add survey
-precision: the source grid is still about 115 m in EMODnet coverage and its
-coastline can differ from the general-purpose basemap.
+ramp and retraced off the main UI thread when the map zooms in. Sub-pixel line
+simplification keeps map interaction responsive without visibly changing the
+trace, and the result is clipped to water polygons from the visible basemap. The
+smoother screen-resolution trace does not add survey precision: the source grid
+is still about 115 m in EMODnet coverage and its coastline can differ from the
+general-purpose basemap.
 
 Run locally from the repository root:
 

--- a/apps/website/_headers
+++ b/apps/website/_headers
@@ -3,7 +3,7 @@
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
   Permissions-Policy: geolocation=(), camera=(), microphone=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' https://unpkg.com; style-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' data: blob: https://tiles.openfreemap.org https://tiles.openseamap.org https://tiles.emodnet-bathymetry.eu https://ows.emodnet-bathymetry.eu https://wms.gebco.net https://gis.charttools.noaa.gov; connect-src 'self' https://relay.tailendcharlie.app https://tiles.openfreemap.org https://tiles.openseamap.org https://tiles.emodnet-bathymetry.eu https://ows.emodnet-bathymetry.eu https://wms.gebco.net https://dap.ceda.ac.uk https://gis.charttools.noaa.gov https://api.open-meteo.com https://marine-api.open-meteo.com; worker-src blob:; child-src blob:; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; object-src 'none'
+  Content-Security-Policy: default-src 'self'; script-src 'self' https://unpkg.com; style-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' data: blob: https://tiles.openfreemap.org https://tiles.openseamap.org https://tiles.emodnet-bathymetry.eu https://ows.emodnet-bathymetry.eu https://wms.gebco.net https://gis.charttools.noaa.gov; connect-src 'self' https://relay.tailendcharlie.app https://tiles.openfreemap.org https://tiles.openseamap.org https://tiles.emodnet-bathymetry.eu https://ows.emodnet-bathymetry.eu https://wms.gebco.net https://dap.ceda.ac.uk https://gis.charttools.noaa.gov https://api.open-meteo.com https://marine-api.open-meteo.com; worker-src 'self' blob:; child-src blob:; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; object-src 'none'
 
 /data/*
   Cache-Control: public, max-age=3600

--- a/apps/website/contour-worker.mjs
+++ b/apps/website/contour-worker.mjs
@@ -1,0 +1,32 @@
+import {
+  deriveShallowContours,
+  parseEmodnetShadingGrid,
+} from "./emodnet-contours.mjs";
+
+export function buildShadingContours({ bounds, colourScale, height, options, pixels, width }) {
+  const parsed = parseEmodnetShadingGrid(
+    { width, height, data: new Uint8ClampedArray(pixels) },
+    colourScale,
+    bounds,
+  );
+  const simplifyTolerance = Math.max(
+    Math.abs(parsed.transform.longitudeStep),
+    Math.abs(parsed.transform.latitudeStep),
+  ) * 0.65;
+  return deriveShallowContours(parsed, undefined, {
+    ...options,
+    simplifyTolerance,
+  });
+}
+
+if (typeof self !== "undefined") {
+  self.addEventListener("message", (event) => {
+    try {
+      self.postMessage({ contours: buildShadingContours(event.data) });
+    } catch (error) {
+      self.postMessage({
+        error: error instanceof Error ? error.message : "Contour generation failed.",
+      });
+    }
+  });
+}

--- a/apps/website/emodnet-contours.mjs
+++ b/apps/website/emodnet-contours.mjs
@@ -14,8 +14,8 @@ const NATIVE_STEP_DEGREES = 1 / 960;
 const GEBCO_CELLS_PER_DEGREE = 240;
 const MAX_GRID_WIDTH = 512;
 const MAX_GRID_HEIGHT = 384;
-const MAX_SHADING_WIDTH = 1024;
-const MAX_SHADING_HEIGHT = 768;
+const MAX_SHADING_WIDTH = 896;
+const MAX_SHADING_HEIGHT = 672;
 const NUMBER_PATTERN = /[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[Ee][-+]?\d+)?/g;
 
 function paddedEmodnetBounds(bounds) {
@@ -68,8 +68,8 @@ export function createShadingContourRequest(bounds, zoom, viewport = {}) {
 
   const viewportWidth = Math.max(256, Number(viewport.width) || 768);
   const viewportHeight = Math.max(192, Number(viewport.height) || 576);
-  const width = Math.min(MAX_SHADING_WIDTH, Math.round(viewportWidth * 1.32));
-  const height = Math.min(MAX_SHADING_HEIGHT, Math.round(viewportHeight * 1.32));
+  const width = Math.min(MAX_SHADING_WIDTH, Math.round(viewportWidth));
+  const height = Math.min(MAX_SHADING_HEIGHT, Math.round(viewportHeight));
   const parameters = new URLSearchParams({
     service: "WMS",
     version: "1.1.1",
@@ -174,7 +174,7 @@ export function contourSampleSupportsZoom(sampleZoom, visibleZoom) {
   return Boolean(
     Number.isFinite(sampleZoom) &&
       Number.isFinite(visibleZoom) &&
-      visibleZoom <= sampleZoom + 0.35,
+      visibleZoom <= sampleZoom + 0.75,
   );
 }
 
@@ -473,11 +473,60 @@ function lineLength(coordinates) {
   }, 0);
 }
 
+function squaredDistanceToSegment(point, first, second) {
+  const longitudeDelta = second[0] - first[0];
+  const latitudeDelta = second[1] - first[1];
+  const lengthSquared = longitudeDelta ** 2 + latitudeDelta ** 2;
+  if (lengthSquared === 0) {
+    return (point[0] - first[0]) ** 2 + (point[1] - first[1]) ** 2;
+  }
+  const ratio = Math.max(0, Math.min(1,
+    ((point[0] - first[0]) * longitudeDelta + (point[1] - first[1]) * latitudeDelta) /
+      lengthSquared));
+  const projected = [
+    first[0] + ratio * longitudeDelta,
+    first[1] + ratio * latitudeDelta,
+  ];
+  return (point[0] - projected[0]) ** 2 + (point[1] - projected[1]) ** 2;
+}
+
+function simplifyLine(coordinates, tolerance) {
+  if (coordinates.length <= 2 || !Number.isFinite(tolerance) || tolerance <= 0) {
+    return coordinates;
+  }
+  const keep = new Uint8Array(coordinates.length);
+  keep[0] = 1;
+  keep[coordinates.length - 1] = 1;
+  const toleranceSquared = tolerance ** 2;
+  const ranges = [[0, coordinates.length - 1]];
+  while (ranges.length) {
+    const [firstIndex, lastIndex] = ranges.pop();
+    let furthestIndex = -1;
+    let furthestDistance = toleranceSquared;
+    for (let index = firstIndex + 1; index < lastIndex; index += 1) {
+      const distance = squaredDistanceToSegment(
+        coordinates[index],
+        coordinates[firstIndex],
+        coordinates[lastIndex],
+      );
+      if (distance > furthestDistance) {
+        furthestDistance = distance;
+        furthestIndex = index;
+      }
+    }
+    if (furthestIndex < 0) continue;
+    keep[furthestIndex] = 1;
+    ranges.push([firstIndex, furthestIndex], [furthestIndex, lastIndex]);
+  }
+  return coordinates.filter((_, index) => keep[index]);
+}
+
 export function deriveShallowContours(
   parsed,
   levels = SHALLOW_CONTOUR_LEVELS,
   {
     featurePrefix = "emodnet-live",
+    simplifyTolerance = 0,
     sourceName = "EMODnet Bathymetry DTM 2024",
     warning = "Model-derived contour; not a charted sounding or safe clearance.",
   } = {},
@@ -488,10 +537,10 @@ export function deriveShallowContours(
     const lines = stitchSegments(contourSegments(depthGrid, level));
     lines.forEach((line, index) => {
       if (line.length < 3) return;
-      const coordinates = line.map(([row, column]) => [
+      const coordinates = simplifyLine(line.map(([row, column]) => [
         Number((parsed.transform.longitudeOrigin + column * parsed.transform.longitudeStep).toFixed(6)),
         Number((parsed.transform.latitudeOrigin + row * parsed.transform.latitudeStep).toFixed(6)),
-      ]);
+      ]), simplifyTolerance);
       if (lineLength(coordinates) < Math.abs(parsed.transform.longitudeStep) * 1.5) return;
       features.push({
         type: "Feature",

--- a/apps/website/map-data.test.mjs
+++ b/apps/website/map-data.test.mjs
@@ -16,6 +16,7 @@ import {
   parseGebcoGrid,
 } from "./emodnet-contours.mjs";
 import { sampleWindAt, windFieldGeoJson, windGrid, windRequestUrl } from "./wind-field.mjs";
+import { buildShadingContours } from "./contour-worker.mjs";
 import {
   currentEffect,
   currentFieldGeoJson,
@@ -60,14 +61,14 @@ test("builds a screen-resolution request for the EMODnet depth shading colours",
   assert.match(request.url, /layers=emodnet%3Amean/i);
   assert.match(request.url, /styles=multicolour/i);
   assert.match(request.legendUrl, /GetLegendGraphic/i);
-  assert.equal(request.gridWidth, 1024);
-  assert.equal(request.gridHeight, 768);
+  assert.equal(request.gridWidth, 896);
+  assert.equal(request.gridHeight, 672);
   assert.ok(boundsContain(request.bounds, { west: -5.2, south: 50.05, east: -4.95, north: 50.25 }));
 });
 
 test("refreshes a cached colour trace as the map zooms in", () => {
-  assert.equal(contourSampleSupportsZoom(10, 10.3), true);
-  assert.equal(contourSampleSupportsZoom(10, 10.5), false);
+  assert.equal(contourSampleSupportsZoom(10, 10.7), true);
+  assert.equal(contourSampleSupportsZoom(10, 10.8), false);
   assert.equal(contourSampleSupportsZoom(10, 9), true);
   assert.equal(contourSampleSupportsZoom(null, 10), false);
 });
@@ -123,8 +124,33 @@ test("recovers shallow depths from the official shading colour ramp", () => {
   const contours = deriveShallowContours(parsed, [5], {
     sourceName: "EMODnet multicolour depth shading",
   });
+  const simplified = deriveShallowContours(parsed, [5], {
+    simplifyTolerance: 0.04,
+    sourceName: "EMODnet multicolour depth shading",
+  });
   assert.equal(contours.features.length, 1);
   assert.equal(contours.features[0].properties.label, "5 m");
+  assert.ok(
+    simplified.features[0].geometry.coordinates.length <
+      contours.features[0].geometry.coordinates.length,
+  );
+
+  const workerContours = buildShadingContours({
+    bounds: { west: -5.2, south: 50.05, east: -4.95, north: 50.25 },
+    colourScale,
+    height: 4,
+    options: { sourceName: "EMODnet multicolour depth shading" },
+    pixels: pixels.buffer.slice(0),
+    width: 4,
+  });
+  const workerFiveMetreContours = workerContours.features.filter(
+    (feature) => feature.properties.depthM === 5,
+  );
+  assert.equal(workerFiveMetreContours.length, 1);
+  assert.ok(
+    workerFiveMetreContours[0].geometry.coordinates.length <
+      contours.features[0].geometry.coordinates.length,
+  );
 });
 
 test("parses negative seabed elevations into shallow contours", () => {

--- a/apps/website/planner.html
+++ b/apps/website/planner.html
@@ -290,6 +290,6 @@
       integrity="sha384-5+cfbwT0iiub6VsQAdn6yz16nr6sDiQoHx6tm4O8OVYXHYOxcffFmCJBL0dgdvGp"
       crossorigin="anonymous"
     ></script>
-    <script type="module" src="/planner.js?v=20260821-9"></script>
+    <script type="module" src="/planner.js?v=20260821-10"></script>
   </body>
 </html>

--- a/apps/website/planner.js
+++ b/apps/website/planner.js
@@ -22,7 +22,6 @@ import {
   EMODNET_COVERAGE,
   geometryContainsCoordinate,
   parseEmodnetColourScale,
-  parseEmodnetShadingGrid,
   parseGebcoGrid,
 } from "./emodnet-contours.mjs";
 import { windFieldGeoJson, windGrid, windRequestUrl } from "./wind-field.mjs";
@@ -144,6 +143,7 @@ let shallowContourBounds = null;
 let shallowContourProvider = null;
 let shallowContourSampleZoom = null;
 let shallowContourAbortController = null;
+let shallowContourWorkerJob = null;
 let emodnetColourScalePromise = null;
 let windRequestSequence = 0;
 let currentFieldRequestSequence = 0;
@@ -1787,6 +1787,45 @@ function loadEmodnetColourScale(url) {
   return emodnetColourScalePromise;
 }
 
+function cancelShadingContourWorker() {
+  if (!shallowContourWorkerJob) return;
+  const { reject, worker } = shallowContourWorkerJob;
+  shallowContourWorkerJob = null;
+  worker.terminate();
+  reject(new DOMException("Contour generation superseded.", "AbortError"));
+}
+
+function deriveShadingContoursInWorker(imageData, colourScale, bounds, options) {
+  cancelShadingContourWorker();
+  return new Promise((resolve, reject) => {
+    const worker = new Worker("/contour-worker.mjs", { type: "module" });
+    shallowContourWorkerJob = { reject, worker };
+    const finish = (callback, value) => {
+      if (shallowContourWorkerJob?.worker === worker) shallowContourWorkerJob = null;
+      worker.terminate();
+      callback(value);
+    };
+    worker.addEventListener("message", (event) => {
+      if (event.data?.error) {
+        finish(reject, new Error(event.data.error));
+      } else {
+        finish(resolve, event.data.contours);
+      }
+    });
+    worker.addEventListener("error", () => {
+      finish(reject, new Error("The browser contour worker failed."));
+    });
+    worker.postMessage({
+      bounds,
+      colourScale,
+      height: imageData.height,
+      options,
+      pixels: imageData.data.buffer,
+      width: imageData.width,
+    }, [imageData.data.buffer]);
+  });
+}
+
 async function updateShallowContours(force = false) {
   if (!mapReady || !elements.shallowContoursVisible.checked) return;
   const visibleBounds = visibleMapBounds();
@@ -1822,6 +1861,7 @@ async function updateShallowContours(force = false) {
   }
 
   shallowContourAbortController?.abort();
+  cancelShadingContourWorker();
   shallowContourAbortController = new AbortController();
   const controller = shallowContourAbortController;
   elements.shallowContourStatus.textContent = provider === "emodnet"
@@ -1833,34 +1873,37 @@ async function updateShallowContours(force = false) {
       signal: controller.signal,
     });
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
-    let parsed;
+    let contours;
     if (provider === "emodnet") {
       const [imageData, colourScale] = await Promise.all([
         responseImageData(response),
         loadEmodnetColourScale(request.legendUrl),
       ]);
-      parsed = parseEmodnetShadingGrid(imageData, colourScale, request.bounds);
+      contours = await deriveShadingContoursInWorker(
+        imageData,
+        colourScale,
+        request.bounds,
+        {
+          featurePrefix: "emodnet-shading",
+          sourceName: "EMODnet DTM 2024 multicolour depth shading",
+          warning:
+            "Dynamically traced from modelled depth-shading colours; not a charted sounding or safe clearance.",
+        },
+      );
     } else {
-      parsed = parseGebcoGrid(await response.text());
+      contours = deriveShallowContours(
+        parseGebcoGrid(await response.text()),
+        undefined,
+        {
+          featurePrefix: "gebco-live",
+          sourceName: "GEBCO 2026 Grid",
+          warning:
+            "Coarse global model-derived contour; not a charted sounding or safe clearance.",
+        },
+      );
     }
     if (controller !== shallowContourAbortController) return;
-    shallowContourData = deriveShallowContours(
-      parsed,
-      undefined,
-      provider === "emodnet"
-        ? {
-            featurePrefix: "emodnet-shading",
-            sourceName: "EMODnet DTM 2024 multicolour depth shading",
-            warning:
-              "Dynamically traced from modelled depth-shading colours; not a charted sounding or safe clearance.",
-          }
-        : {
-            featurePrefix: "gebco-live",
-            sourceName: "GEBCO 2026 Grid",
-            warning:
-              "Coarse global model-derived contour; not a charted sounding or safe clearance.",
-          },
-    );
+    shallowContourData = contours;
     shallowContourBounds = request.bounds;
     shallowContourProvider = provider;
     shallowContourSampleZoom = zoom;


### PR DESCRIPTION
## Summary
- trace colour-derived depth contours in a cancellable module worker so panning and zooming stay responsive
- reduce raster work and simplify generated contour geometry while preserving shallow-water detail
- reuse samples over a wider zoom range and permit the same-origin worker in the site CSP

## Performance
- Falmouth contour vertices: 15,036 -> 3,076 (79.5% reduction)
- generated GeoJSON: ~348 KB -> ~87 KB (74.9% reduction)
- sampled pixels: 786,432 -> 602,112 (23.4% reduction)

## Verification
- node --check apps/website/planner.js
- node --check apps/website/contour-worker.mjs
- node --check apps/website/emodnet-contours.mjs
- node --test apps/website/planner-core.test.mjs apps/website/map-data.test.mjs (30 passed)
- python3 -m unittest tools/contours/test_generate_emodnet_shallow_contours.py (2 passed)
- ./tools/build_website.sh
- git diff --check