### PR TITLE
fix: smooth contours and map interaction

### DIFF
--- a/apps/website/README.md
+++ b/apps/website/README.md
@@ -16,7 +16,7 @@ motorcycle preferences or cafe discovery.
 - OpenFreeMap general context and a toggleable OpenSeaMap seamark overlay;
 - toggleable EMODnet Bathymetry DTM 2024 depth shading with three transparent
   water-only palettes, on-demand 2/5/10/20/30 m contours dynamically traced at
-  screen resolution from the same official multicolour shading surface throughout
+  zoom-adaptive native-cell resolution from the same official multicolour shading surface throughout
   its North Atlantic and European coverage, a coarser GEBCO 2026 fallback elsewhere
   in the world, and EMODnet's generalised 50 m-and-deeper European overlay;
 - a zoom-adaptive wind field with downwind arrows, speed/time labels, gust detail,
@@ -49,12 +49,14 @@ OpenSeaMap, EMODnet, tide and weather data remain visibly attributed and carry
 their source limitations.
 
 The EMODnet shallow contours are decoded from its official styled-raster colour
-ramp and retraced off the main UI thread when the map zooms in. Sub-pixel line
-simplification keeps map interaction responsive without visibly changing the
-trace, and the result is clipped to water polygons from the visible basemap. The
-smoother screen-resolution trace does not add survey precision: the source grid
-is still about 115 m in EMODnet coverage and its coastline can differ from the
-general-purpose basemap.
+ramp and retraced off the main UI thread when the map zooms in. Repeated WMS
+display pixels are collapsed back to real model cells before interpolation;
+zoom-adaptive smoothing increases while simplification decreases as the user
+zooms closer. Image decoding and visible-water clipping also run in the worker,
+and map-driven overlay refreshes are coalesced after interaction settles. This
+smoother trace does not add survey precision: the source grid is still about
+115 m in EMODnet coverage and its coastline can differ from the general-purpose
+basemap.
 
 Run locally from the repository root:
 

--- a/apps/website/contour-worker.mjs
+++ b/apps/website/contour-worker.mjs
@@ -1,31 +1,132 @@
 import {
+  clipContoursToWater,
   deriveShallowContours,
+  geometryContainsCoordinate,
   parseEmodnetShadingGrid,
+  parseGebcoGrid,
 } from "./emodnet-contours.mjs";
 
-export function buildShadingContours({ bounds, colourScale, height, options, pixels, width }) {
+let storedContours = null;
+let storedSampleId = null;
+
+export function buildShadingContours({ bounds, colourScale, height, options = {}, pixels, width }) {
   const parsed = parseEmodnetShadingGrid(
     { width, height, data: new Uint8ClampedArray(pixels) },
     colourScale,
     bounds,
   );
+  const {
+    simplifyToleranceCells = 0.65,
+    ...deriveOptions
+  } = options;
   const simplifyTolerance = Math.max(
     Math.abs(parsed.transform.longitudeStep),
     Math.abs(parsed.transform.latitudeStep),
-  ) * 0.65;
+  ) * simplifyToleranceCells;
   return deriveShallowContours(parsed, undefined, {
-    ...options,
+    ...deriveOptions,
     simplifyTolerance,
   });
 }
 
+export function renderContoursForDisplay(
+  contours,
+  { adjustment = null, bounds = null, waterGeometries = [] } = {},
+) {
+  const clipped = waterGeometries.length
+    ? clipContoursToWater(
+        contours,
+        (coordinate) => waterGeometries.some((geometry) =>
+          geometryContainsCoordinate(geometry, coordinate)),
+        bounds,
+      )
+    : contours;
+  if (!adjustment || !Number.isFinite(Number(adjustment.heightM))) return clipped;
+  const tideHeight = Number(adjustment.heightM);
+  return {
+    ...clipped,
+    features: clipped.features.map((feature) => {
+      const depth = Number(feature.properties?.depthM);
+      const adjustedDepth = depth + tideHeight;
+      return {
+        ...feature,
+        properties: {
+          ...feature.properties,
+          adjustedDepthM: adjustedDepth,
+          displayLabel: `${depth} m ${adjustment.chartDatum} → ~${adjustedDepth.toFixed(1)} m`,
+          tideHeightM: tideHeight,
+          tideValidTime: adjustment.validTime,
+        },
+      };
+    }),
+  };
+}
+
+async function imageDataFromBlob(blob) {
+  if (typeof createImageBitmap !== "function" || typeof OffscreenCanvas !== "function") {
+    const error = new Error("Worker image decoding is unavailable.");
+    error.code = "IMAGE_DECODE_UNAVAILABLE";
+    throw error;
+  }
+  const bitmap = await createImageBitmap(blob);
+  try {
+    const canvas = new OffscreenCanvas(bitmap.width, bitmap.height);
+    const context = canvas.getContext("2d", { willReadFrequently: true });
+    if (!context) throw new Error("The contour worker could not read the depth image.");
+    context.drawImage(bitmap, 0, 0);
+    return context.getImageData(0, 0, bitmap.width, bitmap.height);
+  } finally {
+    bitmap.close?.();
+  }
+}
+
+export async function handleContourMessage(data) {
+  if (data.type === "derive-blob") {
+    const imageData = await imageDataFromBlob(data.imageBlob);
+    storedContours = buildShadingContours({
+      ...data,
+      height: imageData.height,
+      pixels: imageData.data.buffer,
+      width: imageData.width,
+    });
+    storedSampleId = data.sampleId;
+  } else if (data.type === "derive-pixels") {
+    storedContours = buildShadingContours(data);
+    storedSampleId = data.sampleId;
+  } else if (data.type === "derive-gebco") {
+    storedContours = deriveShallowContours(
+      parseGebcoGrid(data.text),
+      undefined,
+      data.options,
+    );
+    storedSampleId = data.sampleId;
+  } else if (data.type === "store") {
+    storedContours = data.contours;
+    storedSampleId = data.sampleId;
+  } else if (data.type === "render" && data.sampleId !== storedSampleId) {
+    throw new Error("The requested contour sample is no longer available.");
+  }
+  if (!storedContours || data.sampleId !== storedSampleId) {
+    throw new Error("No contour sample is available to render.");
+  }
+  return {
+    contours: renderContoursForDisplay(storedContours, data.display),
+    sourceFeatureCount: storedContours.features.length,
+  };
+}
+
 if (typeof self !== "undefined") {
-  self.addEventListener("message", (event) => {
+  self.addEventListener("message", async (event) => {
+    const { jobId, sampleId } = event.data;
     try {
-      self.postMessage({ contours: buildShadingContours(event.data) });
+      const result = await handleContourMessage(event.data);
+      self.postMessage({ ...result, jobId, sampleId });
     } catch (error) {
       self.postMessage({
+        code: error?.code,
         error: error instanceof Error ? error.message : "Contour generation failed.",
+        jobId,
+        sampleId,
       });
     }
   });

--- a/apps/website/emodnet-contours.mjs
+++ b/apps/website/emodnet-contours.mjs
@@ -14,18 +14,20 @@ const NATIVE_STEP_DEGREES = 1 / 960;
 const GEBCO_CELLS_PER_DEGREE = 240;
 const MAX_GRID_WIDTH = 512;
 const MAX_GRID_HEIGHT = 384;
-const MAX_SHADING_WIDTH = 896;
-const MAX_SHADING_HEIGHT = 672;
+const MAX_SHADING_WIDTH = 1280;
+const MAX_SHADING_HEIGHT = 960;
 const NUMBER_PATTERN = /[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[Ee][-+]?\d+)?/g;
 
 function paddedEmodnetBounds(bounds) {
   const width = bounds.east - bounds.west;
   const height = bounds.north - bounds.south;
+  const longitudePadding = Math.max(width * 0.16, NATIVE_STEP_DEGREES * 6);
+  const latitudePadding = Math.max(height * 0.16, NATIVE_STEP_DEGREES * 6);
   const requested = {
-    west: Math.max(EMODNET_COVERAGE.west, bounds.west - width * 0.16),
-    south: Math.max(EMODNET_COVERAGE.south, bounds.south - height * 0.16),
-    east: Math.min(EMODNET_COVERAGE.east, bounds.east + width * 0.16),
-    north: Math.min(EMODNET_COVERAGE.north, bounds.north + height * 0.16),
+    west: Math.max(EMODNET_COVERAGE.west, bounds.west - longitudePadding),
+    south: Math.max(EMODNET_COVERAGE.south, bounds.south - latitudePadding),
+    east: Math.min(EMODNET_COVERAGE.east, bounds.east + longitudePadding),
+    north: Math.min(EMODNET_COVERAGE.north, bounds.north + latitudePadding),
   };
   return requested.east > requested.west && requested.north > requested.south
     ? requested
@@ -68,8 +70,25 @@ export function createShadingContourRequest(bounds, zoom, viewport = {}) {
 
   const viewportWidth = Math.max(256, Number(viewport.width) || 768);
   const viewportHeight = Math.max(192, Number(viewport.height) || 576);
-  const width = Math.min(MAX_SHADING_WIDTH, Math.round(viewportWidth));
-  const height = Math.min(MAX_SHADING_HEIGHT, Math.round(viewportHeight));
+  const quality = contourQualityForZoom(zoom);
+  const nativeWidth = Math.max(
+    2,
+    Math.ceil((requested.east - requested.west) / NATIVE_STEP_DEGREES),
+  );
+  const nativeHeight = Math.max(
+    2,
+    Math.ceil((requested.north - requested.south) / NATIVE_STEP_DEGREES),
+  );
+  const width = Math.min(
+    MAX_SHADING_WIDTH,
+    nativeWidth,
+    Math.max(2, Math.round(viewportWidth * quality.rasterScale)),
+  );
+  const height = Math.min(
+    MAX_SHADING_HEIGHT,
+    nativeHeight,
+    Math.max(2, Math.round(viewportHeight * quality.rasterScale)),
+  );
   const parameters = new URLSearchParams({
     service: "WMS",
     version: "1.1.1",
@@ -97,6 +116,9 @@ export function createShadingContourRequest(bounds, zoom, viewport = {}) {
     bounds: requested,
     gridWidth: width,
     gridHeight: height,
+    nativeResolution: width === nativeWidth && height === nativeHeight,
+    simplifyToleranceCells: quality.simplifyToleranceCells,
+    smoothPasses: quality.smoothPasses,
     legendUrl: `${WMS_URL}?${legendParameters}`,
     url: `${WMS_URL}?${parameters}`,
   };
@@ -174,8 +196,23 @@ export function contourSampleSupportsZoom(sampleZoom, visibleZoom) {
   return Boolean(
     Number.isFinite(sampleZoom) &&
       Number.isFinite(visibleZoom) &&
-      visibleZoom <= sampleZoom + 0.75,
+      (visibleZoom <= sampleZoom ||
+        contourQualityForZoom(visibleZoom).level === contourQualityForZoom(sampleZoom).level),
   );
+}
+
+export function contourQualityForZoom(zoom) {
+  const value = Number(zoom);
+  if (value >= 15) {
+    return { level: 3, rasterScale: 1.3, simplifyToleranceCells: 0.18, smoothPasses: 3 };
+  }
+  if (value >= 13) {
+    return { level: 2, rasterScale: 1.12, simplifyToleranceCells: 0.3, smoothPasses: 2 };
+  }
+  if (value >= 11) {
+    return { level: 1, rasterScale: 0.92, simplifyToleranceCells: 0.45, smoothPasses: 1 };
+  }
+  return { level: 0, rasterScale: 0.68, simplifyToleranceCells: 0.65, smoothPasses: 0 };
 }
 
 export function parseEmodnetGrid(text) {
@@ -309,15 +346,15 @@ function elevationFromColour(colour, scale) {
 }
 
 export function parseEmodnetShadingGrid(imageData, colourScale, bounds) {
-  const width = Number(imageData?.width);
-  const height = Number(imageData?.height);
+  const sourceWidth = Number(imageData?.width);
+  const sourceHeight = Number(imageData?.height);
   const pixels = imageData?.data;
   if (
-    !Number.isInteger(width) ||
-    !Number.isInteger(height) ||
-    width < 2 ||
-    height < 2 ||
-    pixels?.length !== width * height * 4 ||
+    !Number.isInteger(sourceWidth) ||
+    !Number.isInteger(sourceHeight) ||
+    sourceWidth < 2 ||
+    sourceHeight < 2 ||
+    pixels?.length !== sourceWidth * sourceHeight * 4 ||
     !bounds ||
     bounds.east <= bounds.west ||
     bounds.north <= bounds.south ||
@@ -327,11 +364,31 @@ export function parseEmodnetShadingGrid(imageData, colourScale, bounds) {
     throw new Error("The depth shading image was incomplete.");
   }
 
+  // GeoServer expands the roughly 1/960° EMODnet cells with nearest-neighbour
+  // pixels when the requested image is larger than the source grid. Trace one
+  // sample per real model cell so marching squares interpolates between depth
+  // samples instead of following the edges of those repeated display pixels.
+  const width = Math.min(
+    sourceWidth,
+    Math.max(2, Math.ceil((bounds.east - bounds.west) / NATIVE_STEP_DEGREES)),
+  );
+  const height = Math.min(
+    sourceHeight,
+    Math.max(2, Math.ceil((bounds.north - bounds.south) / NATIVE_STEP_DEGREES)),
+  );
   const colourCache = new Map();
   const rows = Array.from({ length: height }, () => Array(width));
   for (let row = 0; row < height; row += 1) {
+    const sourceRow = Math.min(
+      sourceHeight - 1,
+      Math.floor(((row + 0.5) / height) * sourceHeight),
+    );
     for (let column = 0; column < width; column += 1) {
-      const offset = (row * width + column) * 4;
+      const sourceColumn = Math.min(
+        sourceWidth - 1,
+        Math.floor(((column + 0.5) / width) * sourceWidth),
+      );
+      const offset = (sourceRow * sourceWidth + sourceColumn) * 4;
       if (pixels[offset + 3] < 128) {
         rows[row][column] = Number.NaN;
         continue;
@@ -521,12 +578,37 @@ function simplifyLine(coordinates, tolerance) {
   return coordinates.filter((_, index) => keep[index]);
 }
 
+function smoothLine(points, passes) {
+  let result = points;
+  const passCount = Math.max(0, Math.min(4, Math.floor(Number(passes) || 0)));
+  for (let pass = 0; pass < passCount && result.length > 3; pass += 1) {
+    const closed = pointKey(result[0]) === pointKey(result.at(-1));
+    const uniqueLength = closed ? result.length - 1 : result.length;
+    const next = result.map((point) => [...point]);
+    const start = closed ? 0 : 1;
+    const end = closed ? uniqueLength : uniqueLength - 1;
+    for (let index = start; index < end; index += 1) {
+      const previous = result[(index - 1 + uniqueLength) % uniqueLength];
+      const current = result[index];
+      const following = result[(index + 1) % uniqueLength];
+      next[index] = [
+        previous[0] * 0.25 + current[0] * 0.5 + following[0] * 0.25,
+        previous[1] * 0.25 + current[1] * 0.5 + following[1] * 0.25,
+      ];
+    }
+    if (closed) next[next.length - 1] = [...next[0]];
+    result = next;
+  }
+  return result;
+}
+
 export function deriveShallowContours(
   parsed,
   levels = SHALLOW_CONTOUR_LEVELS,
   {
     featurePrefix = "emodnet-live",
     simplifyTolerance = 0,
+    smoothPasses = 0,
     sourceName = "EMODnet Bathymetry DTM 2024",
     warning = "Model-derived contour; not a charted sounding or safe clearance.",
   } = {},
@@ -537,7 +619,7 @@ export function deriveShallowContours(
     const lines = stitchSegments(contourSegments(depthGrid, level));
     lines.forEach((line, index) => {
       if (line.length < 3) return;
-      const coordinates = simplifyLine(line.map(([row, column]) => [
+      const coordinates = simplifyLine(smoothLine(line, smoothPasses).map(([row, column]) => [
         Number((parsed.transform.longitudeOrigin + column * parsed.transform.longitudeStep).toFixed(6)),
         Number((parsed.transform.latitudeOrigin + row * parsed.transform.latitudeStep).toFixed(6)),
       ]), simplifyTolerance);

--- a/apps/website/map-data.test.mjs
+++ b/apps/website/map-data.test.mjs
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import {
   boundsContain,
   clipContoursToWater,
+  contourQualityForZoom,
   contourSampleSupportsZoom,
   createContourRequest,
   createGebcoContourRequest,
@@ -16,7 +17,11 @@ import {
   parseGebcoGrid,
 } from "./emodnet-contours.mjs";
 import { sampleWindAt, windFieldGeoJson, windGrid, windRequestUrl } from "./wind-field.mjs";
-import { buildShadingContours } from "./contour-worker.mjs";
+import {
+  buildShadingContours,
+  handleContourMessage,
+  renderContoursForDisplay,
+} from "./contour-worker.mjs";
 import {
   currentEffect,
   currentFieldGeoJson,
@@ -51,7 +56,7 @@ test("builds a bounded EMODnet request across England", () => {
   assert.ok(boundsContain(request.bounds, { west: -5, south: 50, east: 1, north: 55 }));
 });
 
-test("builds a screen-resolution request for the EMODnet depth shading colours", () => {
+test("caps the EMODnet colour trace at the real model-cell resolution", () => {
   const request = createShadingContourRequest(
     { west: -5.2, south: 50.05, east: -4.95, north: 50.25 },
     12,
@@ -61,16 +66,34 @@ test("builds a screen-resolution request for the EMODnet depth shading colours",
   assert.match(request.url, /layers=emodnet%3Amean/i);
   assert.match(request.url, /styles=multicolour/i);
   assert.match(request.legendUrl, /GetLegendGraphic/i);
-  assert.equal(request.gridWidth, 896);
-  assert.equal(request.gridHeight, 672);
+  assert.equal(request.gridWidth, 317);
+  assert.equal(request.gridHeight, 254);
+  assert.equal(request.nativeResolution, true);
+  assert.equal(request.smoothPasses, 1);
+  assert.equal(request.simplifyToleranceCells, 0.45);
   assert.ok(boundsContain(request.bounds, { west: -5.2, south: 50.05, east: -4.95, north: 50.25 }));
+
+  const broadRequest = createShadingContourRequest(
+    { west: -5.8, south: 49.8, east: 1.8, north: 55.9 },
+    9,
+    { width: 900, height: 700 },
+  );
+  assert.equal(broadRequest.gridWidth, 612);
+  assert.equal(broadRequest.gridHeight, 476);
+  assert.equal(broadRequest.nativeResolution, false);
 });
 
 test("refreshes a cached colour trace as the map zooms in", () => {
-  assert.equal(contourSampleSupportsZoom(10, 10.7), true);
-  assert.equal(contourSampleSupportsZoom(10, 10.8), false);
+  assert.equal(contourSampleSupportsZoom(10, 10.5), true);
+  assert.equal(contourSampleSupportsZoom(10, 10.9), true);
+  assert.equal(contourSampleSupportsZoom(10.9, 11), false);
+  assert.equal(contourSampleSupportsZoom(13, 13.5), true);
   assert.equal(contourSampleSupportsZoom(10, 9), true);
   assert.equal(contourSampleSupportsZoom(null, 10), false);
+  assert.equal(contourQualityForZoom(10).smoothPasses, 0);
+  assert.equal(contourQualityForZoom(12).smoothPasses, 1);
+  assert.equal(contourQualityForZoom(14).smoothPasses, 2);
+  assert.equal(contourQualityForZoom(15).smoothPasses, 3);
 });
 
 test("recovers shallow depths from the official shading colour ramp", () => {
@@ -150,6 +173,36 @@ test("recovers shallow depths from the official shading colour ramp", () => {
   assert.ok(
     workerFiveMetreContours[0].geometry.coordinates.length <
       contours.features[0].geometry.coordinates.length,
+  );
+});
+
+test("collapses repeated display pixels before tracing native depth cells", () => {
+  const colourScale = [
+    { elevation: -10, colour: [0, 0, 255] },
+    { elevation: 0, colour: [255, 0, 0] },
+  ];
+  const pixels = new Uint8ClampedArray(8 * 8 * 4);
+  for (let row = 0; row < 8; row += 1) {
+    for (let column = 0; column < 8; column += 1) {
+      const offset = (row * 8 + column) * 4;
+      const deep = row >= 2 && row < 6 && column >= 2 && column < 6;
+      pixels.set(deep ? [0, 0, 255, 255] : [255, 0, 0, 255], offset);
+    }
+  }
+  const parsed = parseEmodnetShadingGrid(
+    { width: 8, height: 8, data: pixels },
+    colourScale,
+    { west: 0, south: 0, east: 4 / 960, north: 4 / 960 },
+  );
+  assert.equal(parsed.rows.length, 4);
+  assert.equal(parsed.rows[0].length, 4);
+
+  const unsmoothed = deriveShallowContours(parsed, [5]);
+  const smoothed = deriveShallowContours(parsed, [5], { smoothPasses: 2 });
+  assert.equal(smoothed.features.length, unsmoothed.features.length);
+  assert.notDeepEqual(
+    smoothed.features[0].geometry.coordinates,
+    unsmoothed.features[0].geometry.coordinates,
   );
 });
 
@@ -236,6 +289,59 @@ test("clips only the on-land pieces of a connected contour", () => {
   assert.deepEqual(
     clipped.features.map((feature) => feature.geometry.coordinates),
     [[[0, 0], [1, 0]], [[3, 0], [4, 0]]],
+  );
+});
+
+test("clips and tide-adjusts contours in the worker display pipeline", () => {
+  const contours = {
+    type: "FeatureCollection",
+    features: [{
+      type: "Feature",
+      id: "five-metres",
+      properties: { depthM: 5, label: "5 m" },
+      geometry: { type: "LineString", coordinates: [[0, 0.5], [1, 0.5], [2, 0.5]] },
+    }],
+  };
+  const displayed = renderContoursForDisplay(contours, {
+    adjustment: { chartDatum: "LAT", heightM: 1.2, validTime: "2026-08-22T00:00:00Z" },
+    bounds: { west: 0, south: 0, east: 2, north: 1 },
+    waterGeometries: [{
+      type: "Polygon",
+      coordinates: [[[0, 0], [1.1, 0], [1.1, 1], [0, 1], [0, 0]]],
+    }],
+  });
+  assert.equal(displayed.features.length, 1);
+  assert.deepEqual(displayed.features[0].geometry.coordinates, [[0, 0.5], [1, 0.5]]);
+  assert.equal(displayed.features[0].properties.adjustedDepthM, 6.2);
+  assert.match(displayed.features[0].properties.displayLabel, /~6\.2 m/);
+});
+
+test("reuses a stored contour sample for later viewport renders", async () => {
+  const contours = {
+    type: "FeatureCollection",
+    features: [{
+      type: "Feature",
+      id: "ten-metres",
+      properties: { depthM: 10, label: "10 m" },
+      geometry: { type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0]] },
+    }],
+  };
+  const stored = await handleContourMessage({
+    contours,
+    display: {},
+    sampleId: "sample-a",
+    type: "store",
+  });
+  assert.equal(stored.sourceFeatureCount, 1);
+  const rerendered = await handleContourMessage({
+    display: { adjustment: { chartDatum: "LAT", heightM: 0.8 } },
+    sampleId: "sample-a",
+    type: "render",
+  });
+  assert.equal(rerendered.contours.features[0].properties.adjustedDepthM, 10.8);
+  await assert.rejects(
+    handleContourMessage({ display: {}, sampleId: "sample-b", type: "render" }),
+    /no longer available/,
   );
 });
 

--- a/apps/website/planner.html
+++ b/apps/website/planner.html
@@ -290,6 +290,6 @@
       integrity="sha384-5+cfbwT0iiub6VsQAdn6yz16nr6sDiQoHx6tm4O8OVYXHYOxcffFmCJBL0dgdvGp"
       crossorigin="anonymous"
     ></script>
-    <script type="module" src="/planner.js?v=20260821-10"></script>
+    <script type="module" src="/planner.js?v=20260822-1"></script>
   </body>
 </html>

--- a/apps/website/planner.js
+++ b/apps/website/planner.js
@@ -14,15 +14,12 @@ import {
 } from "./planner-storage.mjs";
 import {
   boundsContain,
-  clipContoursToWater,
   contourSampleSupportsZoom,
   createGebcoContourRequest,
   createShadingContourRequest,
-  deriveShallowContours,
   EMODNET_COVERAGE,
   geometryContainsCoordinate,
   parseEmodnetColourScale,
-  parseGebcoGrid,
 } from "./emodnet-contours.mjs";
 import { windFieldGeoJson, windGrid, windRequestUrl } from "./wind-field.mjs";
 import {
@@ -142,8 +139,14 @@ let shallowContourData = EMPTY_FEATURE_COLLECTION;
 let shallowContourBounds = null;
 let shallowContourProvider = null;
 let shallowContourSampleZoom = null;
+let shallowContourSampleId = null;
+let shallowContourSampleSequence = 0;
 let shallowContourAbortController = null;
-let shallowContourWorkerJob = null;
+let shallowContourWorker = null;
+let shallowContourWorkerJobSequence = 0;
+let shallowContourWorkerJobs = new Map();
+let shallowContourRenderSequence = 0;
+let shallowContourRenderTimer = null;
 let emodnetColourScalePromise = null;
 let windRequestSequence = 0;
 let currentFieldRequestSequence = 0;
@@ -156,6 +159,7 @@ let marineRefreshPending = { field: false, route: false };
 let tideTableRequestSequence = 0;
 let sunRequestSequence = 0;
 let environmentRefreshTimer = null;
+let mapMoveRefreshTimer = null;
 
 restoreDraft();
 syncTimeSliderFromStart();
@@ -591,11 +595,26 @@ window.addEventListener("tideandseekthemechange", (event) => {
   map.setStyle(MAP_STYLE_URLS[theme]);
 });
 
+map.on("movestart", () => {
+  clearTimeout(mapMoveRefreshTimer);
+  clearTimeout(shallowContourRenderTimer);
+  shallowContourAbortController?.abort();
+  shallowContourAbortController = null;
+  shallowContourRenderSequence += 1;
+  windRequestSequence += 1;
+  currentFieldRequestSequence += 1;
+  tideTableRequestSequence += 1;
+  sunRequestSequence += 1;
+});
+
 map.on("moveend", () => {
-  updateShallowContours();
-  if (elements.windVisible.checked) updateWindField();
-  if (elements.currentVisible.checked) updateCurrentField();
-  scheduleEnvironmentRefresh();
+  clearTimeout(mapMoveRefreshTimer);
+  mapMoveRefreshTimer = setTimeout(() => {
+    updateShallowContours();
+    if (elements.windVisible.checked) updateWindField();
+    if (elements.currentVisible.checked) updateCurrentField();
+  }, 180);
+  scheduleEnvironmentRefresh(420);
 });
 
 map.on("click", async (event) => {
@@ -1261,7 +1280,8 @@ async function updateCurrentField() {
   const canvas = map.getCanvas();
   const dimensions = currentGridDimensions(canvas.clientWidth, canvas.clientHeight, map.getZoom());
   const candidates = marineGrid(bounds, dimensions.columns, dimensions.rows);
-  const points = waterOnlyModelPoints(candidates);
+  const waterContainsPoint = renderedWaterContainsPoint();
+  const points = waterOnlyModelPoints(candidates, waterContainsPoint);
   if (points.length === 0) {
     map.getSource("current-field")?.setData(EMPTY_FEATURE_COLLECTION);
     elements.currentStatus.textContent = "No basemap water cells are visible for the current field.";
@@ -1286,8 +1306,8 @@ async function updateCurrentField() {
       dimensions.columns,
       dimensions.rows,
     );
-    const waterSamples = field.samples.filter((sample) => basemapShowsWater(sample.point));
-    const visibleField = currentFeaturesOverWater(field.geojson);
+    const waterSamples = field.samples.filter((sample) => waterContainsPoint(sample.point));
+    const visibleField = currentFeaturesOverWater(field.geojson, waterContainsPoint);
     if (visibleField.features.length === 0) throw new Error("no visible model sea cells");
     map.getSource("current-field")?.setData(visibleField);
     const centre = {
@@ -1719,34 +1739,49 @@ function refreshDepthAdjustment() {
 
 function syncAdjustedContourData() {
   if (!mapReady) return shallowContourData;
-  const waterPredicate = renderedWaterPredicate();
-  const waterClippedData = waterPredicate
-    ? clipContoursToWater(shallowContourData, waterPredicate, visibleMapBounds())
-    : shallowContourData;
-  const data = currentDepthAdjustment
-    ? {
-        ...waterClippedData,
-        features: waterClippedData.features.map((feature) => {
-          const adjustedDepth = Number(feature.properties?.depthM) + currentDepthAdjustment.heightM;
-          return {
-            ...feature,
-            properties: {
-              ...feature.properties,
-              adjustedDepthM: adjustedDepth,
-              displayLabel: `${feature.properties.depthM} m ${currentDepthAdjustment.chartDatum} → ~${adjustedDepth.toFixed(1)} m`,
-              tideHeightM: currentDepthAdjustment.heightM,
-              tideValidTime: marineDepthContext?.validTime,
-            },
-          };
-        }),
+  clearTimeout(shallowContourRenderTimer);
+  const sampleId = shallowContourSampleId;
+  if (!sampleId || !shallowContourWorker) {
+    map.getSource("shallow-contours")?.setData(shallowContourData);
+    return shallowContourData;
+  }
+  const renderSequence = ++shallowContourRenderSequence;
+  shallowContourRenderTimer = setTimeout(async () => {
+    try {
+      const result = await contourWorkerRequest("render", {
+        display: contourDisplayContext(),
+        sampleId,
+      });
+      if (
+        renderSequence !== shallowContourRenderSequence ||
+        sampleId !== shallowContourSampleId
+      ) return;
+      shallowContourData = result.contours;
+      map.getSource("shallow-contours")?.setData(shallowContourData);
+    } catch (error) {
+      if (error.name !== "AbortError") {
+        elements.shallowContourStatus.textContent = `Contours could not be refreshed (${error.message}).`;
       }
-    : waterClippedData;
-  map.getSource("shallow-contours")?.setData(data);
-  return data;
+    }
+  }, 0);
+  return shallowContourData;
 }
 
-async function responseImageData(response) {
-  const blob = await response.blob();
+function contourDisplayContext(adjustment = currentDepthAdjustment) {
+  return {
+    adjustment
+      ? {
+          chartDatum: adjustment.chartDatum,
+          heightM: adjustment.heightM,
+          validTime: marineDepthContext?.validTime,
+        }
+      : null,
+    bounds: visibleMapBounds(),
+    waterGeometries: renderedWaterGeometries(),
+  };
+}
+
+async function imageDataFromBlob(blob) {
   let objectUrl = null;
   const bitmap = typeof createImageBitmap === "function"
     ? await createImageBitmap(blob)
@@ -1787,43 +1822,78 @@ function loadEmodnetColourScale(url) {
   return emodnetColourScalePromise;
 }
 
-function cancelShadingContourWorker() {
-  if (!shallowContourWorkerJob) return;
-  const { reject, worker } = shallowContourWorkerJob;
-  shallowContourWorkerJob = null;
-  worker.terminate();
-  reject(new DOMException("Contour generation superseded.", "AbortError"));
+function ensureContourWorker() {
+  if (shallowContourWorker) return shallowContourWorker;
+  const worker = new Worker("/contour-worker.mjs?v=20260822-1", { type: "module" });
+  shallowContourWorker = worker;
+  worker.addEventListener("message", (event) => {
+    const job = shallowContourWorkerJobs.get(event.data?.jobId);
+    if (!job) return;
+    shallowContourWorkerJobs.delete(event.data.jobId);
+    if (event.data?.error) {
+      const error = new Error(event.data.error);
+      error.code = event.data.code;
+      job.reject(error);
+    } else {
+      job.resolve(event.data);
+    }
+  });
+  worker.addEventListener("error", () => {
+    if (shallowContourWorker !== worker) return;
+    const error = new Error("The browser contour worker failed.");
+    for (const job of shallowContourWorkerJobs.values()) job.reject(error);
+    shallowContourWorkerJobs.clear();
+    shallowContourWorker = null;
+  });
+  return worker;
 }
 
-function deriveShadingContoursInWorker(imageData, colourScale, bounds, options) {
-  cancelShadingContourWorker();
+function restartContourWorker() {
+  const error = new DOMException("Contour generation superseded.", "AbortError");
+  for (const job of shallowContourWorkerJobs.values()) job.reject(error);
+  shallowContourWorkerJobs.clear();
+  shallowContourWorker?.terminate();
+  shallowContourWorker = null;
+  return ensureContourWorker();
+}
+
+function contourWorkerRequest(type, payload, transfer = []) {
+  const worker = ensureContourWorker();
+  const jobId = ++shallowContourWorkerJobSequence;
   return new Promise((resolve, reject) => {
-    const worker = new Worker("/contour-worker.mjs", { type: "module" });
-    shallowContourWorkerJob = { reject, worker };
-    const finish = (callback, value) => {
-      if (shallowContourWorkerJob?.worker === worker) shallowContourWorkerJob = null;
-      worker.terminate();
-      callback(value);
-    };
-    worker.addEventListener("message", (event) => {
-      if (event.data?.error) {
-        finish(reject, new Error(event.data.error));
-      } else {
-        finish(resolve, event.data.contours);
-      }
-    });
-    worker.addEventListener("error", () => {
-      finish(reject, new Error("The browser contour worker failed."));
-    });
-    worker.postMessage({
-      bounds,
-      colourScale,
+    shallowContourWorkerJobs.set(jobId, { reject, resolve });
+    worker.postMessage({ ...payload, jobId, type }, transfer);
+  });
+}
+
+async function deriveShadingContoursInWorker(
+  imageBlob,
+  colourScale,
+  bounds,
+  options,
+  sampleId,
+  display,
+) {
+  const payload = {
+    bounds,
+    colourScale,
+    display,
+    imageBlob,
+    options,
+    sampleId,
+  };
+  try {
+    return await contourWorkerRequest("derive-blob", payload);
+  } catch (error) {
+    if (error.code !== "IMAGE_DECODE_UNAVAILABLE") throw error;
+    const imageData = await imageDataFromBlob(imageBlob);
+    return contourWorkerRequest("derive-pixels", {
+      ...payload,
       height: imageData.height,
-      options,
       pixels: imageData.data.buffer,
       width: imageData.width,
     }, [imageData.data.buffer]);
-  });
+  }
 }
 
 async function updateShallowContours(force = false) {
@@ -1846,13 +1916,16 @@ async function updateShallowContours(force = false) {
     shallowContourBounds = null;
     shallowContourProvider = null;
     shallowContourSampleZoom = null;
+    shallowContourSampleId = null;
     shallowContourData = EMPTY_FEATURE_COLLECTION;
+    map.getSource("shallow-contours")?.setData(shallowContourData);
     refreshDepthAdjustment();
     return;
   }
   if (
     !force &&
     shallowContourProvider === provider &&
+    shallowContourSampleId &&
     boundsContain(shallowContourBounds, visibleBounds) &&
     contourSampleSupportsZoom(shallowContourSampleZoom, zoom)
   ) {
@@ -1861,9 +1934,15 @@ async function updateShallowContours(force = false) {
   }
 
   shallowContourAbortController?.abort();
-  cancelShadingContourWorker();
+  restartContourWorker();
+  shallowContourSampleId = null;
   shallowContourAbortController = new AbortController();
   const controller = shallowContourAbortController;
+  const sampleId = `contour-${++shallowContourSampleSequence}`;
+  const nextDepthAdjustment = marineDepthContext
+    ? depthAdjustmentFor({ provider, ...marineDepthContext })
+    : null;
+  const display = contourDisplayContext(nextDepthAdjustment);
   elements.shallowContourStatus.textContent = provider === "emodnet"
     ? "Tracing shallow contours from the visible EMODnet depth colours…"
     : "Loading the global GEBCO grid and deriving contours for this map area…";
@@ -1873,48 +1952,59 @@ async function updateShallowContours(force = false) {
       signal: controller.signal,
     });
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
-    let contours;
+    let result;
     if (provider === "emodnet") {
-      const [imageData, colourScale] = await Promise.all([
-        responseImageData(response),
+      const [imageBlob, colourScale] = await Promise.all([
+        response.blob(),
         loadEmodnetColourScale(request.legendUrl),
       ]);
-      contours = await deriveShadingContoursInWorker(
-        imageData,
+      result = await deriveShadingContoursInWorker(
+        imageBlob,
         colourScale,
         request.bounds,
         {
           featurePrefix: "emodnet-shading",
+          simplifyToleranceCells: request.simplifyToleranceCells,
+          smoothPasses: request.smoothPasses,
           sourceName: "EMODnet DTM 2024 multicolour depth shading",
           warning:
             "Dynamically traced from modelled depth-shading colours; not a charted sounding or safe clearance.",
         },
+        sampleId,
+        display,
       );
     } else {
-      contours = deriveShallowContours(
-        parseGebcoGrid(await response.text()),
-        undefined,
-        {
+      result = await contourWorkerRequest("derive-gebco", {
+        display,
+        options: {
           featurePrefix: "gebco-live",
           sourceName: "GEBCO 2026 Grid",
           warning:
             "Coarse global model-derived contour; not a charted sounding or safe clearance.",
         },
-      );
+        sampleId,
+        text: await response.text(),
+      });
     }
     if (controller !== shallowContourAbortController) return;
-    shallowContourData = contours;
+    shallowContourData = result.contours;
     shallowContourBounds = request.bounds;
     shallowContourProvider = provider;
     shallowContourSampleZoom = zoom;
+    shallowContourSampleId = sampleId;
+    currentDepthAdjustment = nextDepthAdjustment;
+    map.getSource("shallow-contours")?.setData(shallowContourData);
     refreshDepthAdjustment();
     if (provider === "emodnet") {
-      elements.shallowContourStatus.textContent = `${shallowContourData.features.length.toLocaleString("en-GB")} lines dynamically traced from the ${request.gridWidth}×${request.gridHeight} EMODnet colour surface · underlying model cells remain about 115 m · clipped to visible basemap water.`;
+      const resolution = request.nativeResolution
+        ? "native model-cell sampling"
+        : "screen-adaptive sampling";
+      elements.shallowContourStatus.textContent = `${result.sourceFeatureCount.toLocaleString("en-GB")} smoothed lines dynamically traced with ${resolution} from the ${request.gridWidth}×${request.gridHeight} EMODnet colour surface · underlying model cells remain about 115 m · clipped to visible basemap water off the UI thread.`;
     } else {
       const resolution = request.resolutionLimited
         ? "high-detail view sampling; zoom closer for the native grid"
         : "native 15 arc-second model grid";
-      elements.shallowContourStatus.textContent = `${shallowContourData.features.length.toLocaleString("en-GB")} connected GEBCO global fallback lines for this area · ${resolution} · clipped to visible basemap water.`;
+      elements.shallowContourStatus.textContent = `${result.sourceFeatureCount.toLocaleString("en-GB")} connected GEBCO global fallback lines for this area · ${resolution} · clipped to visible basemap water off the UI thread.`;
     }
   } catch (error) {
     if (error.name === "AbortError") return;
@@ -1932,12 +2022,12 @@ function visibleMapBounds() {
   };
 }
 
-function waterOnlyModelPoints(points) {
+function waterOnlyModelPoints(points, waterContainsPoint = renderedWaterContainsPoint()) {
   if (!mapReady || !map.getLayer("water")) return points;
-  return points.filter(basemapShowsWater);
+  return points.filter(waterContainsPoint);
 }
 
-function currentFeaturesOverWater(geojson) {
+function currentFeaturesOverWater(geojson, waterContainsPoint = renderedWaterContainsPoint()) {
   if (!mapReady || !map.getLayer("water")) return geojson;
   return {
     ...geojson,
@@ -1945,39 +2035,31 @@ function currentFeaturesOverWater(geojson) {
       const longitude = Number(feature.properties?.anchorLongitude);
       const latitude = Number(feature.properties?.anchorLatitude);
       return !Number.isFinite(longitude) || !Number.isFinite(latitude) ||
-        basemapShowsWater({ longitude, latitude });
+        waterContainsPoint({ longitude, latitude });
     }),
   };
 }
 
-function basemapShowsWater(point) {
-  try {
-    return map.queryRenderedFeatures(
-      map.project([point.longitude, point.latitude]),
-      { layers: ["water"] },
-    ).length > 0;
-  } catch {
-    return true;
-  }
-}
-
-function renderedWaterPredicate() {
-  if (!mapReady || !map.getLayer("water")) return null;
-  let geometries;
+function renderedWaterGeometries() {
+  if (!mapReady || !map.getLayer("water")) return [];
   try {
     const canvas = map.getCanvas();
-    geometries = map.queryRenderedFeatures(
+    return map.queryRenderedFeatures(
       [[0, 0], [canvas.clientWidth, canvas.clientHeight]],
       { layers: ["water"] },
     )
       .map((feature) => feature.geometry)
       .filter(Boolean);
   } catch {
-    return null;
+    return [];
   }
-  if (!geometries.length) return null;
-  return (coordinate) => geometries.some((geometry) =>
-    geometryContainsCoordinate(geometry, coordinate));
+}
+
+function renderedWaterContainsPoint() {
+  const geometries = renderedWaterGeometries();
+  if (!geometries.length) return () => true;
+  return ({ longitude, latitude }) => geometries.some((geometry) =>
+    geometryContainsCoordinate(geometry, [longitude, latitude]));
 }
 
 function fitPassage() {


### PR DESCRIPTION
## Summary
- collapse repeated EMODnet WMS display pixels back to native model cells before tracing so contour interpolation no longer follows visible pixel blocks
- progressively increase smoothing and reduce simplification at closer zoom levels while retaining the source-resolution safety warning
- move image decoding, GEBCO derivation, water clipping and tide-label updates into a persistent contour worker
- coalesce pan/zoom overlay refreshes and reuse one rendered-water lookup for current filtering

## Performance
Falmouth benchmark for the contour pipeline:
- samples: 602,112 -> 80,518 (86.6% reduction)
- displayed GeoJSON: ~87 KB -> ~37 KB (57% reduction)
- displayed vertices: 3,076 -> 1,133 (63% reduction)
- worker derivation: ~164 ms -> ~79 ms
- worker water clip: ~2 ms and no longer blocks the UI thread

## Verification
- node --check apps/website/planner.js
- node --check apps/website/contour-worker.mjs
- node --check apps/website/emodnet-contours.mjs
- node --test apps/website/planner-core.test.mjs apps/website/map-data.test.mjs (33 passed)
- python3 -m unittest tools/contours/test_generate_emodnet_shallow_contours.py (2 passed)
- ./tools/build_website.sh
- local HTTP smoke checks for planner and module worker
- git diff --check