### PR TITLE
fix: restore planner map loading

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,0 +1,38 @@
+name: Website CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/website/**'
+      - 'tools/build_website.sh'
+      - 'tools/contours/**'
+      - 'tools/places/**'
+      - '.github/workflows/website.yml'
+  pull_request:
+    paths:
+      - 'apps/website/**'
+      - 'tools/build_website.sh'
+      - 'tools/contours/**'
+      - 'tools/places/**'
+      - '.github/workflows/website.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: website-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: Syntax, test and build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - run: node --test apps/website/browser-syntax.test.mjs apps/website/planner-core.test.mjs apps/website/map-data.test.mjs
+      - run: python3 -m unittest tools/places/test_generate_sailing_pois.py
+      - run: python3 -m unittest tools/contours/test_generate_emodnet_shallow_contours.py
+      - run: ./tools/build_website.sh
+      - run: test -f build/website/planner.js

--- a/README.md
+++ b/README.md
@@ -79,8 +79,7 @@ uv run pytest
 ```
 
 ```bash
-node --check apps/website/planner.js
-node --test apps/website/planner-core.test.mjs
+node --test apps/website/browser-syntax.test.mjs apps/website/planner-core.test.mjs apps/website/map-data.test.mjs
 python3 -m unittest tools/places/test_generate_sailing_pois.py
 ```
 

--- a/apps/website/README.md
+++ b/apps/website/README.md
@@ -76,8 +76,7 @@ The public static build is assembled and deployed to Cloudflare Pages using
 Focused verification:
 
 ```sh
-node --check apps/website/planner.js
-node --test apps/website/planner-core.test.mjs apps/website/map-data.test.mjs
+node --test apps/website/browser-syntax.test.mjs apps/website/planner-core.test.mjs apps/website/map-data.test.mjs
 python3 -m unittest tools/places/test_generate_sailing_pois.py
 python3 -m unittest tools/contours/test_generate_emodnet_shallow_contours.py
 ```

--- a/apps/website/browser-syntax.test.mjs
+++ b/apps/website/browser-syntax.test.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+test("production browser modules use valid JavaScript syntax", () => {
+  const directory = new URL(".", import.meta.url);
+  const modulePaths = readdirSync(directory, { withFileTypes: true })
+    .filter((entry) =>
+      entry.isFile() &&
+      (entry.name.endsWith(".js") || entry.name.endsWith(".mjs")) &&
+      !entry.name.endsWith(".test.mjs"))
+    .map((entry) => fileURLToPath(new URL(entry.name, directory)));
+  const parser = `
+    import { readFileSync } from "node:fs";
+    import { SourceTextModule } from "node:vm";
+    for (const modulePath of ${JSON.stringify(modulePaths)}) {
+      new SourceTextModule(readFileSync(modulePath, "utf8"), { identifier: modulePath });
+    }
+  `;
+  const result = spawnSync(
+    process.execPath,
+    ["--experimental-vm-modules", "--input-type=module", "--eval", parser],
+    { encoding: "utf8" },
+  );
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+});

--- a/apps/website/planner.html
+++ b/apps/website/planner.html
@@ -290,6 +290,6 @@
       integrity="sha384-5+cfbwT0iiub6VsQAdn6yz16nr6sDiQoHx6tm4O8OVYXHYOxcffFmCJBL0dgdvGp"
       crossorigin="anonymous"
     ></script>
-    <script type="module" src="/planner.js?v=20260822-1"></script>
+    <script type="module" src="/planner.js?v=20260822-2"></script>
   </body>
 </html>

--- a/apps/website/planner.js
+++ b/apps/website/planner.js
@@ -1769,7 +1769,7 @@ function syncAdjustedContourData() {
 
 function contourDisplayContext(adjustment = currentDepthAdjustment) {
   return {
-    adjustment
+    adjustment: adjustment
       ? {
           chartDatum: adjustment.chartDatum,
           heightM: adjustment.heightM,
@@ -1824,7 +1824,7 @@ function loadEmodnetColourScale(url) {
 
 function ensureContourWorker() {
   if (shallowContourWorker) return shallowContourWorker;
-  const worker = new Worker("/contour-worker.mjs?v=20260822-1", { type: "module" });
+  const worker = new Worker("/contour-worker.mjs?v=20260822-2", { type: "module" });
   shallowContourWorker = worker;
   worker.addEventListener("message", (event) => {
     const job = shallowContourWorkerJobs.get(event.data?.jobId);


### PR DESCRIPTION
## Summary
- fix the malformed object property that stopped `planner.js` parsing before map initialisation
- bump planner and contour-worker asset versions to bypass the broken cached files
- add browser-module syntax coverage and a dedicated Website CI workflow

## Verification
- 34 Node tests
- 4 Python data-generator tests
- production website build
- live browser smoke: map canvas, controls and 335 EMODnet contours loaded with zero console errors